### PR TITLE
Sparsity pattern detection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
+SparsityDetection = "684fba80-ace3-11e9-3d08-3bc7ed6f96df"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 

--- a/examples/pf.jl
+++ b/examples/pf.jl
@@ -8,7 +8,7 @@ using KernelAbstractions
 # datafile = "GO-Data/datasets/Trial_3_Real-Time/Network_13R-015/scenario_11/case.raw"
 # datafile = "test/case14.raw"
 # npartition: Number of partitions for the additive Schwarz preconditioner
-function pf(datafile, npartition=2, solver="default", device = CPU())
+function pf(datafile, npartition=2; solver="default", device = CPU())
     # read data
     println(solver)
     
@@ -16,5 +16,7 @@ function pf(datafile, npartition=2, solver="default", device = CPU())
     x = ExaPF.PowerSystem.get_x(pf)
     u = ExaPF.PowerSystem.get_u(pf)
     p = ExaPF.PowerSystem.get_p(pf)
-    return solve(pf, x, u, p, npartition, solver, device = device);
+    return solve(pf, x, u, p; npartitions=npartition,
+                                solver=solver,
+                                device=device)
 end

--- a/src/ExaPF.jl
+++ b/src/ExaPF.jl
@@ -24,6 +24,7 @@ using TimerOutputs
 export solve
 
 # Import submodules
+include("helpers.jl")
 include("parse/parse.jl")
 using .Parse
 include("ad.jl")
@@ -36,20 +37,6 @@ include("powersystem.jl")
 using .PowerSystem
 
 const TIMER = TimerOutput()
