### PR TITLE
Integration with ProxAL

### DIFF
--- a/src/PowerSystem/PowerSystem.jl
+++ b/src/PowerSystem/PowerSystem.jl
@@ -190,6 +190,19 @@ Reactive power `Q` of the complex power `S = P + iQ`.
 """
 struct ReactivePower <: AbstractNetworkValues end
 
+"""
+    ActiveLoad <: AbstractNetworkValues
+
+Active load `Pd` at buses.
+"""
+struct ActiveLoad <: AbstractNetworkValues end
+
+"""
+    ReactiveLoad <: AbstractNetworkValues
+
+Reactive load `Qd` at buses.
+"""
+struct ReactiveLoad <: AbstractNetworkValues end
 
 # Templating
 """

--- a/src/PowerSystem/PowerSystem.jl
+++ b/src/PowerSystem/PowerSystem.jl
@@ -4,7 +4,7 @@ using Printf
 using SparseArrays
 using ..ExaPF: ParsePSSE, ParseMAT, IndexSet, Spmat
 
-import Base: show
+import Base: show, get
 
 const PQ_BUS_TYPE = 1
 const PV_BUS_TYPE = 2
@@ -256,6 +256,29 @@ function get_bus_generators(buses, gens, bus_id_to_indexes)
     end
     return bus_gen
 end
+
+function get_active_branches(lines, remove_lines)
+    if isempty(remove_lines)
+        return lines
+    else
+        lines = lines[1:end .!= remove_lines, :]
+        return lines
+    end
+end
+
+function import_dataset(datafile::String)
+    if endswith(datafile, ".raw")
+        data_raw = ParsePSSE.parse_raw(datafile)
+        return ParsePSSE.raw_to_exapf(data_raw)
+    elseif endswith(datafile, ".m")
+        data_mat = ParseMAT.parse_mat(datafile)
+        return ParseMAT.mat_to_exapf(data_mat)
+    else
+        error("Unsupported format in file $(datafile): supported extensions are " *
+              "Matpower (.m) or PSSE (.raw)")
+    end
+end
+
 
 include("topology.jl")
 include("power_network.jl")

