### PR TITLE
Pre-release cleansings 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Adrian Maldonado <maldonadod@anl.gov>", "Michel Schanen <mschanen@an
 version = "0.3.0"
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -12,28 +11,26 @@ IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
-LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
-SparsityDetection = "684fba80-ace3-11e9-3d08-3bc7ed6f96df"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
 CUDA = "2.0"
 julia = "^1"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-scripts = ["Ipopt", "NLsolve"]
-test = ["Test", "Random", "Ipopt"]
+scripts = ["Ipopt", "NLsolve", "UnicodePlots", "BenchmarkTools"]
+test = ["Test", "Random", "Ipopt", "BenchmarkTools"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,8 +20,18 @@ SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
-CUDA = "2.0"
-julia = "^1"
+CUDA = "^2.0"
+FiniteDiff = "2.7"
+ForwardDiff = "0.10"
+IterativeSolvers = "0.8"
+KernelAbstractions = "0.4.5"
+Krylov = "0.5.5"
+LightGraphs = "1.3"
+MathOptInterface = "0.9"
+Metis = "1"
+SparseDiffTools = "1"
+TimerOutputs = "0.5"
+julia = "^1.5"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/lib/formulations.md
+++ b/docs/src/lib/formulations.md
@@ -42,6 +42,7 @@ NumberOfControl
 
 ```@docs
 powerflow
+power_balance!
 
 ```
 

--- a/docs/src/lib/linearsolver.md
+++ b/docs/src/lib/linearsolver.md
@@ -2,12 +2,27 @@
 CurrentModule = ExaPF.LinearSolvers
 ```
 
-## Description
+## Linear solvers
+
+`ExaPF` allows to solve linear systems with either
+direct and indirect linear algebra.
+```@docs
+ldiv!
+
+```
+
+## Preconditioning
+
+To solve linear systems with iterative methods, `ExaPF`
+provides an implementation of a block-Jacobi preconditioner,
+portable on GPU.
+
 ```@docs
 AbstractPreconditioner
 ```
 
-## API Reference
+### Block-Jacobi preconditioner
+
 ```@docs
 BlockJacobiPreconditioner
 update

--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -1,6 +1,4 @@
 
-import Base: show
-
 """
     AbstractNLPEvaluator
 

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -102,7 +102,7 @@ function update!(nlp::ReducedSpaceEvaluator, u; verbose_level=0)
     conv = powerflow(nlp.model, jac_x, nlp.buffer, tol=nlp.ε_tol;
                      solver=nlp.linear_solver, verbose_level=verbose_level)
     if !conv.has_converged
-        error("Newton-Raphson algorithm failed to converge ($(conv.norm_residuals))")
+        @warn("Newton-Raphson algorithm failed to converge ($(conv.norm_residuals))")
         return conv
     end
     ∇gₓ = nlp.autodiff.Jgₓ.J

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -281,7 +281,7 @@ function Base.show(io::IO, nlp::ReducedSpaceEvaluator)
     println(io, "    * #cons: ", m)
     println(io, "    * constraints:")
     for cons in nlp.constraints
-        println("        - ", cons)
+        println(io, "        - ", cons)
     end
     print(io, "    * linear solver: ", nlp.linear_solver)
 end

--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -170,7 +170,7 @@ function ldiv!(solver::KrylovBICGSTAB,
     y::AbstractVector, J::AbstractMatrix, x::AbstractVector,
 )
     P = solver.precond.P
-    (y[:], status) = Krylov.bicgstab(J, x, N=P)
+    (y[:], status) = Krylov.bicgstab(J, x, N=P, atol=1e-10, verbose=false)
     return length(status.residuals)
 end
 

--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -7,13 +7,12 @@ using Krylov
 using LinearAlgebra
 using Printf
 using SparseArrays
-using TimerOutputs
 
-import ..ExaPF: xnorm, TIMER, csclsvqr!
+import ..ExaPF: xnorm, csclsvqr!
 import Base: show
 
 export bicgstab, list_solvers
-export DirectSolver, BICGSTAB, EigenBICGSTAB
+export DirectSolver, BICGSTAB, EigenBICGSTAB, KrylovBICGSTAB
 export get_transpose
 
 @enum(
@@ -70,7 +69,7 @@ end
 get_transpose(::DirectSolver, M::CUDA.CUSPARSE.CuSparseMatrixCSR) = CuSparseMatrixCSC(M)
 
 function update!(solver::AbstractIterativeLinearSolver, J)
-    @timeit solver.timer "Preconditioner"  update(J, solver.precond, solver.timer)
+    update(J, solver.precond)
 end
 
 struct BICGSTAB <: AbstractIterativeLinearSolver
@@ -78,9 +77,8 @@ struct BICGSTAB <: AbstractIterativeLinearSolver
     maxiter::Int
     tol::Float64
     verbose::Bool
-    timer::TimerOutput
 end
-BICGSTAB(precond; maxiter=2_000, tol=1e-8, verbose=false) = BICGSTAB(precond, maxiter, tol, verbose, TIMER)
+BICGSTAB(precond; maxiter=2_000, tol=1e-8, verbose=false) = BICGSTAB(precond, maxiter, tol, verbose)
 function ldiv!(solver::BICGSTAB,
     y::AbstractVector, J::AbstractMatrix, x::AbstractVector,
 )
@@ -99,9 +97,8 @@ struct EigenBICGSTAB <: AbstractIterativeLinearSolver
     maxiter::Int
     tol::Float64
     verbose::Bool
-    timer::TimerOutput
 end
-EigenBICGSTAB(precond; maxiter=2_000, tol=1e-8, verbose=false) = EigenBICGSTAB(precond, maxiter, tol, verbose, TIMER)
+EigenBICGSTAB(precond; maxiter=2_000, tol=1e-8, verbose=false) = EigenBICGSTAB(precond, maxiter, tol, verbose)
 function ldiv!(solver::EigenBICGSTAB,
     y::AbstractVector, J::AbstractMatrix, x::AbstractVector,
 )
@@ -119,9 +116,8 @@ end
 struct RefBICGSTAB <: AbstractIterativeLinearSolver
     precond::AbstractPreconditioner
     verbose::Bool
-    timer::TimerOutput
 end
-RefBICGSTAB(precond; verbose=true) = RefBICGSTAB(precond, verbose, TIMER)
+RefBICGSTAB(precond; verbose=true) = RefBICGSTAB(precond, verbose)
 function ldiv!(solver::RefBICGSTAB,
     y::AbstractVector, J::AbstractMatrix, x::AbstractVector,
 )
@@ -134,9 +130,8 @@ struct RefGMRES <: AbstractIterativeLinearSolver
     precond::AbstractPreconditioner
     restart::Int
     verbose::Bool
-    timer::TimerOutput
 end
-RefGMRES(precond; restart=4, verbose=true) = RefGMRES(precond, restart, verbose, TIMER)
+RefGMRES(precond; restart=4, verbose=true) = RefGMRES(precond, restart, verbose)
 function ldiv!(solver::RefGMRES,
     y::AbstractVector, J::AbstractMatrix, x::AbstractVector,
 )
@@ -149,9 +144,8 @@ struct DQGMRES <: AbstractIterativeLinearSolver
     precond::AbstractPreconditioner
     memory::Int
     verbose::Bool
-    timer::TimerOutput
 end
-DQGMRES(precond; memory=4, verbose=false) = DQGMRES(precond, memory, verbose, TIMER)
+DQGMRES(precond; memory=4, verbose=false) = DQGMRES(precond, memory, verbose)
 function ldiv!(solver::DQGMRES,
     y::AbstractVector, J::AbstractMatrix, x::AbstractVector,
 )
@@ -163,9 +157,8 @@ end
 struct KrylovBICGSTAB <: AbstractIterativeLinearSolver
     precond::AbstractPreconditioner
     verbose::Bool
-    timer::TimerOutput
 end
-KrylovBICGSTAB(precond; verbose=false) = KrylovBICGSTAB(precond, verbose, TIMER)
+KrylovBICGSTAB(precond; verbose=false) = KrylovBICGSTAB(precond, verbose)
 function ldiv!(solver::KrylovBICGSTAB,
     y::AbstractVector, J::AbstractMatrix, x::AbstractVector,
 )

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -7,7 +7,6 @@ using ForwardDiff
 using KernelAbstractions
 using SparseArrays
 using TimerOutputs
-using SparsityDetection
 using SparseDiffTools
 using ..ExaPF: Spmat, xzeros
 

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -137,8 +137,6 @@ struct StateJacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
         _init_seed!(t1sseeds, coloring, ncolor, nmap)
 
         compressedJ = MT(zeros(Float64, ncolor, nmap))
-        nthreads=256
-        nblocks=ceil(Int64, nmap/nthreads)
         # Views
         varx = view(x, map)
         t1svarx = view(t1sx, map)
@@ -183,7 +181,6 @@ struct ControlJacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
         nv_a = size(v_a, 1)
         npbus = size(pinj, 1)
         nref = size(ref, 1)
-        # ncolor = size(unique(coloring),1)
         if F isa Array
             VI = Vector{Int}
             VT = Vector{Float64}
@@ -241,14 +238,11 @@ struct ControlJacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
         t1s{N} = ForwardDiff.Dual{Nothing,Float64, N} where N
         x = xzeros(VT, npbus + nv_a)
         t1sx = A{t1s{ncolor}}(x)
-        # t1sF = T{t1s{ncolor}}(undef, nmap)
         t1sF = A{t1s{ncolor}}(zeros(Float64, length(F)))
         t1sseeds = A{ForwardDiff.Partials{ncolor,Float64}}(undef, nmap)
         _init_seed!(t1sseeds, coloring, ncolor, nmap)
 
         compressedJ = MT(zeros(Float64, ncolor, length(F)))
-        nthreads=256
-        nblocks=ceil(Int64, nmap/nthreads)
         # Views
         varx = view(x, map)
         t1svarx = view(t1sx, map)
@@ -378,7 +372,7 @@ function getpartials_kernel!(compressedJ::Array{T, 2}, t1sF, nbus) where T
 end
 
 """
-    uncompress_kernel_gpu(J_nzVal, J_rowPtr, J_colVal, compressedJ, coloring, nmap)
+    uncompress_kernel_gpu!(J_nzVal, J_rowPtr, J_colVal, compressedJ, coloring, nmap)
 
 Uncompress the compressed Jacobian matrix from `compressedJ` to sparse CSR on
 the GPU. Only bitarguments are allowed for the kernel.

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -90,8 +90,8 @@ Return the bounds attached to the variable `var`.
 
     bounds(form::AbstractFormulation, func::Function)
 
-Return the lower and upper bounds attached to a given constraint
-functional.
+Return a tuple of vectors `(lb, ub)` specifying the admissible range
+of the constraints specified by the function `cons_func`.
 
 ## Examples
 
@@ -182,14 +182,6 @@ Get number of constraints specified by the function `cons_func`
 in the formulation `form`.
 """
 function size_constraint end
-
-"""
-    bounds(form::AbstractFormulation, cons_func::Function)
-
-Return a tuple of vectors `(lb, ub)` specifying the admissible range
-of the constraints specified by the function `cons_func`.
-"""
-function bounds end
 
 """
     state_constraints(form::AbstractFormulation, cons::AbstractVector, buffer::AbstractNetworkBuffer)

--- a/src/models/polar/kernels.jl
+++ b/src/models/polar/kernels.jl
@@ -1,11 +1,11 @@
 # Implement kernels for polar formulation
 
 """
-residualFunction
+power_balance
 
 Assembly residual function for N-R power flow
 """
-function residualFunction(V, Ybus, Sbus, pv, pq)
+function power_balance(V, Ybus, Sbus, pv, pq)
     # form mismatch vector
     mis = V .* conj(Ybus * V) - Sbus
     # form residual vector

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -305,7 +305,7 @@ function powerflow(
 
         # Find descent direction
         if isa(solver, LinearSolvers.AbstractIterativeLinearSolver)
-            LinearSolvers.update!(solver, J)
+            @timeit TIMER "Preconditioner" LinearSolvers.update!(solver, J)
         end
         @timeit TIMER "Linear Solver" n_iters = LinearSolvers.ldiv!(solver, dx, J, F)
         push!(linsol_iters, n_iters)

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -353,6 +353,7 @@ function powerflow(
     # Timer outputs display
     if verbose_level >= VERBOSE_LEVEL_MEDIUM
         show(TIMER)
+        reset_timer!(TIMER)
         println("")
     end
     conv = ConvergenceStatus(converged, iter, normF, sum(linsol_iters))

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -175,9 +175,11 @@ function power_balance!(polar::PolarForm, buffer::PolarNetworkState)
 
     F = buffer.balance
     fill!(F, 0.0)
-    residual_polar!(F, Vm, Va,
-                            polar.ybus_re, polar.ybus_im,
-                            pbus, qbus, pv, pq, nbus)
+    residual_polar!(
+        F, Vm, Va,
+        polar.ybus_re, polar.ybus_im,
+        pbus, qbus, pv, pq, nbus
+    )
 end
 
 # TODO: find better naming

--- a/test/iterative_solvers.jl
+++ b/test/iterative_solvers.jl
@@ -12,7 +12,6 @@ using Krylov
 const LS = ExaPF.LinearSolvers
 
 @testset "Iterative linear solvers with custom block Jacobi" begin
-    to = TimerOutputs.TimerOutput()
     # Square and preconditioned problems.
     function square_preconditioned(n :: Int=10)
         A   = ones(n, n) + (n-1) * Matrix(I, n, n)
@@ -25,7 +24,7 @@ const LS = ExaPF.LinearSolvers
     spA = sparse(A)
     nblocks = 2
     precond = LS.BlockJacobiPreconditioner(spA, nblocks, CPU())
-    LS.update(spA, precond, to)
+    LS.update(spA, precond)
     @testset "BICGSTAB" begin
         LS.ldiv!(LS.BICGSTAB(precond), x, spA, b)
         r = b - spA * x
@@ -45,7 +44,6 @@ end
 @testset "Wrapping of iterative solvers" begin
     nblocks = 2
     n, m = 32, 32
-    to = TimerOutputs.TimerOutput()
 
     # Add a diagonal term for conditionning
     A = randn(n, m) + 15I
@@ -75,7 +73,7 @@ end
         # First test the custom implementation of BICGSTAB
         @testset "BICGSTAB" begin
             # Need to update preconditioner before resolution
-            LS.update(As, precond, to)
+            LS.update(As, precond)
             fill!(x0, 0.0)
             n_iters = LS.ldiv!(LS.BICGSTAB(precond), x0, As, bs)
             @test n_iters <= m

--- a/test/polar_form.jl
+++ b/test/polar_form.jl
@@ -28,7 +28,7 @@ const PS = PowerSystem
     @testset "Initiate polar formulation on device $device" for (device, M) in ITERATORS
         polar = PolarForm(pf, device)
         # Test printing
-        println(polar)
+        println(devnull, polar)
 
         b = bounds(polar, State())
         b = bounds(polar, Control())

--- a/test/polar_form.jl
+++ b/test/polar_form.jl
@@ -3,7 +3,6 @@ using CUDA.CUSPARSE
 using Printf
 using FiniteDiff
 using ForwardDiff
-using BenchmarkTools
 using KernelAbstractions
 using LinearAlgebra
 using Random

--- a/test/powersystem.jl
+++ b/test/powersystem.jl
@@ -90,7 +90,7 @@ const PS = PowerSystem
     @testset "Computing residuals" begin
         F = zeros(Float64, npv + 2*npq)
         # First compute a reference value for resisual computed at V
-        F♯ = ExaPF.residualFunction(V, Ybus, Sbus, pv, pq)
+        F♯ = ExaPF.power_balance(V, Ybus, Sbus, pv, pq)
         # residual_polar! uses only binary types as this function is meant
         # to be deported on the GPU
         ExaPF.residual_polar!(F, Vm, Va,

--- a/test/reduced_evaluator.jl
+++ b/test/reduced_evaluator.jl
@@ -28,7 +28,7 @@
         constraints = Function[ExaPF.state_constraint, ExaPF.power_constraints]
         nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0, p; constraints=constraints)
         # Test printing
-        println(nlp)
+        println(devnull, nlp)
 
         # Test evaluator is well instantiated on target device
         TNLP = typeof(nlp)

--- a/test/reduced_gradient.jl
+++ b/test/reduced_gradient.jl
@@ -1,7 +1,6 @@
 using Printf
 using FiniteDiff
 using ForwardDiff
-using BenchmarkTools
 using KernelAbstractions
 using LinearAlgebra
 using Random


### PR DESCRIPTION
- clean-up `Project.toml` and adds compatible versions for all deps packages
- add default tolerance for `Krylov.bicgstab` 
- change default behavior for Newton-Krylov: when algorithm failed to converge, issues a warning instead of an error
- minor cleanings in the documentation & add documentation for `LinearSolvers.ldiv!` 
- remove `TimerOutputs` in submodule `LinearSolvers` (and only in this submodule)
