### PR TITLE
Refactoring - Part II

### DIFF
--- a/src/ExaPF.jl
+++ b/src/ExaPF.jl
@@ -23,18 +23,20 @@ using TimerOutputs
 
 export Pf, solve
 
+# Import submodules
 include("parse/parse.jl")
-include("parse/parse_raw.jl")
-include("ad.jl")
+using .Parse
 include("target/kernels.jl")
-include("algorithms/precondition.jl")
-include("iterative.jl")
-include("network.jl")
-
-using .AD
 using .Kernels
+include("ad.jl")
+using .AD
+include("algorithms/precondition.jl")
 using .Precondition
+include("iterative.jl")
 using .Iterative
+include("network.jl")
+using .Network
+
 
 const TIMER = TimerOutput()
 

--- a/src/ExaPF.jl
+++ b/src/ExaPF.jl
@@ -9,6 +9,18 @@
 __precompile__(false)
 module ExaPF
 
+using CUDA
+using CUDA.CUSPARSE
+using CUDA.CUSOLVER
+using ForwardDiff
+using IterativeSolvers
+using Krylov
+using LinearAlgebra
+using Printf
+using SparseArrays
+using SparseDiffTools
+using TimerOutputs
+
 export Pf, solve
 
 include("parse/parse.jl")
@@ -18,21 +30,11 @@ include("target/kernels.jl")
 include("algorithms/precondition.jl")
 include("iterative.jl")
 include("network.jl")
-using ForwardDiff
-using LinearAlgebra
-using SparseArrays
-using Printf
-using CUDA
-using CUDA.CUSPARSE
-using CUDA.CUSOLVER
-using TimerOutputs
-using SparseDiffTools
-using IterativeSolvers
+
 using .AD
 using .Kernels
 using .Precondition
 using .Iterative
-using Krylov
 
 const TIMER = TimerOutput()
 

--- a/src/ExaPF.jl
+++ b/src/ExaPF.jl
@@ -26,7 +26,6 @@ using CUDA
 using CUDA.CUSPARSE
 using CUDA.CUSOLVER
 using TimerOutputs
-to = TimerOutput()
 using SparseDiffTools
 using IterativeSolvers
 using .AD
@@ -34,6 +33,8 @@ using .Kernels
 using .Precondition
 using .Iterative
 using Krylov
+
+const TIMER = TimerOutput()
 
 struct Pf
     V::Array{Complex{Float64}}
@@ -96,7 +97,6 @@ Returns vectors indexing buses by type: ref, pv, pq.
 
 """
 function bustypeindex(bus, gen)
-
     # retrieve indeces
     BUS_B, BUS_AREA, BUS_VM, BUS_VA, BUS_NVHI, BUS_NVLO, BUS_EVHI,
     BUS_EVLO, BUS_TYPE = Parse.idx_bus()
@@ -109,7 +109,6 @@ function bustypeindex(bus, gen)
     # then that bus turns to a PQ bus.
 
     # Design note: this might be computed once and then modified for each contingency.
-
     gencon = zeros(Int8, size(bus, 1))
 
     for i in 1:size(gen, 1)
@@ -133,10 +132,7 @@ function bustypeindex(bus, gen)
     pv = findall(x->x==2, bustype)
     pq = findall(x->x==1, bustype)
 
-
-
     return ref, pv, pq
-
 end
 
 """
