### PR TITLE
Implement caches to update data inplace

### DIFF
--- a/src/PowerSystem/PowerSystem.jl
+++ b/src/PowerSystem/PowerSystem.jl
@@ -31,8 +31,6 @@ struct PVIndexes <: AbstractIndexing end
 struct PQIndexes <: AbstractIndexing end
 struct SlackIndexes <: AbstractIndexing end
 struct GeneratorIndexes <: AbstractIndexing end
-struct PVGeneratorIndexes <: AbstractIndexing end
-struct SlackGeneratorIndexes <: AbstractIndexing end
 
 # TODO: replace const *_BUS_TYPE with this enum
 @enum BusType begin

--- a/src/models/caches.jl
+++ b/src/models/caches.jl
@@ -8,3 +8,28 @@ struct IndexingCache{IVT} <: AbstractCache
     index_generators::IVT
 end
 
+struct NetworkState{VT} <: AbstractCache
+    vmag::VT
+    vang::VT
+    pinj::VT
+    qinj::VT
+    pg::VT
+    qg::VT
+end
+
+function NetworkState(nbus, ngen, device)
+    if isa(device, CPU)
+        VT = Vector{Float64}
+    elseif isa(device, CUDADevice)
+        VT = CuVector{Float64, Nothing}
+    end
+    vmag = VT(undef, nbus)
+    vang = VT(undef, nbus)
+    pinj = VT(undef, nbus)
+    qinj = VT(undef, nbus)
+
+    pg = VT(undef, ngen)
+    qg = VT(undef, ngen)
+    return NetworkState{VT}(vmag, vang, pinj, qinj, pg, qg)
+end
+

--- a/src/models/caches.jl
+++ b/src/models/caches.jl
@@ -1,0 +1,10 @@
+abstract type AbstractCache end
+
+"Store indexing on target device"
+struct IndexingCache{IVT} <: AbstractCache
+    index_pv::IVT
+    index_pq::IVT
+    index_ref::IVT
+    index_generators::IVT
+end
+

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -1,8 +1,6 @@
 export PolarForm, get, bounds, powerflow
 export State, Control, Parameters, NumberOfState, NumberOfControl
 
-import Base: copyto!
-
 """
     AbstractFormulation
 

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -181,5 +181,6 @@ The result is stored inplace, inside the vector `g`.
 """
 function thermal_limit_constraints end
 
+include("caches.jl")
 # Polar formulation
 include("polar.jl")

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -1,6 +1,7 @@
 export PolarForm, get, bounds, powerflow
 export State, Control, Parameters, NumberOfState, NumberOfControl
 