--- a/src/PowerSystem/PowerSystem.jl
+++ b/src/PowerSystem/PowerSystem.jl
@@ -229,6 +229,34 @@ v_min, v_max = bounds(pf, Buses(), VoltageMagnitude())
 """
 function bounds end
 
+# Utils
+function get_bus_id_to_indexes(bus)
+    BUS_I = IndexSet.idx_bus()[1]
+    nbus = size(bus, 1)
+
+    bus_id_to_indexes = Dict{Int,Int}()
+    for i in 1:nbus
+        busn = bus[i, BUS_I]
+        bus_id_to_indexes[busn] = i
+    end
+    return bus_id_to_indexes
+end
+
+function get_bus_generators(buses, gens, bus_id_to_indexes)
+    bus_gen = Dict{Int, Array{Int}}()
+    GEN_BUS = IndexSet.idx_gen()[1]
+    for g in 1:size(gens, 1)
+        bus_id = gens[g, GEN_BUS]
+        bus_index = bus_id_to_indexes[bus_id]
+        if haskey(bus_gen, bus_index)
+            push!(bus_gen[bus_index], g)
+        else
+            bus_gen[bus_index] = Int[g]
+        end
+    end
+    return bus_gen
+end
+
 include("topology.jl")
 include("power_network.jl")
 

--- a/src/PowerSystem/power_network.jl
+++ b/src/PowerSystem/power_network.jl
@@ -37,10 +37,10 @@ struct PowerNetwork <: AbstractPowerSystem
         if data_format == 0
             println("Reading PSSE format")
             data_raw = ParsePSSE.parse_raw(datafile)
-            data, bus_id_to_indexes = ParsePSSE.raw_to_exapf(data_raw)
+            data = ParsePSSE.raw_to_exapf(data_raw)
         elseif data_format == 1
             data_mat = ParseMAT.parse_mat(datafile)
-            data, bus_id_to_indexes = ParseMAT.mat_to_exapf(data_mat)
+            data = ParseMAT.mat_to_exapf(data_mat)
         end
         # Parsed data indexes
         BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, VA, BASE_KV, ZONE, VMAX, VMIN,
@@ -50,6 +50,8 @@ struct PowerNetwork <: AbstractPowerSystem
         bus = data["bus"]
         gen = data["gen"]
         SBASE = data["baseMVA"][1]
+
+        bus_id_to_indexes = get_bus_id_to_indexes(data["bus"])
 
         # size of the system
         nbus = size(bus, 1)
@@ -223,9 +225,9 @@ function get_costs_coefficients(pf::PowerNetwork)
 
         # polynomial coefficients
         # TODO: currently scale by baseMVA. Is it a good idea?
-        c0 = cost_data[i, COST][3]
-        c1 = cost_data[i, COST][2] * baseMVA
-        c2 = cost_data[i, COST][1] * baseMVA^2
+        c0 = cost_data[i, COST+2]
+        c1 = cost_data[i, COST+1] * baseMVA
+        c2 = cost_data[i, COST] * baseMVA^2
         coefficients[i, :] .= (bustype, c0, c1, c2)
     end
     return coefficients

--- a/src/PowerSystem/power_network.jl
+++ b/src/PowerSystem/power_network.jl
@@ -91,6 +91,10 @@ get(pf::PowerNetwork, ::NumberOfPVBuses) = length(pf.pv)
 get(pf::PowerNetwork, ::NumberOfPQBuses) = length(pf.pq)
 get(pf::PowerNetwork, ::NumberOfSlackBuses) = length(pf.ref)
 
+## Loads
+get(pf::PowerNetwork, ::ActiveLoad) = real.(pf.sload)
+get(pf::PowerNetwork, ::ReactiveLoad) = imag.(pf.sload)
+
 ## Indexing
 function get(pf::PowerNetwork, ::GeneratorIndexes)
     GEN_BUS = IndexSet.idx_gen()[1]

--- a/src/PowerSystem/topology.jl
+++ b/src/PowerSystem/topology.jl
@@ -21,6 +21,10 @@ function makeYbus(data, bus_to_indexes)
     baseMVA = data["baseMVA"]
     bus     = data["bus"]
     branch  = data["branch"]
+    return makeYbus(bus, branch, baseMVA, bus_to_indexes)
+end
+
+function makeYbus(bus, branch, baseMVA, bus_to_indexes)
     F_BUS, T_BUS, BR_R, BR_X, BR_B, RATE_A, RATE_B, RATE_C, TAP, SHIFT, BR_STATUS,
     ANGMIN, ANGMAX, PF, QF, PT, QT, MU_SF, MU_ST, MU_ANGMIN, MU_ANGMAX = IndexSet.idx_branch()
     BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, VA, BASE_KV, ZONE, VMAX, VMIN,
@@ -74,7 +78,6 @@ function makeYbus(data, bus_to_indexes)
     Ybus = Cf' * Yf + Ct' * Yt + sparse(1:nb, 1:nb, Ysh, nb, nb)
 
     return Ybus
-
 end
 
 """

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -88,6 +88,21 @@ get(form, NumberOfControl())
 function get end
 
 """
+    setvalues!(form::AbstractFormulation, attr::PS.AbstractNetworkAttribute, values)
+
+Update inplace the attribute's values specified by `attr`.
+
+## Examples
+
+```julia
+setvalues!(form, ActiveLoad(), new_ploads)
+setvalues!(form, ReactiveLoad(), new_qloads)
+
+```
+"""
+function setvalues! end
+
+"""
     bounds(form::AbstractFormulation, var::AbstractVariable)
 
 Return the bounds attached to the variable `var`.

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -120,6 +120,7 @@ function PolarForm(pf::PS.PowerNetwork, device; nocost=false)
     )
 end
 
+# Getters
 function get(polar::PolarForm, ::NumberOfState)
     npv = PS.get(polar.network, PS.NumberOfPVBuses())
     npq = PS.get(polar.network, PS.NumberOfPQBuses())
@@ -131,6 +132,17 @@ function get(polar::PolarForm, ::NumberOfControl)
     return nref + 2*npv
 end
 
+# Setters
+function setvalues!(polar::PolarForm, ::PS.ActiveLoad, values)
+    @assert length(polar.active_load) == length(values)
+    copyto!(polar.active_load, values)
+end
+function setvalues!(polar::PolarForm, ::PS.ReactiveLoad, values)
+    @assert length(polar.reactive_load) == length(values)
+    copyto!(polar.reactive_load, values)
+end
+
+## Bounds
 function bounds(polar::PolarForm{T, IT, VT, AT}, ::State) where {T, IT, VT, AT}
     return polar.x_min, polar.x_max
 end

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -48,8 +48,8 @@ function PolarForm(pf::PS.PowerNetwork, device; nocost=false)
     # Get coefficients penalizing the generation of the generators
     coefs = convert(AT{Float64, 2}, PS.get_costs_coefficients(pf))
     # Move load to the target device
-    pload = convert(VT, real.(pf.sload))
-    qload = convert(VT, imag.(pf.sload))
+    pload = convert(VT, PS.get(pf, PS.ActiveLoad()))
+    qload = convert(VT, PS.get(pf, PS.ReactiveLoad()))
 
     # Move the indexing to the target device
     idx_gen = PS.get(pf, PS.GeneratorIndexes())

--- a/src/parsers/parse_mat.jl
+++ b/src/parsers/parse_mat.jl
@@ -40,15 +40,13 @@ function mat_to_exapf(data_mat)
     LAM_P, LAM_Q, MU_VMAX, MU_VMIN = IndexSet.idx_bus()
 
     nbus = length(data_mat["bus"])
-    bus_array = Array{Any}(undef, nbus, 17)
+    bus_array = zeros(nbus, 13)
 
     # Keep the correspondence between Matpower's ID and ExaPF
     # contiguous indexing.
-    bus_id_to_indexes = Dict{Int,Int}()
 
     for (i, bus) in enumerate(data_mat["bus"])
         busn = bus["bus_i"]
-        bus_id_to_indexes[busn] = i
         bus_array[i, BUS_I] = busn
         bus_array[i, BUS_TYPE] = bus["bus_type"]
         bus_array[i, PD] = bus["pd"]
@@ -71,7 +69,7 @@ function mat_to_exapf(data_mat)
     MU_QMIN = IndexSet.idx_gen()
 
     ngen = length(data_mat["gen"])
-    gen_array = Array{Any}(undef, ngen, 25)
+    gen_array = zeros(ngen, 16)
 
     for (i, gen) in enumerate(data_mat["gen"])
         gen_array[i, GEN_BUS] = gen["gen_bus"]
@@ -97,8 +95,7 @@ function mat_to_exapf(data_mat)
     ANGMIN, ANGMAX, PF, QF, PT, QT, MU_SF, MU_ST, MU_ANGMIN, MU_ANGMAX = IndexSet.idx_branch()
 
     nbranch = length(data_mat["branch"])
-    #branch_array = Array{Any}(undef, nbranch, 21)
-    branch_array = zeros(nbranch, 21)
+    branch_array = zeros(nbranch, 13)
 
     for (i, branch) in enumerate(data_mat["branch"])
         branch_array[i, F_BUS] = branch["f_bus"]
@@ -122,17 +119,19 @@ function mat_to_exapf(data_mat)
 
     MODEL, STARTUP, SHUTDOWN, NCOST, COST = IndexSet.idx_cost()
     ncost = length(data_mat["gencost"])
-    cost_array = Array{Any}(undef, ncost, 5)
+    cost_array = zeros(ncost, 7)
     for (i, cos) in enumerate(data_mat["gencost"])
         cost_array[i, MODEL] = cos["model"]
         cost_array[i, STARTUP] = cos["startup"]
         cost_array[i, SHUTDOWN] = cos["shutdown"]
         cost_array[i, NCOST] = cos["ncost"]
-        cost_array[i, COST] = cos["cost"]
+        cost_array[i, COST] = cos["cost"][1]
+        cost_array[i, COST+1] = cos["cost"][2]
+        cost_array[i, COST+2] = cos["cost"][3]
     end
     data["cost"] = cost_array
 
-    return data, bus_id_to_indexes
+    return data
 end
 
 ### Data and functions specific to Matpower format ###

--- a/src/parsers/parse_raw.jl
+++ b/src/parsers/parse_raw.jl
@@ -329,8 +329,6 @@ function raw_to_exapf(rawdata::Dict{String, Array})
     end
     data["branch"] = branch_array
 
-    # TODO:
-    bus_id_to_indexes = Dict{Int, Int}([(i, i) for i in 1:nbus])
-    return data, bus_id_to_indexes
+    return data
 end
 

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -7,7 +7,7 @@ import ExaPF: ParseMAT, PowerSystem, IndexSet
 
 @testset "Power flow 9 bus case" begin
     datafile = joinpath(dirname(@__FILE__), "..", "data", "case9.m")
-    pf = PowerSystem.PowerNetwork(datafile, 1)
+    pf = PowerSystem.PowerNetwork(datafile)
 
     # test impedance matrix entries
     @test isapprox(real(pf.Ybus[1, 1]), 0.0)
@@ -44,7 +44,7 @@ end
 
 @testset "Power flow 14 bus case" begin
     datafile = joinpath(dirname(@__FILE__), "..", "data", "case14.m")
-    pf = PowerSystem.PowerNetwork(datafile, 1)
+    pf = PowerSystem.PowerNetwork(datafile)
     polar = PolarForm(pf, CPU())
     x = ExaPF.initial(polar, State())
     u = ExaPF.initial(polar, Control())
@@ -67,7 +67,7 @@ end
 
 @testset "Power flow 30 bus case" begin
     datafile = joinpath(dirname(@__FILE__), "..", "data", "case30.m")
-    pf = PowerSystem.PowerNetwork(datafile, 1)
+    pf = PowerSystem.PowerNetwork(datafile)
 
     # retrieve initial state of network
     polar = PolarForm(pf, CPU())
@@ -91,7 +91,7 @@ end
 
 @testset "Power flow 300 bus case" begin
     datafile = joinpath(dirname(@__FILE__), "..", "data", "case300.m")
-    pf = PowerSystem.PowerNetwork(datafile, 1)
+    pf = PowerSystem.PowerNetwork(datafile)
 
     polar = PolarForm(pf, CPU())
     x = ExaPF.initial(polar, State())

--- a/test/polar_form.jl
+++ b/test/polar_form.jl
@@ -17,7 +17,7 @@ const PS = PowerSystem
 @testset "Polar formulation" begin
     datafile = joinpath(dirname(@__FILE__), "..", "data", "case9.m")
     tolerance = 1e-8
-    pf = PS.PowerNetwork(datafile, 1)
+    pf = PS.PowerNetwork(datafile)
 
     if has_cuda_gpu()
         ITERATORS = zip([CPU(), CUDADevice()], [Array, CuArray])

--- a/test/powersystem.jl
+++ b/test/powersystem.jl
@@ -14,7 +14,7 @@ const PS = PowerSystem
     to = TimerOutputs.TimerOutput()
     datafile = joinpath(dirname(@__FILE__), "..", "data", local_case)
     data_raw = ParsePSSE.parse_raw(datafile)
-    data, bus_to_indexes = ParsePSSE.raw_to_exapf(data_raw)
+    data = ParsePSSE.raw_to_exapf(data_raw)
 
     # Parsed data indexes
     BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, VA, BASE_KV, ZONE, VMAX, VMIN,
@@ -24,6 +24,8 @@ const PS = PowerSystem
     bus = data["bus"]
     gen = data["gen"]
     SBASE = data["baseMVA"][1]
+
+    bus_to_indexes = PS.get_bus_id_to_indexes(bus)
     nbus = size(bus, 1)
 
     # obtain V0 from raw data

--- a/test/reduced_evaluator.jl
+++ b/test/reduced_evaluator.jl
@@ -18,7 +18,7 @@
         @test nlp.ε_tol == tol
     end
 
-    pf = PowerSystem.PowerNetwork(datafile, 1)
+    pf = PowerSystem.PowerNetwork(datafile)
     @testset "Test API on $device" for (device, M) in ITERATORS
         polar = PolarForm(pf, device)
         x0 = ExaPF.initial(polar, State())

--- a/test/reduced_gradient.jl
+++ b/test/reduced_gradient.jl
@@ -16,7 +16,7 @@ const PS = PowerSystem
     @testset "Case $case" for case in ["case9.m", "case30.m"]
         datafile = joinpath(dirname(@__FILE__), "..", "data", case)
         tolerance = 1e-8
-        pf = PS.PowerNetwork(datafile, 1)
+        pf = PS.PowerNetwork(datafile)
 
         polar = PolarForm(pf, CPU())
         cache = ExaPF.get(polar, ExaPF.PhysicalState())


### PR DESCRIPTION
This PR is a draft to follow the integration with ProxAL. 
Currently, this PR implements: 
- generic parsing functions allowing the parser to be called externally (https://github.com/exanauts/ProxAL.jl/pull/5)
- refactoring of the `PowerNetwork` constructor to read as input either a file or directly a dataset
- implement a new argument in the constructor of `PowerNetwork` to remove lines when loading the model (https://github.com/exanauts/ExaPF.jl/issues/64)