-
-
-mutable struct Spmat{T}
-    colptr
-    rowval
-    nzval
-
-    # function spmat{T}(colptr::Vector{Int64}, rowval::Vector{Int64}, nzval::Vector{T}) where T
-    function Spmat{T}(mat::SparseMatrixCSC{Complex{Float64}, Int}) where T
-        matreal = new(T{Int64}(mat.colptr), T{Int64}(mat.rowval), T{Float64}(real.(mat.nzval)))
-        matimag = new(T{Int64}(mat.colptr), T{Int64}(mat.rowval), T{Float64}(imag.(mat.nzval)))
-        return matreal, matimag
-    end
-end
 
 """
 residualFunction
@@ -107,6 +94,37 @@ function residualFunction_real!(F, v_re, v_im,
 
     return F
 end
+function residualFunction_polar_sparsity!(F, v_m, v_a,
+                     ybus_re, ybus_im,
+                     pinj, qinj, pv, pq, nbus)
+
+    npv = size(pv, 1)
+    npq = size(pq, 1)
+
+    for i in 1:length(pv)+length(pq)
+        # REAL PQ: (npv+1:npv+npq)
+        # IMAG PQ: (npv+npq+1:npv+2npq)
+        fr = (i <= npv) ? pv[i] : pq[i - npv]
+        F[i] -= pinj[fr]
+        if i > npv
+            F[i + npq] -= qinj[fr]
+        end
+        for c in ybus_re.colptr[fr]:ybus_re.colptr[fr+1]-1
+            to = ybus_re.rowval[c]
+            aij = v_a[fr] - v_a[to]
+            # f_re = a * cos + b * sin
+            # f_im = a * sin - b * cos
+            coef_cos = v_m[fr]*v_m[to]*ybus_re.nzval[c]
+            coef_sin = v_m[fr]*v_m[to]*ybus_im.nzval[c]
+            cos_val = cos(aij)
+            sin_val = sin(aij)
+            F[i] += coef_cos * cos_val + coef_sin * sin_val
+            if i > npv
+                F[npq + i] += coef_cos * sin_val - coef_sin * cos_val
+            end
+        end
+    end
+end
 
 @kernel function residual_kernel!(F, v_m, v_a,
                      ybus_re_nzval, ybus_re_colptr, ybus_re_rowval,
@@ -142,8 +160,8 @@ end
 end
 
 function residualFunction_polar!(F, v_m, v_a,
-                     ybus_re_nzval, ybus_re_colptr, ybus_re_rowval,
-                     ybus_im_nzval, ybus_im_colptr, ybus_im_rowval,
+                     ybus_re,
+                     ybus_im,
                      pinj, qinj, pv, pq, nbus)
     npv = length(pv)
     npq = length(pq)
@@ -153,8 +171,8 @@ function residualFunction_polar!(F, v_m, v_a,
         kernel! = residual_kernel!(CUDADevice(), 256)
     end
     ev = kernel!(F, v_m, v_a,
-                 ybus_re_nzval, ybus_re_colptr, ybus_re_rowval,
-                 ybus_im_nzval, ybus_im_colptr, ybus_im_rowval,
+                 ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
+                 ybus_im.nzval, ybus_im.colptr, ybus_im.rowval,
                  pinj, qinj, pv, pq, nbus,
                  ndrange=npv+npq)
     wait(ev)
@@ -278,13 +296,14 @@ function solve(pf::PowerSystem.PowerNetwork,
 
     # Evaluate residual function
     residualFunction_polar!(F, Vm, Va,
-                            ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
-                            ybus_im.nzval, ybus_im.colptr, ybus_im.rowval,
+                            ybus_re, ybus_im,
                             pbus, qbus, pv, pq, nbus)
-
-    # Initiate coloring for AD
-    J = residualJacobian(V, Ybus, pv, pq)
-    dim_J = size(J, 1)
+    # Build the AD Jacobian structure
+    stateJacobianAD = AD.StateJacobianAD(residualFunction_polar_sparsity!, F, Vm, Va,
+                                         ybus_re, ybus_im, pbus, qbus, pv, pq, ref, nbus)
+    designJacobianAD = AD.DesignJacobianAD(residualFunction_polar_sparsity!, F, Vm, Va, 
+                                           ybus_re, ybus_im, pbus, qbus, pv, pq, ref, nbus)
+    J = stateJacobianAD.J
     preconditioner = Precondition.NoPreconditioner()
     if solver != "default"
         nblock = size(J,1) / npartitions
@@ -294,15 +313,6 @@ function solve(pf::PowerSystem.PowerNetwork,
         preconditioner = Precondition.Preconditioner(J, npartitions, device)
         println("$npartitions partitions created")
     end
-
-    println("Coloring...")
-    @timeit TIMER "Coloring" coloring = T{Int64}(matrix_colors(J))
-    ncolors = size(unique(coloring),1)
-    println("Number of Jacobian colors: ", ncolors)
-    println("Creating JacobianAD...")
-    J = M(J)
-    stateJacobianAD = AD.StateJacobianAD(J, coloring, F, Vm, Va, pbus, pv, pq, ref)
-    # designJacobianAD = AD.DesignJacobianAD(J, coloring, F, Vm, Va, pbus, pv, pq, ref)
 
     # check for convergence
     normF = norm(F, Inf)
@@ -360,8 +370,7 @@ function solve(pf::PowerSystem.PowerNetwork,
         F .= 0.0
         @timeit TIMER "Residual function" begin
             residualFunction_polar!(F, Vm, Va,
-                ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
-                ybus_im.nzval, ybus_im.colptr, ybus_im.rowval,
+                ybus_re, ybus_im,
                 pbus, qbus, pv, pq, nbus)
         end
 
@@ -382,9 +391,9 @@ function solve(pf::PowerSystem.PowerNetwork,
     # Timer outputs display
     show(TIMER)
     reset_timer!(TIMER)
-    # AD.designJacobianAD!(designJacobianAD, residualFunction_polar!, Vm, Va,
-    #                         ybus_re, ybus_im, pbus, qbus, pv, pq, ref, nbus, TIMER)
-    return V, converged, normF, linsol_iters[1], sum(linsol_iters)#, designJacobianAD.J
+    AD.designJacobianAD!(designJacobianAD, residualFunction_polar!, Vm, Va,
+                            ybus_re, ybus_im, pbus, qbus, pv, pq, ref, nbus, TIMER)
+    return V, converged, normF, linsol_iters[1], sum(linsol_iters), designJacobianAD.J
 end
 
 # end of module

--- a/src/algorithms/precondition.jl
+++ b/src/algorithms/precondition.jl
@@ -30,8 +30,6 @@ mutable struct Preconditioner <: AbstractPreconditioner
     function Preconditioner(J, npart, device=CPU())
         if isa(J, CuSparseMatrixCSR)
             J = SparseMatrixCSC(J)
-        # else
-        #     J = cuJ
         end
         m, n = size(J)
         if npart < 2

--- a/src/algorithms/precondition.jl
+++ b/src/algorithms/precondition.jl
@@ -28,6 +28,11 @@ mutable struct Preconditioner <: AbstractPreconditioner
     cupart
     P
     function Preconditioner(J, npart, device=CPU())
+        if isa(J, CuSparseMatrixCSR)
+            J = SparseMatrixCSC(J)
+        # else
+        #     J = cuJ
+        end
         m, n = size(J)
         if npart < 2
             error("Number of partitions `npart` should be at" *

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,0 +1,16 @@
+mutable struct Spmat{T}
+    colptr
+    rowval
+    nzval
+
+    # create 2 Spmats from complex matrix
+    function Spmat{T}(mat::SparseMatrixCSC{Complex{Float64}, Int}) where T
+        matreal = new(T{Int64}(mat.colptr), T{Int64}(mat.rowval), T{Float64}(real.(mat.nzval)))
+        matimag = new(T{Int64}(mat.colptr), T{Int64}(mat.rowval), T{Float64}(imag.(mat.nzval)))
+        return matreal, matimag
+    end
+    # copy constructor
+    function Spmat{T}(mat) where T
+        return new(T{Int64}(mat.colptr), T{Int64}(mat.rowval), T{Float64}(mat.nzval))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,8 +61,7 @@ case = "case14.raw"
         # residual_polar! uses only binary types as this function is meant
         # to be deported on the GPU
         ExaPF.residualFunction_polar!(F, Vm, Va,
-            ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
-            ybus_im.nzval, ybus_im.colptr, ybus_im.rowval,
+            ybus_re, ybus_im,
             pbus, qbus, pv, pq, nbus)
         @test F ≈ F♯
     end
@@ -73,8 +72,8 @@ case = "case14.raw"
         J♯ = copy(J)
 
         # Then, create a JacobianAD object
-        coloring = ExaPF.matrix_colors(J)
-        jacobianAD = ExaPF.AD.StateJacobianAD(J, coloring, F, Vm, Va, pbus, pv, pq, ref)
+        jacobianAD = ExaPF.AD.StateJacobianAD(ExaPF.residualFunction_polar_sparsity!, F, Vm, Va,
+                                            ybus_re, ybus_im, pbus, qbus, pv, pq, ref, nbus)
         # and compute Jacobian with ForwardDiff
         ExaPF.AD.residualJacobianAD!(
             jacobianAD, ExaPF.residualFunction_polar!, Vm, Va,


### PR DESCRIPTION
This enables sparisty detection of the Jacobians. This takes place on the CPU. Unfortunately I couldn't get the KA residual to work with the SparsityDetection.jl.

The coloring etc now takes place in the AD module and is not in solve() anymore.