### PR TITLE
Fix tests on julia 1.5

### DIFF
--- a/src/ExaPF.jl
+++ b/src/ExaPF.jl
@@ -125,7 +125,7 @@ end
     if i > npv
         F[i + npq] -= qinj[fr]
     end
-    @inbounds for (j,c) in enumerate(ybus_re_colptr[fr]:ybus_re_colptr[fr+1]-1)
+    @inbounds for c in ybus_re_colptr[fr]:ybus_re_colptr[fr+1]-1
         to = ybus_re_rowval[c]
         aij = v_a[fr] - v_a[to]
         # f_re = a * cos + b * sin
@@ -252,7 +252,7 @@ function solve(pf::PowerSystem.PowerNetwork, x::AbstractArray, u::AbstractArray,
     qbus = T(imag(Sbus))
 
     # initiate voltage
-    Vm, Va = similar(V), similar(V)
+    Vm, Va = similar(V, Float64), similar(V, Float64)
     polar!(Vm, Va, V, device)
 
     # indices

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -37,7 +37,9 @@ function getpartials_gpu(compressedJ, t1sF)
     index = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     stride = blockDim().x * gridDim().x
     for i in index:stride:size(t1sF, 1) # Go over outputs
-        compressedJ[:, i] .= ForwardDiff.partials.(t1sF[i]).values
+        for j in eachindex(ForwardDiff.partials.(t1sF[i]).values)
+            @inbounds compressedJ[j, i] = ForwardDiff.partials.(t1sF[i]).values[j]
+        end
     end
 end
 

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -6,6 +6,7 @@ using LinearAlgebra
 using BenchmarkTools
 using SparseArrays
 using TimerOutputs
+import ExaPF: Parse, PowerSystem
 
 # read data
 function run_benchmark(datafile)


### PR DESCRIPTION
This PR brings several fixes to run ExaPF on GPU. 

- In AD, we now define `get_partial` and `myseed` manually on the GPU, without relying on KernelAbstractions. That would avoid potential issues with ForwardDiff
- There is a bug with slicing in Julia 1.5 and CUDA.jl. See https://github.com/JuliaGPU/CUDA.jl/issues/350 . Instead of using `.=` in `get_partials`, we now copy the elements manually
- In `ExaPF.solve`, there was an issue with types on line 255: `similar(V)` returned a `CuArray{Complex{Float64}}` (expected behavior in Julia), whereas we need a `CuArray{Float64}` for `Vm` and `Va`. For some reasons, that works in Julia 1.4 but leads to an `InvalidIRError` in julia 1.5