### PR TITLE
Improve API of NLPEvaluator and PolarForm

### DIFF
--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -95,6 +95,14 @@ at control `u`. Modify vector `cons` inplace.
 """
 function primal_infeasibility! end
 
+"""
+    reset!(nlp::AbstractNLPEvaluator)
+
+Reset evaluator `nlp` to default configuration.
+
+"""
+function reset! end
+
 abstract type AbstractNLPAttribute end
 struct Variables <: AbstractNLPAttribute end
 struct Constraints <: AbstractNLPAttribute end

--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -129,3 +129,13 @@ end
 
 primal_infeasibility!(ag::AugLagEvaluator, cons, u) = primal_infeasibility!(ag.inner, cons, u)
 primal_infeasibility(ag::AugLagEvaluator, u) = primal_infeasibility(ag.inner, u)
+
+function reset!(ag::AugLagEvaluator)
+    reset!(ag.inner)
+    empty!(ag.counter)
+    fill!(ag.cons, 0)
+    fill!(ag.infeasibility, 0)
+    fill!(ag.λ, 0)
+    fill!(ag.λc, 0)
+end
+

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -1,4 +1,5 @@
 
+# AD Factory
 abstract type AbstractADFactory end
 
 struct ADFactory <: AbstractADFactory
@@ -7,6 +8,7 @@ struct ADFactory <: AbstractADFactory
     ∇f::AD.ObjectiveAD
 end
 
+# Counters
 abstract type AbstractCounter end
 
 mutable struct NLPCounter <: AbstractCounter
@@ -19,6 +21,13 @@ mutable struct NLPCounter <: AbstractCounter
 end
 NLPCounter() = NLPCounter(0, 0, 0, 0, 0, 0)
 
+function Base.empty!(c::NLPCounter)
+    for attr in fieldnames(NLPCounter)
+        setfield!(c, attr, 0)
+    end
+end
+
+# Active set utils
 function _check(val, val_min, val_max)
     violated_inf = findall(val .< val_min)
     violated_sup = findall(val .> val_max)
@@ -41,6 +50,7 @@ function active_set(c, c♭, c♯; tol=1e-8)
     return active_lb, active_ub
 end
 
+# Scaler utils
 abstract type AbstractScaler end
 
 scale_factor(h, tol, η) = max(tol, η / max(1.0, h))

--- a/src/Evaluators/penalty.jl
+++ b/src/Evaluators/penalty.jl
@@ -106,3 +106,10 @@ end
 primal_infeasibility!(pen::PenaltyEvaluator, cons, u) = primal_infeasibility!(pen.inner, cons, u)
 primal_infeasibility(pen::PenaltyEvaluator, u) = primal_infeasibility(pen.inner, u)
 
+function reset!(pen::PenaltyEvaluator)
+    reset!(pen.inner)
+    fill!(pen.cons, 0)
+    fill!(pen.infeasibility, 0)
+    fill!(pen.penalties, 0)
+end
+

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -252,6 +252,7 @@ function primal_infeasibility(nlp::ReducedSpaceEvaluator, u)
     return primal_infeasibility!(nlp, cons, u)
 end
 
+# Printing
 function sanity_check(nlp::ReducedSpaceEvaluator, u, cons)
     println("Check violation of constraints")
     print("Control  \t")
@@ -268,3 +269,16 @@ function sanity_check(nlp::ReducedSpaceEvaluator, u, cons)
             err_sup, n_sup, err_inf, n_inf)
 end
 
+function Base.show(io::IO, nlp::ReducedSpaceEvaluator)
+    n = n_variables(nlp)
+    m = n_constraints(nlp)
+    println(io, "A ReducedSpaceEvaluator object")
+    println(io, "    * device: ", nlp.model.device)
+    println(io, "    * #vars: ", n)
+    println(io, "    * #cons: ", m)
+    println(io, "    * constraints:")
+    for cons in nlp.constraints
+        println("        - ", cons)
+    end
+    print(io, "    * linear solver: ", nlp.linear_solver)
+end

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -282,3 +282,14 @@ function Base.show(io::IO, nlp::ReducedSpaceEvaluator)
     end
     print(io, "    * linear solver: ", nlp.linear_solver)
 end
+
+function reset!(nlp::ReducedSpaceEvaluator)
+    # Reset adjoint
+    fill!(nlp.λ, 0)
+    # Reset initial state
+    x0 = initial(nlp.model, State())
+    copy!(nlp.x, x0)
+    # Reset buffer
+    nlp.buffer = get(nlp.model, PhysicalState())
+end
+

--- a/src/ExaPF.jl
+++ b/src/ExaPF.jl
@@ -22,6 +22,8 @@ using SparseArrays
 using SparseDiffTools
 using TimerOutputs
 
+import Base: show, get
+
 const MOI = MathOptInterface
 const TIMER = TimerOutput()
 

--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -9,7 +9,7 @@ using Printf
 using SparseArrays
 using TimerOutputs
 
-import ..ExaPF: norm2, TIMER, csclsvqr!
+import ..ExaPF: xnorm, TIMER, csclsvqr!
 import Base: show
 
 export bicgstab, list_solvers

--- a/src/LinearSolvers/bicgstab.jl
+++ b/src/LinearSolvers/bicgstab.jl
@@ -71,7 +71,7 @@ function bicgstab(A, b, P, xi;
         xi .= xi .+ alpha .* y .+ omegai1 .* z
 
         mul!(residual, A, xi, 1.0, -1.0)
-        anorm = norm2(residual)
+        anorm = xnorm(residual)
 
         if verbose
             @printf("%4d %10.4e\n", iter, anorm)

--- a/src/PowerSystem/power_network.jl
+++ b/src/PowerSystem/power_network.jl
@@ -76,7 +76,7 @@ end
 # Getters
 ## Network attributes
 get(pf::PowerNetwork, ::NumberOfBuses) = pf.nbus
-get(pf::PowerNetwork, ::NumberOfLines) = size(pf.data["branch"], 1)
+get(pf::PowerNetwork, ::NumberOfLines) = size(pf.data["branch"], 2)
 get(pf::PowerNetwork, ::NumberOfGenerators) = pf.ngen
 get(pf::PowerNetwork, ::NumberOfPVBuses) = length(pf.pv)
 get(pf::PowerNetwork, ::NumberOfPQBuses) = length(pf.pq)

--- a/src/PowerSystem/power_network.jl
+++ b/src/PowerSystem/power_network.jl
@@ -32,7 +32,7 @@ struct PowerNetwork <: AbstractPowerSystem
     sbus::Vector{Complex{Float64}}
     sload::Vector{Complex{Float64}}
 
-    function PowerNetwork(datafile::String, data_format::Int64=0)
+    function PowerNetwork(datafile::String, data_format::Int64)
 
         if data_format == 0
             println("Reading PSSE format")

--- a/src/PowerSystem/power_network.jl
+++ b/src/PowerSystem/power_network.jl
@@ -72,6 +72,17 @@ struct PowerNetwork <: AbstractPowerSystem
         new(vbus, Ybus, data, nbus, ngen, bustype, bus_id_to_indexes, ref, pv, pq, sbus, sload)
     end
 end
+function PowerNetwork(datafile::String)
+    if endswith(datafile, ".raw")
+        data_format = 0
+    elseif endswith(datafile, ".m")
+        data_format = 1
+    else
+        error("Unsupported format in file $(datafile): supported extensions are " *
+              "Matpower (.m) or PSSE (.raw)")
+    end
+    return PowerNetwork(datafile, data_format)
+end
 
 # Getters
 ## Network attributes

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -9,7 +9,7 @@ using SparseArrays
 using TimerOutputs
 using SparsityDetection
 using SparseDiffTools
-using ..ExaPF: Spmat
+using ..ExaPF: Spmat, xzeros
 
 import Base: show
 
@@ -242,8 +242,7 @@ struct DesignJacobianAD{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
             J = CuSparseMatrixCSR(J)
         end
         t1s{N} = ForwardDiff.Dual{Nothing,Float64, N} where N
-        # x = T{Float64}(undef, nv_m + nv_a)
-        x = VT(zeros(Float64, npbus + nv_a))
+        x = xzeros(VT, npbus + nv_a)
         t1sx = A{t1s{ncolor}}(x)
         # t1sF = T{t1s{ncolor}}(undef, nmap)
         t1sF = A{t1s{ncolor}}(zeros(Float64, length(F)))
@@ -407,7 +406,7 @@ the CPU.
 function uncompress!(J::SparseArrays.SparseMatrixCSC, compressedJ, coloring)
     # CSC is column oriented: nmap is equal to number of columns
     nmap = size(J, 2)
-    # TODO: coloring[i] leads to an out of bounds access here. Added the @assert here to observe. 
+    # TODO: coloring[i] leads to an out of bounds access here. Added the @assert here to observe.
     if maximum(coloring) != size(compressedJ,1)
         @show coloring
         @show J.colptr

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -209,27 +209,3 @@ include("caches.jl")
 # Polar formulation
 include("polar/polar.jl")
 
-
-Base.show(model::AbstractFormulation, x, u, p) = Base.show(stdout, model, x, u, p)
-function Base.show(io::IO, model::AbstractFormulation, x, u, p)
-    nbus = PS.get(model.network, PS.NumberOfBuses())
-    npv = PS.get(model.network, PS.NumberOfPVBuses())
-    npq = PS.get(model.network, PS.NumberOfPQBuses())
-    nref = PS.get(model.network, PS.NumberOfSlackBuses())
-    ngen = PS.get(model.network, PS.NumberOfGenerators())
-    println(io, "Power Network characteristics:")
-    @printf(io, "\tBuses: %d. Slack: %d. PV: %d. PQ: %d\n", nbus, nref, npv, npq)
-    println(io, "\tGenerators: ", ngen, ".")
-    # Print system status
-    @printf(io, "\t==============================================\n")
-    @printf(io, "\tBUS \t TYPE \t VMAG \t VANG \t P \t Q\n")
-    @printf(io, "\t==============================================\n")
-
-    vmag, vang, pinj, qinj = get_network_state(model, x, u, p)
-
-    for i=1:nbus
-        type = model.network.bustype[i]
-        @printf(io, "\t%d \t  %d \t %1.3f\t%3.2f\t%3.3f\t%3.3f\n", i,
-                type, vmag[i], vang[i]*(180.0/pi), pinj[i], qinj[i])
-    end
-end

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -1,8 +1,6 @@
 export PolarForm, get, bounds, powerflow
 export State, Control, Parameters, NumberOfState, NumberOfControl
 
-import Base: show, get
-
 """
     AbstractFormulation
 