@@ -145,12 +141,11 @@ residualFunction
 Assembly residual function for N-R power flow
 """
 function residualFunction(V, Ybus, Sbus, pv, pq)
-
     # form mismatch vector
     mis = V .* conj(Ybus * V) - Sbus
 
     # form residual vector
-    F = [   real(mis[pv]);
+    F = [real(mis[pv]);
          real(mis[pq]);
     imag(mis[pq]) ];
 
@@ -368,7 +363,7 @@ function solve(pf::Pf, npartitions=2, solver="default")
         println("$npartitions partitions created")
     end
     println("Coloring...")
-    @timeit to "Coloring" coloring = T{Int64}(matrix_colors(J))
+    @timeit TIMER "Coloring" coloring = T{Int64}(matrix_colors(J))
     ncolors = size(unique(coloring),1)
     println("Number of Jacobian colors: ", ncolors)
     J = M(J)
@@ -391,37 +386,37 @@ function solve(pf::Pf, npartitions=2, solver="default")
     dx12 = view(dx, j1:j2)
     dx34 = view(dx, j3:j4)
     dx56 = view(dx, j5:j6)
-    @timeit to "Newton" while ((!converged) && (iter < maxiter))
+    @timeit TIMER "Newton" while ((!converged) && (iter < maxiter))
 
         iter += 1
 
         # J = residualJacobian(V, Ybus, pv, pq)
-        @timeit to "Jacobian" AD.residualJacobianAD!(jacobianAD, residualFunction_polar!, Vm, Va,
-                                                     ybus_re, ybus_im, pbus, qbus, pv, pq, nbus, to)
+        @timeit TIMER "Jacobian" AD.residualJacobianAD!(jacobianAD, residualFunction_polar!, Vm, Va,
+                                                     ybus_re, ybus_im, pbus, qbus, pv, pq, nbus, TIMER)
         J = jacobianAD.J
 
         if J isa SparseArrays.SparseMatrixCSC
             if solver == "bicgstab_ref"
                 println("Building preconditioner...")
-                @timeit to "Preconditioner" P = Precondition.update(jacobianAD, preconditioner, to)
+                @timeit TIMER "Preconditioner" P = Precondition.update(jacobianAD, preconditioner, TIMER)
                 println("Solving linear system...")
-                @timeit to "CPU-BICGSTAB" (dx[:], history) = IterativeSolvers.bicgstabl(P*J, P*F, log=true)
+                @timeit TIMER "CPU-BICGSTAB" (dx[:], history) = IterativeSolvers.bicgstabl(P*J, P*F, log=true)
                 push!(linsol_iters, history.iters)
             elseif solver == "bicgstab"
                 println("Building preconditioner...")
-                @timeit to "Preconditioner" P = Precondition.update(jacobianAD, preconditioner, to)
+                @timeit TIMER "Preconditioner" P = Precondition.update(jacobianAD, preconditioner, TIMER)
                 println("Solving linear system...")
-                @timeit to "GPU-BICGSTAB" dx[:], lin_iter = bicgstab(J, F, P, dx, to, maxiter=10000)
+                @timeit TIMER "GPU-BICGSTAB" dx[:], lin_iter = bicgstab(J, F, P, dx, TIMER, maxiter=10000)
                 push!(linsol_iters, lin_iter)
             elseif solver == "gmres"
                 println("Building preconditioner...")
-                @timeit to "Preconditioner" P = Precondition.update(jacobianAD, preconditioner, to)
+                @timeit TIMER "Preconditioner" P = Precondition.update(jacobianAD, preconditioner, TIMER)
                 println("Solving linear system...")
-                @timeit to "CPU-GMRES" (dx[:], history) = IterativeSolvers.gmres(P*J, P*F, log=true)
+                @timeit TIMER "CPU-GMRES" (dx[:], history) = IterativeSolvers.gmres(P*J, P*F, log=true)
                 push!(linsol_iters, history.iters)
             else
                 println("Solving linear system...")
-                @timeit to "CPU-Default sparse solver" dx .= J\F
+                @timeit TIMER "CPU-Default sparse solver" dx .= J\F
                 push!(linsol_iters, 0)
             end
             dx .= -dx
@@ -430,21 +425,21 @@ function solve(pf::Pf, npartitions=2, solver="default")
         if J isa CUDA.CUSPARSE.CuSparseMatrixCSR
             if solver == "bicgstab"
                 println("Building preconditioner...")
-                @timeit to "Preconditioner" P = Precondition.update(jacobianAD, preconditioner, to)
+                @timeit TIMER "Preconditioner" P = Precondition.update(jacobianAD, preconditioner, TIMER)
                 println("Solving linear system...")
-                @timeit to "GPU-BICGSTAB" dx[:], lin_iter = bicgstab(J, F, P, dx, to, maxiter=10000)
+                @timeit TIMER "GPU-BICGSTAB" dx[:], lin_iter = bicgstab(J, F, P, dx, TIMER, maxiter=10000)
                 push!(linsol_iters, lin_iter)
             else
                 println("Solving linear system...")
                 lintol = 1e-8
-                @timeit to "Sparse CUSOLVER" dx  = CUSOLVER.csrlsvqr!(J,F,dx,lintol,one(Cint),'O')
+                @timeit TIMER "Sparse CUSOLVER" dx  = CUSOLVER.csrlsvqr!(J,F,dx,lintol,one(Cint),'O')
                 push!(linsol_iters, 0)
             end
             dx .= -dx
         end
 
         # update voltage
-        @timeit to "Update voltage" begin
+        @timeit TIMER "Update voltage" begin
             if (npv != 0)
                 # Va[pv] .= Va[pv] .+ dx[j1:j2]
                 Vapv .= Vapv .+ dx12
@@ -457,9 +452,9 @@ function solve(pf::Pf, npartitions=2, solver="default")
             end
         end
 
-        @timeit to "Exponential" V .= Vm .* exp.(1im .*Va)
+        @timeit TIMER "Exponential" V .= Vm .* exp.(1im .*Va)
 
-        @timeit to "Angle and magnitude" begin
+        @timeit TIMER "Angle and magnitude" begin
             Vm .= abs.(V)
             Va .= Kernels.@angle(V)
         end
@@ -475,13 +470,13 @@ function solve(pf::Pf, npartitions=2, solver="default")
 
         F .= 0.0
         Kernels.@sync begin
-            @timeit to "Residual function" Kernels.@dispatch threads=nthreads blocks=nblocks residualFunction_polar!(F, Vm, Va,
+            @timeit TIMER "Residual function" Kernels.@dispatch threads=nthreads blocks=nblocks residualFunction_polar!(F, Vm, Va,
             ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
             ybus_im.nzval, ybus_im.colptr, ybus_im.rowval,
             pbus, qbus, pv, pq, nbus)
         end
 
-        @timeit to "Norm" normF = norm(F)
+        @timeit TIMER "Norm" normF = norm(F)
         @printf("Iteration %d. Residual norm: %g.\n", iter, normF)
 
         if normF < tol
@@ -496,12 +491,11 @@ function solve(pf::Pf, npartitions=2, solver="default")
     end
 
     # Timer outputs display
-    show(to)
+    show(TIMER)
     println("")
-    reset_timer!(to)
+    reset_timer!(TIMER)
 
     return V, converged, normF, linsol_iters[1], sum(linsol_iters)
-
 end
 
 # end of module

--- a/src/ExaPF.jl
+++ b/src/ExaPF.jl
@@ -258,7 +258,8 @@ function residualJacobian(V, Ybus, pv, pq)
     J = [j11 j12; j21 j22]
 end
 
-function solve(pf::Pf, npartitions=2, solver="default")
+function solve(pf::Pf, npartitions=2, solver="default";
+               tol=1e-6, maxiter=20)
     # Set array type
     # For CPU choose Vector and SparseMatrixCSC
     # For GPU choose CuVector and SparseMatrixCSR (CSR!!! Not CSC)
@@ -281,10 +282,6 @@ function solve(pf::Pf, npartitions=2, solver="default")
 
     # Convert voltage vector to target
     V = T(V)
-
-    # parameters NR
-    tol = 1e-6
-    maxiter = 20
 
     # iteration variables
     iter = 0

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -1,10 +1,11 @@
 module AD
-include("target/kernels.jl")
-using ForwardDiff
 using CUDA
-using .Kernels
-using TimerOutputs
+using ForwardDiff
 using SparseArrays
+using TimerOutputs
+
+include("target/kernels.jl")
+using .Kernels
 
 function myseed!(duals::AbstractArray{ForwardDiff.Dual{T,V,N}}, x,
                  seeds::AbstractArray{ForwardDiff.Partials{N,V}}) where {T,V,N}

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -4,8 +4,7 @@ using ForwardDiff
 using SparseArrays
 using TimerOutputs
 
-include("target/kernels.jl")
-using .Kernels
+using ..ExaPF: Kernels
 
 function myseed!(duals::AbstractArray{ForwardDiff.Dual{T,V,N}}, x,
                  seeds::AbstractArray{ForwardDiff.Partials{N,V}}) where {T,V,N}

--- a/src/algorithms/precondition.jl
+++ b/src/algorithms/precondition.jl
@@ -1,6 +1,5 @@
 module Precondition
 
-include("../target/kernels.jl")
 using LightGraphs
 using Metis
 using SparseArrays
@@ -8,7 +7,8 @@ using LinearAlgebra
 using CUDA
 using CUDA.CUSPARSE
 using TimerOutputs
-using .Kernels
+
+using ..ExaPF: Kernels
 
 cuzeros = CUDA.zeros
 

--- a/src/algorithms/precondition.jl
+++ b/src/algorithms/precondition.jl
@@ -142,12 +142,11 @@ function fillP_gpu!(cuJs, partition, map, rowPtr, colVal, nzVal, part, b)
     return nothing
 end
 
-function update(jacobianAD, p::Preconditioner, to=nothing)
-    m = size(jacobianAD.J,1)
-    n = size(jacobianAD.J,2)
+function update(J, p::Preconditioner, to=nothing)
+    m = size(J, 1)
+    n = size(J, 2)
     nblocks = length(p.partitions)
-    J = jacobianAD.J
-    if jacobianAD.J isa CuSparseMatrixCSR
+    if J isa CuSparseMatrixCSR
         @timeit to "Fill Block Jacobi" begin
             Kernels.@sync begin
                 for b in 1:nblocks
@@ -168,7 +167,6 @@ function update(jacobianAD, p::Preconditioner, to=nothing)
             end
         end
     else
-        J = jacobianAD.J
         @timeit to "Fill Block Jacobi" begin
             for b in 1:nblocks
                 for i in p.partitions[b]

--- a/src/iterative.jl
+++ b/src/iterative.jl
@@ -1,16 +1,16 @@
 module Iterative
 
-include("algorithms/precondition.jl")
-using LinearAlgebra
-using .Precondition
 using CUDA
-using TimerOutputs
+using LinearAlgebra
 using SparseArrays
+using TimerOutputs
 
-cuzeros = CUDA.zeros
+include("algorithms/precondition.jl")
+using .Precondition
 
 export bicgstab
 
+cuzeros = CUDA.zeros
 # mulinvP = Precondition.mulinvP
 # mulinvP! = Precondition.mulinvP!
 
@@ -21,7 +21,6 @@ Van der Vorst, Henk A.
 "Bi-CGSTAB: A fast and smoothly converging variant of Bi-CG for the solution of nonsymmetric linear systems."
 SIAM Journal on scientific and Statistical Computing 13, no. 2 (1992): 631-644.
 """
