### PR TITLE
Add more unit-tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,8 +24,9 @@ julia = "^1"
 [extras]
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 scripts = ["Ipopt", "NLsolve"]
-test = ["Test"]
+test = ["Test", "Random"]

--- a/src/algorithms/precondition.jl
+++ b/src/algorithms/precondition.jl
@@ -29,10 +29,13 @@ mutable struct Preconditioner <: AbstractPreconditioner
     cupart
     P
     function Preconditioner(J, npart)
+        m, n = size(J)
+        if npart < 2
+            error("Number of partitions `npart` should be at" *
+                  "least 2 for partitioning in Metis")
+        end
         adj = build_adjmatrix(J)
         g = Graph(adj)
-        m = size(J,1)
-        n = size(J,2)
         part = Metis.partition(g, npart)
         partitions = Vector{Vector{Int64}}()
         for i in 1:npart

--- a/src/iterative.jl
+++ b/src/iterative.jl
@@ -2,6 +2,7 @@ module Iterative
 
 using CUDA
 using IterativeSolvers
+using Krylov
 using LinearAlgebra
 using SparseArrays
 using TimerOutputs
@@ -124,8 +125,12 @@ function ldiv!(
         @timeit timer "GPU-BICGSTAB" dx[:], n_iters = bicgstab(J, F, P, dx, timer, maxiter=10000)
     elseif solver == "gmres"
         @timeit timer "Preconditioner" P = Precondition.update(J, preconditioner, timer)
-        @timeit timer "CPU-GMRES" (dx[:], history) = IterativeSolvers.gmres(P*J, P*F, log=true)
+        @timeit timer "CPU-GMRES" (dx[:], history) = IterativeSolvers.gmres(P*J, P*F, restart=4, log=true)
         n_iters = history.iters
+    elseif solver == "dqgmres"
+        @timeit timer "Preconditioner" P = Precondition.update(J, preconditioner, timer)
+        @timeit timer "GPU-DQGMRES" (dx[:], status) = Krylov.dqgmres(J, F, M=P, memory=4)
+        n_iters = length(status.residuals)
     else
         @timeit timer "CPU-Default sparse solver" dx .= J\F
         n_iters = 0
@@ -144,6 +149,10 @@ function ldiv!(
     if solver == "bicgstab"
         @timeit timer "Preconditioner" P = Precondition.update(J, preconditioner, timer)
         @timeit timer "GPU-BICGSTAB" dx[:], n_iters = bicgstab(J, F, P, dx, timer, maxiter=10000)
+    elseif solver == "dqgmres"
+        @timeit timer "Preconditioner" P = Precondition.update(J, preconditioner, timer)
+        @timeit timer "GPU-DQGMRES" (dx[:], status) = Krylov.dqgmres(J, F, M=P, memory=4)
+        n_iters = length(status.residuals)
     else
         lintol = 1e-8
         @timeit timer "Sparse CUSOLVER" dx  = CUSOLVER.csrlsvqr!(J,F,dx,lintol,one(Cint),'O')

--- a/src/iterative.jl
+++ b/src/iterative.jl
@@ -19,7 +19,7 @@ Van der Vorst, Henk A.
 "Bi-CGSTAB: A fast and smoothly converging variant of Bi-CG for the solution of nonsymmetric linear systems."
 SIAM Journal on scientific and Statistical Computing 13, no. 2 (1992): 631-644.
 """
-function bicgstab(A, b, P, xi, to = nothing; tol = 1e-6, maxiter = size(A,1),
+function bicgstab(A, b, P, xi, to::TimerOutput; tol = 1e-6, maxiter = size(A,1),
                   verbose=false)
     # parameters
     n    = size(b, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,10 +12,14 @@ target = "cpu"
 using ExaPF
 import ExaPF: Parse, PowerSystem
 
+case = "case14.raw"
+nblocks = 8
+# case = "ACTIVSg70K.raw"
+# nblocks = 64
 @testset "Powerflow residuals and Jacobian" begin
     # read data
     to = TimerOutputs.TimerOutput()
-    datafile = joinpath(dirname(@__FILE__), "case14.raw")
+    datafile = joinpath(dirname(@__FILE__), case)
     data = Parse.parse_raw(datafile)
     BUS_B, BUS_AREA, BUS_VM, BUS_VA, BUS_NVHI, BUS_NVLO, BUS_EVHI,
     BUS_EVLO, BUS_TYPE = Parse.idx_bus()
@@ -111,9 +115,8 @@ end
 
 @testset "Powerflow CPU" begin
     # Include code to run power flow equation
-    datafile = joinpath(dirname(@__FILE__), "case14.raw")
+    datafile = joinpath(dirname(@__FILE__), case)
     # Direct solver
-    nblocks = 8
     # Create a network object:
     pf = ExaPF.PowerSystem.PowerNetwork(datafile)
     # Note: Reference BICGSTAB in IterativeSolvers
@@ -129,10 +132,10 @@ if has_cuda_gpu()
     target = "cuda"
     @testset "Powerflow GPU" begin
         # Include code to run power flow equation
-        datafile = joinpath(dirname(@__FILE__), "case14.raw")
+        datafile = joinpath(dirname(@__FILE__), case)
         pf = ExaPF.PowerSystem.PowerNetwork(datafile)
         @testset "Powerflow solver $precond" for precond in ["default", "bicgstab"]
-            sol, conv, res = solve(pf, 2, precond)
+            sol, conv, res = solve(pf, nblocks, precond)
             @test conv
             @test res < 1e-6
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ import ExaPF: Parse, PowerSystem
 case = "case14.raw"
 nblocks = 8
 # case = "ACTIVSg70K.raw"
-# nblocks = 64
+# nblocks = 5000
 @testset "Powerflow residuals and Jacobian" begin
     # read data
     to = TimerOutputs.TimerOutput()
@@ -120,7 +120,7 @@ end
     # Create a network object:
     pf = ExaPF.PowerSystem.PowerNetwork(datafile)
     # Note: Reference BICGSTAB in IterativeSolvers
-    @testset "Powerflow solver $precond" for precond in ["default", "gmres", "bicgstab_ref", "bicgstab"]
+    @testset "Powerflow solver $precond" for precond in ["default", "gmres", "dqgmres", "bicgstab_ref", "bicgstab"]
         sol, has_conv, res = solve(pf, nblocks, precond)
         @test has_conv
         @test res < 1e-6
@@ -134,7 +134,7 @@ if has_cuda_gpu()
         # Include code to run power flow equation
         datafile = joinpath(dirname(@__FILE__), case)
         pf = ExaPF.PowerSystem.PowerNetwork(datafile)
-        @testset "Powerflow solver $precond" for precond in ["default", "bicgstab"]
+        @testset "Powerflow solver $precond" for precond in ["default", "dqgmres", "bicgstab"]
             sol, conv, res = solve(pf, nblocks, precond)
             @test conv
             @test res < 1e-6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using CUDA
 # This implies we cannot both test gpu and cpu code here.
 target = "cpu"
 using ExaPF
+import ExaPF: Parse, PowerSystem
 
 @testset "Powerflow residuals and Jacobian" begin
     # read data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using Test
 using TimerOutputs
 using CUDA
 
+Random.seed!(2713)
+
 # This is a problem of the code right now. It can only set once per as
 # this variable is used in macros to generate the code at compile time.
 # This implies we cannot both test gpu and cpu code here.


### PR DESCRIPTION
This PR adds more unit-tests to ExaPF
- we aim at adding "bottom-up" testing before testing the `solve` function by itself. The idea is to fail fast if a problem occurs (if `mul!` is broken in CUDA.jl, I want to detect it before testing the function `solve`)
- we push also small fixes in the core of ExaPF 