--- a/src/models/polar/getters.jl
+++ b/src/models/polar/getters.jl
@@ -1,24 +1,4 @@
 
-function get(
-    polar::PolarForm{T, IT, VT, AT},
-    ::State,
-    vmag::VT,
-    vang::VT,
-    pbus::VT,
-    qbus::VT,
-) where {T, IT, VT, AT}
-    npv = PS.get(polar.network, PS.NumberOfPVBuses())
-    npq = PS.get(polar.network, PS.NumberOfPQBuses())
-    nref = PS.get(polar.network, PS.NumberOfSlackBuses())
-    # build vector x
-    dimension = get(polar, NumberOfState())
-    x = VT(undef, dimension)
-    x[1:npv] = vang[polar.network.pv]
-    x[npv+1:npv+npq] = vang[polar.network.pq]
-    x[npv+npq+1:end] = vmag[polar.network.pq]
-
-    return x
-end
 function get!(
     polar::PolarForm{T, IT, VT, AT},
     ::State,
@@ -40,6 +20,26 @@ end
 
 function get(
     polar::PolarForm{T, IT, VT, AT},
+    ::State,
+    vmag::VT,
+    vang::VT,
+    pbus::VT,
+    qbus::VT,
+) where {T, IT, VT, AT}
+    npv = PS.get(polar.network, PS.NumberOfPVBuses())
+    npq = PS.get(polar.network, PS.NumberOfPQBuses())
+    nref = PS.get(polar.network, PS.NumberOfSlackBuses())
+    # build vector x
+    dimension = get(polar, NumberOfState())
+    x = xzeros(VT, dimension)
+    x[1:npv] = vang[polar.network.pv]
+    x[npv+1:npv+npq] = vang[polar.network.pq]
+    x[npv+npq+1:end] = vmag[polar.network.pq]
+
+    return x
+end
+function get(
+    polar::PolarForm{T, IT, VT, AT},
     ::Control,
     vmag::VT,
     vang::VT,
@@ -52,7 +52,7 @@ function get(
     pload = polar.active_load
     # build vector u
     dimension = get(polar, NumberOfControl())
-    u = VT(undef, dimension)
+    u = xzeros(VT, dimension)
     u[1:nref] = vmag[polar.network.ref]
     # u is equal to active power of generator (Pᵍ)
     # As P = Pᵍ - Pˡ , we get
@@ -74,36 +74,10 @@ function get(
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())
     # build vector p
     dimension = nref + 2*npq
-    p = VT(undef, dimension)
+    p = xzeros(VT, dimension)
     p[1:nref] = vang[polar.network.ref]
     p[nref + 1:nref + npq] = pbus[polar.network.pq]
     p[nref + npq + 1:nref + 2*npq] = qbus[polar.network.pq]
     return p
-end
-
-# Bridge with buses' attributes
-function get(polar::PolarForm{T, IT, VT, AT}, ::PS.Buses, ::PS.VoltageMagnitude, x, u, p; V=eltype(x)) where {T, IT, VT, AT}
-    nbus = PS.get(polar.network, PS.NumberOfBuses())
-    npv = PS.get(polar.network, PS.NumberOfPVBuses())
-    npq = PS.get(polar.network, PS.NumberOfPQBuses())
-    nref = PS.get(polar.network, PS.NumberOfSlackBuses())
-    MT = polar.AT
-    vmag = MT{V, 1}(undef, nbus)
-    vmag[polar.network.pq] = x[npq+npv+1:end]
-    vmag[polar.network.ref] = u[1:nref]
-    vmag[polar.network.pv] = u[nref + npv + 1:nref + 2*npv]
-    return vmag
-end
-function get(polar::PolarForm{T, IT, VT, AT}, ::PS.Buses, ::PS.VoltageAngle, x, u, p; V=eltype(x)) where {T, IT, VT, AT}
-    nbus = PS.get(polar.network, PS.NumberOfBuses())
-    npv = PS.get(polar.network, PS.NumberOfPVBuses())
-    npq = PS.get(polar.network, PS.NumberOfPQBuses())
-    nref = PS.get(polar.network, PS.NumberOfSlackBuses())
-    MT = polar.AT
-    vang = MT{V, 1}(undef, nbus)
-    vang[polar.network.pq] = x[npv+1:npv+npq]
-    vang[polar.network.pv] = x[1:npv]
-    vang[polar.network.ref] = p[1:nref]
-    return vang
 end
 

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -378,3 +378,27 @@ function cost_production(polar::PolarForm, pg)
     cost = sum(c2 .+ c3 .* pg .+ c4 .* pg.^2)
     return cost
 end
+
+# Utils
+function Base.show(io::IO, polar::PolarForm)
+    # Network characteristics
+    nbus = PS.get(polar.network, PS.NumberOfBuses())
+    npv = PS.get(polar.network, PS.NumberOfPVBuses())
+    npq = PS.get(polar.network, PS.NumberOfPQBuses())
+    nref = PS.get(polar.network, PS.NumberOfSlackBuses())
+    ngen = PS.get(polar.network, PS.NumberOfGenerators())
+    nlines = PS.get(polar.network, PS.NumberOfLines())
+    # Polar formulation characteristics
+    n_states = get(polar, NumberOfState())
+    n_controls = get(polar, NumberOfControl())
+    print(io,   "Polar formulation model")
+    println(io, " (instantiated on device $(polar.device))")
+    println(io, "Network characteristics:")
+    @printf(io, "    #buses:      %d  (#slack: %d  #PV: %d  #PQ: %d)\n", nbus, nref, npv, npq)
+    println(io, "    #generators: ", ngen)
+    println(io, "    #lines:      ", nlines)
+    println(io, "giving a mathematical formulation with:")
+    println(io, "    #controls:   ", n_controls)
+    print(io,   "    #states  :   ", n_states)
+end
+

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,9 +23,14 @@ mutable struct Spmat{VTI<:AbstractVector, VTF<:AbstractVector}
 end
 
 # norm
-norm2(x::AbstractVector) = norm(x, 2)
-norm2(x::CuVector) = CUBLAS.nrm2(x)
+xnorm(x::AbstractVector) = norm(x, 2)
+xnorm(x::CuVector) = CUBLAS.nrm2(x)
 
+# Array initialization
+xzeros(S, n) = fill!(S(undef, n), zero(eltype(S)))
+xones(S, n) = fill!(S(undef, n), one(eltype(S)))
+
+# projection operator
 function project!(w::VT, u::VT, u♭::VT, u♯::VT) where VT<:AbstractArray
     w .= max.(min.(u, u♯), u♭)
 end
@@ -53,3 +58,4 @@ function csclsvqr!(A::CuSparseMatrixCSC{Float64},
 
     x
 end
+

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -4,22 +4,6 @@ using MathOptInterface
 
 const MOI = MathOptInterface
 
-const CASE57_SOLUTION = [
-    1.0260825400262428,
-    0.0,
-    0.6,
-    0.0,
-    8.603379123083476,
-    0.0,
-    1.3982297290334753,
-    1.016218932360429,
-    1.009467718490475,
-    1.027857273911734,
-    1.06,
-    0.9962215167521776,
-    0.9965415804936182
-]
-
 function moi_solve(
     optimizer::MOI.AbstractOptimizer,
     nlp::ExaPF.AbstractNLPEvaluator,
@@ -56,6 +40,22 @@ function moi_solve(
 end
 
 @testset "MOI wrapper" begin
+    CASE57_SOLUTION = [
+        1.0260825400262428,
+        0.0,
+        0.6,
+        0.0,
+        8.603379123083476,
+        0.0,
+        1.3982297290334753,
+        1.016218932360429,
+        1.009467718490475,
+        1.027857273911734,
+        1.06,
+        0.9962215167521776,
+        0.9965415804936182
+    ]
+
     datafile = joinpath(dirname(@__FILE__), "..", "data", "case57.m")
     nlp = ExaPF.ReducedSpaceEvaluator(datafile)
     optimizer = Ipopt.Optimizer(

--- a/test/auglag.jl
+++ b/test/auglag.jl
@@ -37,6 +37,8 @@
         # Utils
         inf_pr1 = ExaPF.primal_infeasibility(nlp, u)
         @test inf_pr1 == 0.0
+        # Test reset
+        ExaPF.reset!(pen)
     end
     @testset "Active constraints" begin
         datafile = joinpath(dirname(@__FILE__), "..", "data", "case57.m")

--- a/test/auglag.jl
+++ b/test/auglag.jl
@@ -1,15 +1,9 @@
 @testset "AugLagEvaluators" begin
     @testset "Inactive constraints" begin
         datafile = joinpath(dirname(@__FILE__), "..", "data", "case9.m")
-        pf = PowerSystem.PowerNetwork(datafile, 1)
-        polar = PolarForm(pf, CPU())
-        x0 = ExaPF.initial(polar, State())
-        u0 = ExaPF.initial(polar, Control())
-        p = ExaPF.initial(polar, Parameters())
-
-        constraints = Function[ExaPF.state_constraint, ExaPF.power_constraints]
         # Build reference evaluator
-        nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0, p; constraints=constraints)
+        nlp = ExaPF.ReducedSpaceEvaluator(datafile)
+        u0 = ExaPF.initial(nlp)
         # Build penalty evaluator
         pen = ExaPF.AugLagEvaluator(nlp, u0)
 
@@ -42,16 +36,9 @@
     end
     @testset "Active constraints" begin
         datafile = joinpath(dirname(@__FILE__), "..", "data", "case57.m")
-        pf = PowerSystem.PowerNetwork(datafile, 1)
-        polar = PolarForm(pf, CPU())
-        x0 = ExaPF.initial(polar, State())
-        u0 = ExaPF.initial(polar, Control())
-        p = ExaPF.initial(polar, Parameters())
-
-        constraints = Function[ExaPF.state_constraint, ExaPF.power_constraints]
         # Build reference evaluator
-        nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0, p; constraints=constraints,
-                                          ε_tol=1e-13)
+        nlp = ExaPF.ReducedSpaceEvaluator(datafile)
+        u0 = ExaPF.initial(nlp)
         # Build penalty evaluator
         for scaling in [true, false]
             pen = ExaPF.AugLagEvaluator(nlp, u0; scale=scaling)

--- a/test/penalty.jl
+++ b/test/penalty.jl
@@ -47,6 +47,9 @@ import ExaPF: ParsePSSE, PowerSystem, IndexSet
         @test isequal(g_ref, g)
         # Update penalty weigth
         ExaPF.update_penalty!(pen)
+
+        # Test reset
+        ExaPF.reset!(pen)
     end
     @testset "Active constraints" begin
         datafile = joinpath(dirname(@__FILE__), "..", "data", "case57.m")

--- a/test/penalty.jl
+++ b/test/penalty.jl
@@ -14,15 +14,8 @@ import ExaPF: ParsePSSE, PowerSystem, IndexSet
 @testset "PenaltyEvaluators" begin
     @testset "Inactive constraints" begin
         datafile = joinpath(dirname(@__FILE__), "..", "data", "case9.m")
-        pf = PowerSystem.PowerNetwork(datafile, 1)
-        polar = PolarForm(pf, CPU())
-        x0 = ExaPF.initial(polar, State())
-        u0 = ExaPF.initial(polar, Control())
-        p = ExaPF.initial(polar, Parameters())
-
-        constraints = Function[ExaPF.state_constraint, ExaPF.power_constraints]
-        # Build reference evaluator
-        nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0, p; constraints=constraints)
+        nlp = ExaPF.ReducedSpaceEvaluator(datafile)
+        u0 = ExaPF.initial(nlp)
         # Build penalty evaluator
         pen = ExaPF.PenaltyEvaluator(nlp, u0)
 
@@ -53,15 +46,9 @@ import ExaPF: ParsePSSE, PowerSystem, IndexSet
     end
     @testset "Active constraints" begin
         datafile = joinpath(dirname(@__FILE__), "..", "data", "case57.m")
-        pf = PowerSystem.PowerNetwork(datafile, 1)
-        polar = PolarForm(pf, CPU())
-        x0 = ExaPF.initial(polar, State())
-        u0 = ExaPF.initial(polar, Control())
-        p = ExaPF.initial(polar, Parameters())
+        nlp = ExaPF.ReducedSpaceEvaluator(datafile)
+        u0 = ExaPF.initial(nlp)
 
-        constraints = Function[ExaPF.state_constraint, ExaPF.power_constraints]
-        # Build reference evaluator
-        nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0, p; constraints=constraints)
         # Build penalty evaluator
         for scaling in [true, false]
             pen = ExaPF.PenaltyEvaluator(nlp, u0; scale=scaling)

--- a/test/polar_form.jl
+++ b/test/polar_form.jl
@@ -28,6 +28,8 @@ const PS = PowerSystem
 
     @testset "Initiate polar formulation on device $device" for (device, M) in ITERATORS
         polar = PolarForm(pf, device)
+        # Test printing
+        println(polar)
 
         b = bounds(polar, State())
         b = bounds(polar, Control())

--- a/test/reduced_evaluator.jl
+++ b/test/reduced_evaluator.jl
@@ -15,6 +15,7 @@
 
         constraints = Function[ExaPF.state_constraint, ExaPF.power_constraints]
         nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0, p; constraints=constraints)
+        println(nlp)
 
         # Test evaluator is well instantiated on target device
         TNLP = typeof(nlp)

--- a/test/reduced_evaluator.jl
+++ b/test/reduced_evaluator.jl
@@ -15,6 +15,7 @@
 
         constraints = Function[ExaPF.state_constraint, ExaPF.power_constraints]
         nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0, p; constraints=constraints)
+        # Test printing
         println(nlp)
 
         # Test evaluator is well instantiated on target device
@@ -73,6 +74,11 @@
         inf_pr1 = ExaPF.primal_infeasibility(nlp, u)
         inf_pr2 = ExaPF.primal_infeasibility!(nlp, v, u)
         @test inf_pr1 == inf_pr2
+
+        # test reset!
+        ExaPF.reset!(nlp)
+        @test nlp.x == x0
+        @test iszero(nlp.λ)
     end
 end
 

--- a/test/test_rgm.jl
+++ b/test/test_rgm.jl
@@ -10,15 +10,9 @@ import ExaPF: ParseMAT, PowerSystem, IndexSet
 
 @testset "RGM Optimal Power flow 9 bus case" begin
     datafile = joinpath(dirname(@__FILE__), "..", "data", "case9.m")
-    pf = PowerSystem.PowerNetwork(datafile, 1)
-    polar = PolarForm(pf, CPU())
 
-    xk = ExaPF.initial(polar, State())
-    uk = ExaPF.initial(polar, Control())
-    p = ExaPF.initial(polar, Parameters())
-
-    constraints = Function[ExaPF.state_constraint, ExaPF.power_constraints]
-    nlp = ExaPF.ReducedSpaceEvaluator(polar, xk, uk, p; constraints=constraints)
+    nlp = ExaPF.ReducedSpaceEvaluator(datafile)
+    uk = ExaPF.initial(nlp)
 
     # solve power flow
     ExaPF.update!(nlp, uk)


### PR DESCRIPTION
- add proper dispatch on `Base.show` with `PolarForm` and `ReducedSpaceNLPEvaluator`. Now, we get a proper output when we type: 
```julia
nlp = ReducedSpaceEvaluator(...)
println(nlp)
```
- implement a  `reset!` function to reset properly any `AbstractNLPEvaluator` object, without reloading them in memory (could save a lot of time on the GPU)
- fix the new constructor of `ReducedSpaceEvaluator`: when instantiated from a datafile. the options were not passed correctly. Now, the constructor works as expected. We could load directly the evaluator as 
```julia
nlp = ReducedSpaceEvaluator(dafafile; constraints=[ExaPF.power_constraints], linear_solver=...)

```