### PR TITLE
Allow to compute the adjoint with iterative solvers

### DIFF
--- a/src/iterative.jl
+++ b/src/iterative.jl
@@ -9,6 +9,7 @@ using SparseArrays
 using TimerOutputs
 
 using ..ExaPF: Precondition
+import ..ExaPF: norm2
 
 export bicgstab, list_solvers
 
@@ -23,30 +24,24 @@ of nonsymmetric linear systems."
 SIAM Journal on scientific and Statistical Computing 13, no. 2 (1992): 631-644.
 """
 function bicgstab(A, b, P, xi, to::TimerOutput;
-                  tol=1e-6, maxiter=size(A, 1), verbose=false)
+                  tol=1e-10, maxiter=size(A, 1), verbose=false)
     # parameters
     n    = size(b, 1)
-    x0   = similar(b)
-    x0 = P * b
-    r0   = b - A * x0
-    br0  = copy(r0)
+    xi   = similar(b)
+    mul!(xi, P, b)
+    ri   = b - A * xi
+    br0  = copy(ri)
     rho0 = 1.0
     alpha = 1.0
     omega0 = 1.0
-    if A isa SparseArrays.SparseMatrixCSC
-        v0 = zeros(Float64, n)
-        p0 = zeros(Float64, n)
-    else
-        v0 = cuzeros(Float64, n)
-        p0 = cuzeros(Float64, n)
-    end
+    vi = similar(xi)
+    pi = similar(xi)
+    fill!(vi, 0)
+    fill!(pi, 0)
 
-    ri     = copy(r0)
     rhoi   = copy(rho0)
     omegai = copy(omega0)
-    vi = copy(v0)
-    pi = copy(p0)
-    xi .= x0
+    residual = copy(b)
 
     y = similar(pi)
     s = similar(pi)
@@ -55,7 +50,6 @@ function bicgstab(A, b, P, xi, to::TimerOutput;
     t2 = similar(pi)
     pi1 = similar(pi)
     vi1 = similar(pi)
-    xi1 = similar(pi)
     t = similar(pi)
 
     go = true
@@ -65,22 +59,26 @@ function bicgstab(A, b, P, xi, to::TimerOutput;
             @timeit to "First stage" begin
                 rhoi1 = dot(br0, ri) ; beta = (rhoi1/rhoi) * (alpha / omegai)
                 pi1 .= ri .+ beta .* (pi .- omegai .* vi)
-                y .= P * pi1
-                vi1 .= A * y
+                mul!(y, P, pi1)
+                mul!(vi1, A, y)
                 alpha = rhoi1 / dot(br0, vi1)
-                s .= ri .- (alpha * vi1)
-                z .= P * s
-                t .= A * z
-                t1 .= P * t
-                t2 .= P * s
+                s .= ri .- (alpha .* vi1)
+                mul!(z, P, s)
+                mul!(t, A, z)
+                mul!(t1, P, t)
+                mul!(t2, P, s)
             end
             @timeit to "Main stage" begin
                 omegai1 = dot(t1, t2) / dot(t1, t1)
-                xi1 .= xi .+ alpha .* y .+ omegai1 .* z
+                xi .= xi .+ alpha .* y .+ omegai1 .* z
             end
 
             @timeit to "End stage" begin
-                anorm = norm((A * xi1) .- b)
+                # TODO: should update to five arguments mul!
+                #       once CUDA.jl 1.4 is released
+                # mul!(residual, A, xi, 1.0, -1.0)
+                residual .= A * xi .- b
+                anorm = norm2(residual)
 
                 if verbose
                     println("\tIteration: ", iter)
@@ -103,7 +101,6 @@ function bicgstab(A, b, P, xi, to::TimerOutput;
                 pi     .= pi1
                 vi     .= vi1
                 omegai = omegai1
-                xi     .= xi1
                 iter   += 1
             end
         end

--- a/src/models/polar/kernels.jl
+++ b/src/models/polar/kernels.jl
@@ -32,7 +32,7 @@ function residualJacobian(V, Ybus, pv, pq)
     J = [j11 j12; j21 j22]
 end
 
-function _sparsity_pattern(polar::PolarForm)
+function _state_jacobian(polar::PolarForm)
     pf = polar.network
     ref = polar.network.ref
     pv = polar.network.pv
@@ -44,9 +44,9 @@ function _sparsity_pattern(polar::PolarForm)
     Vre = rand(n)
     Vim = rand(n)
     V = Vre .+ 1im .* Vim
-    J = residualJacobian(V, Y, pv, pq)
-    return findnz(J)
+    return residualJacobian(V, Y, pv, pq)
 end
+_sparsity_pattern(polar::PolarForm) = findnz(_state_jacobian(polar))
 
 @kernel function residual_kernel!(F, @Const(v_m), @Const(v_a),
                                   @Const(ybus_re_nzval), @Const(ybus_re_colptr), @Const(ybus_re_rowval),

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -293,7 +293,7 @@ function powerflow(
 
     # check for convergence
     normF = norm(F, Inf)
-    if verbose_level >= VERBOSE_LEVEL_HIGH
+    if verbose_level >= VERBOSE_LEVEL_LOW
         @printf("Iteration %d. Residual norm: %g.\n", iter, normF)
     end
     if normF < tol
@@ -345,7 +345,7 @@ function powerflow(
         end
 
         @timeit TIMER "Norm" normF = norm2(F)
-        if verbose_level >= VERBOSE_LEVEL_HIGH
+        if verbose_level >= VERBOSE_LEVEL_LOW
             @printf("Iteration %d. Residual norm: %g.\n", iter, normF)
         end
 
@@ -366,6 +366,7 @@ function powerflow(
     if verbose_level >= VERBOSE_LEVEL_MEDIUM
         show(TIMER)
         println("")
+        reset_timer!(TIMER)
     end
     conv = ConvergenceStatus(converged, iter, normF, sum(linsol_iters))
     return conv

--- a/test/iterative_solvers.jl
+++ b/test/iterative_solvers.jl
@@ -75,7 +75,8 @@ end
             ExaPF.Precondition.update(As, precond, to)
             P = precond.P
             fill!(x0, 0.0)
-            x_sol, n_iters = ExaPF.bicgstab(As, bs, P, x0, to)
+            x_sol, n_iters, status = ExaPF.bicgstab(As, bs, P, x0, to)
+            @test status == ExaPF.Iterative.Converged
             @test n_iters <= m
             @test x_sol ≈ xs♯ atol=1e-6
         end


### PR DESCRIPTION
This PR adds the ability to compute the adjoint in the `ReducedSpaceNLPEvaluator` with an iterative solver. 

Minor fixes: 
- reduce the number of memory allocations in BICGSTAB (2x speed-up for `case300.m` 
- start to introduce the templating for the iterative solvers (upcoming PR)