### PR TITLE
Refact parsers to be called externally

### DIFF
--- a/src/PowerSystem/PowerSystem.jl
+++ b/src/PowerSystem/PowerSystem.jl
@@ -229,6 +229,34 @@ v_min, v_max = bounds(pf, Buses(), VoltageMagnitude())
 """
 function bounds end
 
+# Utils
+function get_bus_id_to_indexes(bus)
+    BUS_I = IndexSet.idx_bus()[1]
+    nbus = size(bus, 1)
+
+    bus_id_to_indexes = Dict{Int,Int}()
+    for i in 1:nbus
+        busn = bus[i, BUS_I]
+        bus_id_to_indexes[busn] = i
+    end
+    return bus_id_to_indexes
+end
+
+function get_bus_generators(buses, gens, bus_id_to_indexes)
+    bus_gen = Dict{Int, Array{Int}}()
+    GEN_BUS = IndexSet.idx_gen()[1]
+    for g in 1:size(gens, 1)
+        bus_id = gens[g, GEN_BUS]
+        bus_index = bus_id_to_indexes[bus_id]
+        if haskey(bus_gen, bus_index)
+            push!(bus_gen[bus_index], g)
+        else
+            bus_gen[bus_index] = Int[g]
+        end
+    end
+    return bus_gen
+end
+
 include("topology.jl")
 include("power_network.jl")
 

--- a/src/PowerSystem/power_network.jl
+++ b/src/PowerSystem/power_network.jl
@@ -37,10 +37,10 @@ struct PowerNetwork <: AbstractPowerSystem
         if data_format == 0
             println("Reading PSSE format")
             data_raw = ParsePSSE.parse_raw(datafile)
-            data, bus_id_to_indexes = ParsePSSE.raw_to_exapf(data_raw)
+            data = ParsePSSE.raw_to_exapf(data_raw)
         elseif data_format == 1
             data_mat = ParseMAT.parse_mat(datafile)
-            data, bus_id_to_indexes = ParseMAT.mat_to_exapf(data_mat)
+            data = ParseMAT.mat_to_exapf(data_mat)
         end
         # Parsed data indexes
         BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, VA, BASE_KV, ZONE, VMAX, VMIN,
@@ -50,6 +50,8 @@ struct PowerNetwork <: AbstractPowerSystem
         bus = data["bus"]
         gen = data["gen"]
         SBASE = data["baseMVA"][1]
+
+        bus_id_to_indexes = get_bus_id_to_indexes(data["bus"])
 
         # size of the system
         nbus = size(bus, 1)
@@ -224,9 +226,9 @@ function get_costs_coefficients(pf::PowerNetwork)
 
         # polynomial coefficients
         # TODO: currently scale by baseMVA. Is it a good idea?
-        c0 = cost_data[i, COST][3]
-        c1 = cost_data[i, COST][2] * baseMVA
-        c2 = cost_data[i, COST][1] * baseMVA^2
+        c0 = cost_data[i, COST+2]
+        c1 = cost_data[i, COST+1] * baseMVA
+        c2 = cost_data[i, COST] * baseMVA^2
         coefficients[i, :] .= (bustype, c0, c1, c2)
     end
     return coefficients

--- a/src/PowerSystem/topology.jl
+++ b/src/PowerSystem/topology.jl
@@ -21,6 +21,10 @@ function makeYbus(data, bus_to_indexes)
     baseMVA = data["baseMVA"]
     bus     = data["bus"]
     branch  = data["branch"]
+    return makeYbus(bus, branch, baseMVA, bus_to_indexes)
+end
+
+function makeYbus(bus, branch, baseMVA, bus_to_indexes)
     F_BUS, T_BUS, BR_R, BR_X, BR_B, RATE_A, RATE_B, RATE_C, TAP, SHIFT, BR_STATUS,
     ANGMIN, ANGMAX, PF, QF, PT, QT, MU_SF, MU_ST, MU_ANGMIN, MU_ANGMAX = IndexSet.idx_branch()
     BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, VA, BASE_KV, ZONE, VMAX, VMIN,
@@ -74,7 +78,6 @@ function makeYbus(data, bus_to_indexes)
     Ybus = Cf' * Yf + Ct' * Yt + sparse(1:nb, 1:nb, Ysh, nb, nb)
 
     return Ybus
-
 end
 
 """

--- a/src/parsers/parse_mat.jl
+++ b/src/parsers/parse_mat.jl
@@ -40,15 +40,13 @@ function mat_to_exapf(data_mat)
     LAM_P, LAM_Q, MU_VMAX, MU_VMIN = IndexSet.idx_bus()
 
     nbus = length(data_mat["bus"])