-
 function bicgstab(A, b, P, xi, to = nothing; tol = 1e-6, maxiter = size(A,1),
                   verbose=false)
     # parameters

--- a/src/iterative.jl
+++ b/src/iterative.jl
@@ -6,8 +6,7 @@ using LinearAlgebra
 using SparseArrays
 using TimerOutputs
 
-include("algorithms/precondition.jl")
-using .Precondition
+using ..ExaPF: Precondition
 
 export bicgstab
 

--- a/src/iterative.jl
+++ b/src/iterative.jl
@@ -1,6 +1,7 @@
 module Iterative
 
 using CUDA
+using IterativeSolvers
 using LinearAlgebra
 using SparseArrays
 using TimerOutputs
@@ -11,8 +12,6 @@ using .Precondition
 export bicgstab
 
 cuzeros = CUDA.zeros
-# mulinvP = Precondition.mulinvP
-# mulinvP! = Precondition.mulinvP!
 
 """
 bicgstab according to
@@ -27,7 +26,6 @@ function bicgstab(A, b, P, xi, to = nothing; tol = 1e-6, maxiter = size(A,1),
     n    = size(b, 1)
     x0   = similar(b)
     x0 = P * b
-    # mulinvP!(x0, b, p)
     r0   = b - A * x0
     br0  = copy(r0)
     rho0 = 1.0
@@ -44,7 +42,6 @@ function bicgstab(A, b, P, xi, to = nothing; tol = 1e-6, maxiter = size(A,1),
     omegai = copy(omega0)
     vi = copy(v0)
     pi = copy(p0)
-    # xi = x
     xi .= x0
 
     y = similar(pi)
@@ -76,7 +73,6 @@ function bicgstab(A, b, P, xi, to = nothing; tol = 1e-6, maxiter = size(A,1),
             @timeit to "Main stage" begin
                 omegai1 = dot(t1, t2) / dot(t1, t1)
                 xi1 .= xi .+ alpha .* y .+ omegai1 .* z
-                # xi1 .= xi .+ alpha .* y .+ omegai1 .* z
             end
 
             @timeit to "End stage" begin
@@ -110,6 +106,51 @@ function bicgstab(A, b, P, xi, to = nothing; tol = 1e-6, maxiter = size(A,1),
     end
 
     return xi, iter
+end
+
+function ldiv!(
+    dx::AbstractVector,
+    J::SparseArrays.SparseMatrixCSC,
+    F::AbstractVector,
+    solver::String,
+    preconditioner,
+    timer::TimerOutputs.TimerOutput=nothing,
+)
+    if solver == "bicgstab_ref"
+        @timeit timer "Preconditioner" P = Precondition.update(J, preconditioner, timer)
+        @timeit timer "CPU-BICGSTAB" (dx[:], history) = IterativeSolvers.bicgstabl(P*J, P*F, log=true)
+        n_iters = history.iters
+    elseif solver == "bicgstab"
+        @timeit timer "Preconditioner" P = Precondition.update(J, preconditioner, timer)
+        @timeit timer "GPU-BICGSTAB" dx[:], n_iters = bicgstab(J, F, P, dx, timer, maxiter=10000)
+    elseif solver == "gmres"
+        @timeit timer "Preconditioner" P = Precondition.update(J, preconditioner, timer)
+        @timeit timer "CPU-GMRES" (dx[:], history) = IterativeSolvers.gmres(P*J, P*F, log=true)
+        n_iters = history.iters
+    else
+        @timeit timer "CPU-Default sparse solver" dx .= J\F
+        n_iters = 0
+    end
+    return n_iters
+end
+
+function ldiv!(
+    dx::CuVector,
+    J::CUDA.CUSPARSE.CuSparseMatrixCSR,
+    F::CuVector,
+    solver::String,
+    preconditioner,
+    timer=nothing,
+)
+    if solver == "bicgstab"
+        @timeit timer "Preconditioner" P = Precondition.update(J, preconditioner, timer)
+        @timeit timer "GPU-BICGSTAB" dx[:], n_iters = bicgstab(J, F, P, dx, timer, maxiter=10000)
+    else
+        lintol = 1e-8
+        @timeit timer "Sparse CUSOLVER" dx  = CUSOLVER.csrlsvqr!(J,F,dx,lintol,one(Cint),'O')
+        n_iters = 0
+    end
+    return n_iters
 end
 
 end

--- a/src/network.jl
+++ b/src/network.jl
@@ -1,8 +1,8 @@
 module Network
 
 using SparseArrays
-include("parse/parse.jl")
-include("parse/parse_raw.jl")
+
+using ..ExaPF: Parse
 
 # Create an admittance matrix. The implementation is a modification of
 # MATPOWER's makeYbus. We attach the original MATPOWER's license in makeYbus.m:
@@ -32,12 +32,12 @@ function makeYbus(raw_data)
     fsh = raw_data["FIXED SHUNT"]
 
     BUS_B, BUS_AREA, BUS_VM, BUS_VA, BUS_NVHI, BUS_NVLO, BUS_EVHI,
-        BUS_EVLO = idx_bus()
+        BUS_EVLO = Parse.idx_bus()
     BR_FR, BR_TO, BR_CKT, BR_R, BR_X, BR_B, BR_RATEA, BR_RATEC,
-        BR_STAT = idx_branch()
+        BR_STAT = Parse.idx_branch()
     TR_FR, TR_TO, TR_CKT, TR_MAG1, TR_MAG2, TR_STAT, TR_R, TR_X, TR_WINDV1,
-        TR_ANG, TR_RATEA, TR_RATEC, TR_WINDV2 = idx_transformer()
-    FSH_BUS, FSH_ID, FSH_STAT, FSH_G, FSH_B = idx_fshunt()
+        TR_ANG, TR_RATEA, TR_RATEC, TR_WINDV2 = Parse.idx_transformer()
+    FSH_BUS, FSH_ID, FSH_STAT, FSH_G, FSH_B = Parse.idx_fshunt()
 
     nb = size(bus, 1)
     nbr = size(branch, 1)


### PR DESCRIPTION
This PR adds more refactoring to ExaPF. In short: 
- we rename `TimerOutputs`'s `to` to `TIMER`, as we had clashes with local variables named `to` previously
- we improve the handling of submodules in the package, to ensure that all modules are using the same types 
- we move all iterative solvers and preconditioning into the submodule `Iterative`, by adding a dedicated function `ldiv!`. Multiple dispatch could be use further here, but that will be the goal of a future PR