+import Base: copyto!
 
 """
     AbstractFormulation

--- a/src/models/polar.jl
+++ b/src/models/polar.jl
@@ -277,7 +277,7 @@ function get_network_state(polar::PolarForm{T, IT, VT, AT}, x, u, p; V=Float64) 
     return vmag, vang, pinj, qinj
 end
 
-function copyto!(network::NetworkState, x, u, p, polar::PolarForm{T, IT, VT, AT}) where {T, IT, VT, AT}
+function load!(network::NetworkState, x, u, p, polar::PolarForm{T, IT, VT, AT}) where {T, IT, VT, AT}
     nbus = PS.get(polar.network, PS.NumberOfBuses())
     npv = PS.get(polar.network, PS.NumberOfPVBuses())
     npq = PS.get(polar.network, PS.NumberOfPQBuses())

--- a/test/polar_form.jl
+++ b/test/polar_form.jl
@@ -84,7 +84,7 @@ const PS = PowerSystem
             network = ExaPF.NetworkState(nbus, ngen, device)
             # network is a buffer instantiated on the target device
             @test isa(network.vmag, M)
-            ExaPF.copyto!(network, x0, u0, p, polar)
+            ExaPF.load!(network, x0, u0, p, polar)
         end
     end
 

--- a/test/polar_form.jl
+++ b/test/polar_form.jl
@@ -14,10 +14,12 @@ using TimerOutputs
 using ExaPF
 import ExaPF: PowerSystem, AD, Precondition, Iterative
 
+const PS = PowerSystem
+
 @testset "Polar formulation" begin
     datafile = "test/data/case9.m"
     tolerance = 1e-8
-    pf = PowerSystem.PowerNetwork(datafile, 1)
+    pf = PS.PowerNetwork(datafile, 1)
 
     @testset "Device $device" for (device, M) in zip([CPU(), CUDADevice()], [Array, CuArray])
         polar = PolarForm(pf, device)
@@ -40,37 +42,49 @@ import ExaPF: PowerSystem, AD, Precondition, Iterative
             @test isa(v, M)
         end
 
-        # Init AD factory
-        jx, ju = ExaPF.init_ad_factory(polar, x0, u0, p)
+        @testset "Polar model API" begin
+            # Init AD factory
+            jx, ju = ExaPF.init_ad_factory(polar, x0, u0, p)
 
-        # Test powerflow
-        xₖ, _ = @time powerflow(polar, jx, x0, u0, p, verbose_level=0, tol=tolerance)
+            # Test powerflow with x, u, p signature
+            xₖ, _ = @time powerflow(polar, jx, x0, u0, p, verbose_level=0, tol=tolerance)
 
-        # Test callbacks
-        ## Power Balance
-        g = ExaPF.power_balance(polar, xₖ, u0, p)
-        @test isa(g, M)
-        # As we run powerflow before, the balance should be below tolerance
-        @test norm(g, Inf) < tolerance
-        ## Cost Production
-        c = @time ExaPF.cost_production(polar, xₖ, u0, p)
-        @test isa(c, Real)
-        ## Inequality constraint
-        for cons in [ExaPF.state_constraint, ExaPF.power_constraints]
-            m = ExaPF.size_constraint(polar, cons)
-            @test isa(m, Int)
-            g = M{Float64, 1}(undef, m) # TODO: this signature is not great
-            fill!(g, 0)
-            cons(polar, g, xₖ, u0, p)
+            # Test callbacks
+            ## Power Balance
+            g = ExaPF.power_balance(polar, xₖ, u0, p)
+            @test isa(g, M)
+            # As we run powerflow before, the balance should be below tolerance
+            @test norm(g, Inf) < tolerance
+            ## Cost Production
+            c = @time ExaPF.cost_production(polar, xₖ, u0, p)
+            @test isa(c, Real)
+            ## Inequality constraint
+            for cons in [ExaPF.state_constraint, ExaPF.power_constraints]
+                m = ExaPF.size_constraint(polar, cons)
+                @test isa(m, Int)
+                g = M{Float64, 1}(undef, m) # TODO: this signature is not great
+                fill!(g, 0)
+                cons(polar, g, xₖ, u0, p)
 
-            g_min, g_max = ExaPF.bounds(polar, cons)
-            @test length(g_min) == m
-            @test length(g_max) == m
-            # Are we on the correct device?
-            @test isa(g_min, M)
-            @test isa(g_max, M)
-            # Test constraints are consistent
-            @test isless(g_min, g_max)
+                g_min, g_max = ExaPF.bounds(polar, cons)
+                @test length(g_min) == m
+                @test length(g_max) == m
+                # Are we on the correct device?
+                @test isa(g_min, M)
+                @test isa(g_max, M)
+                # Test constraints are consistent
+                @test isless(g_min, g_max)
+            end
+        end
+
+        # Test model with network state signature
+        @testset "Network state" begin
+            nbus = PS.get(polar.network, PS.NumberOfBuses())
+            ngen = PS.get(polar.network, PS.NumberOfGenerators())
+            network = ExaPF.NetworkState(nbus, ngen, device)
+            # network is a buffer instantiated on the target device
+            @test isa(network.vmag, M)
+            ExaPF.copyto!(network, x0, u0, p, polar)
         end
     end
 


### PR DESCRIPTION
This PR is a first step in the process of avoiding memory allocations. 

It introduces two caches: 
- `IndexingCache`: stores the indexes of the PV, PQ, Slack buses on the target device, once and for all
- `NetworkState`: this cache is more interesting, as it stores the current values of Vmag, Vang, Pinj, Qinj, Pg, Qg. 

To discuss: currently, this PR introduces a function `copyto!` to copy the vectors `x, u, p` to a `NetworkState`. But I am not sure about the naming and the signature: 
```julia
copyto!(network::NetworkState, x, u, p, polar::PolarForm{T, IT, VT, AT}) where {T, IT, VT, AT}
```

We also revisit the signature of `PolarForm` to be more precise with the types involved (type safety is of primary importance to avoid unnecessary allocations)