-    bus_array = Array{Any}(undef, nbus, 17)
+    bus_array = zeros(nbus, 13)
 
     # Keep the correspondence between Matpower's ID and ExaPF
     # contiguous indexing.
-    bus_id_to_indexes = Dict{Int,Int}()
 
     for (i, bus) in enumerate(data_mat["bus"])
         busn = bus["bus_i"]
-        bus_id_to_indexes[busn] = i
         bus_array[i, BUS_I] = busn
         bus_array[i, BUS_TYPE] = bus["bus_type"]
         bus_array[i, PD] = bus["pd"]
@@ -71,7 +69,7 @@ function mat_to_exapf(data_mat)
     MU_QMIN = IndexSet.idx_gen()
 
     ngen = length(data_mat["gen"])
-    gen_array = Array{Any}(undef, ngen, 25)
+    gen_array = zeros(ngen, 16)
 
     for (i, gen) in enumerate(data_mat["gen"])
         gen_array[i, GEN_BUS] = gen["gen_bus"]
@@ -97,8 +95,7 @@ function mat_to_exapf(data_mat)
     ANGMIN, ANGMAX, PF, QF, PT, QT, MU_SF, MU_ST, MU_ANGMIN, MU_ANGMAX = IndexSet.idx_branch()
 
     nbranch = length(data_mat["branch"])
-    #branch_array = Array{Any}(undef, nbranch, 21)
-    branch_array = zeros(nbranch, 21)
+    branch_array = zeros(nbranch, 13)
 
     for (i, branch) in enumerate(data_mat["branch"])
         branch_array[i, F_BUS] = branch["f_bus"]
@@ -122,17 +119,19 @@ function mat_to_exapf(data_mat)
 
     MODEL, STARTUP, SHUTDOWN, NCOST, COST = IndexSet.idx_cost()
     ncost = length(data_mat["gencost"])
-    cost_array = Array{Any}(undef, ncost, 5)
+    cost_array = zeros(ncost, 7)
     for (i, cos) in enumerate(data_mat["gencost"])
         cost_array[i, MODEL] = cos["model"]
         cost_array[i, STARTUP] = cos["startup"]
         cost_array[i, SHUTDOWN] = cos["shutdown"]
         cost_array[i, NCOST] = cos["ncost"]
-        cost_array[i, COST] = cos["cost"]
+        cost_array[i, COST] = cos["cost"][1]
+        cost_array[i, COST+1] = cos["cost"][2]
+        cost_array[i, COST+2] = cos["cost"][3]
     end
     data["cost"] = cost_array
 
-    return data, bus_id_to_indexes
+    return data
 end
 
 ### Data and functions specific to Matpower format ###

--- a/src/parsers/parse_raw.jl
+++ b/src/parsers/parse_raw.jl
@@ -329,8 +329,6 @@ function raw_to_exapf(rawdata::Dict{String, Array})
     end
     data["branch"] = branch_array
 
-    # TODO:
-    bus_id_to_indexes = Dict{Int, Int}([(i, i) for i in 1:nbus])
-    return data, bus_id_to_indexes
+    return data
 end
 

--- a/test/powersystem.jl
+++ b/test/powersystem.jl
@@ -14,7 +14,7 @@ const PS = PowerSystem
     to = TimerOutputs.TimerOutput()
     datafile = joinpath(dirname(@__FILE__), "..", "data", local_case)
     data_raw = ParsePSSE.parse_raw(datafile)
-    data, bus_to_indexes = ParsePSSE.raw_to_exapf(data_raw)
+    data = ParsePSSE.raw_to_exapf(data_raw)
 
     # Parsed data indexes
     BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, VA, BASE_KV, ZONE, VMAX, VMIN,
@@ -24,6 +24,8 @@ const PS = PowerSystem
     bus = data["bus"]
     gen = data["gen"]
     SBASE = data["baseMVA"][1]
+
+    bus_to_indexes = PS.get_bus_id_to_indexes(bus)
     nbus = size(bus, 1)
 
     # obtain V0 from raw data


### PR DESCRIPTION
First steps of integration with ProxAL.jl: 
- fix parsing of matpower files to return always `Array{Float64, 2}` instead of `Array{Any, 2}` 
- move the routine `get_bus_id_to_indexes` apart, for factorization
- allow the parser to be called externally 
- allow to build the admittance matrix externally 