### PR TITLE
Refactoring AutoDiff

### DIFF
--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -85,7 +85,7 @@ function gradient!(ag::AugLagEvaluator, grad, u)
     # Import buffer (has been updated previously in update!)
     buffer = base_nlp.buffer
     # Import AutoDiff objects
-    ∇gᵤ = jacobian(model, base_nlp.autodiff.Jgᵤ, buffer)
+    ∇gᵤ = jacobian(model, base_nlp.autodiff.Jgᵤ, buffer, AutoDiff.ControlJacobian())
     ∂obj = base_nlp.autodiff.∇f
     jvx = ∂obj.jvₓ ; fill!(jvx, 0)
     jvu = ∂obj.jvᵤ ; fill!(jvu, 0)

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -4,7 +4,7 @@ abstract type AbstractAutoDiffFactory end
 
 struct AutoDiffFactory <: AbstractAutoDiffFactory
     Jgₓ::AutoDiff.Jacobian
-    Jgᵤ::AutoDiff.ControlJacobian
+    Jgᵤ::AutoDiff.Jacobian
     ∇f::AdjointStackObjective
 end
 

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -3,7 +3,7 @@
 abstract type AbstractAutoDiffFactory end
 
 struct AutoDiffFactory <: AbstractAutoDiffFactory
-    Jgₓ::AutoDiff.StateJacobian
+    Jgₓ::AutoDiff.Jacobian
     Jgᵤ::AutoDiff.ControlJacobian
     ∇f::AdjointStackObjective
 end

--- a/src/Evaluators/penalty.jl
+++ b/src/Evaluators/penalty.jl
@@ -75,7 +75,7 @@ function gradient!(pen::PenaltyEvaluator, grad, u)
     # Import buffer (has been updated previously in update!)
     buffer = base_nlp.buffer
     # Import AutoDiff objects
-    ∇gᵤ = jacobian(model, base_nlp.autodiff.Jgᵤ, buffer)
+    ∇gᵤ = jacobian(model, base_nlp.autodiff.Jgᵤ, buffer, AutoDiff.ControlJacobian())
     ∂obj = base_nlp.autodiff.∇f
     jvx = ∂obj.jvₓ ; fill!(jvx, 0)
     jvu = ∂obj.jvᵤ ; fill!(jvu, 0)

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -139,7 +139,7 @@ function gradient!(nlp::ReducedSpaceEvaluator, g, u)
     xₖ = nlp.x
     ∇gₓ = nlp.autodiff.Jgₓ.J
     # Evaluate Jacobian of power flow equation on current u
-    ∇gᵤ = jacobian(nlp.model, nlp.autodiff.Jgᵤ, buffer)
+    ∇gᵤ = jacobian(nlp.model, nlp.autodiff.Jgᵤ, buffer, AutoDiff.ControlJacobian())
     # Evaluate adjoint of cost function and update inplace AdjointStackObjective
     ∂cost(nlp.model, nlp.autodiff.∇f, buffer)
 

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -54,7 +54,8 @@ Creates an object for the Jacobian
 * `varx::SubT`: View of `map` on `x`
 * `t1svarx::SubD`: Active (AD) view of `map` on `x`
 """
-struct Jacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
+# struct Jacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
+struct Jacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} 
     J::SMT
     compressedJ::MT
     coloring::VI
@@ -66,9 +67,11 @@ struct Jacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
     # Cache views on x and its dual vector to avoid reallocating on the GPU
     varx::SubT
     t1svarx::SubD
-    function Jacobian(structure, F, v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus)
-        nv_m = size(v_m, 1)
-        nv_a = size(v_a, 1)
+    function Jacobian(structure, F, v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus, type)
+        nv_m = length(v_m)
+        nv_a = length(v_a)
+        npbus = length(pinj)
+        nref = length(ref)
         if F isa Array
             VI = Vector{Int}
             VT = Vector{Float64}
@@ -85,14 +88,8 @@ struct Jacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
             error("Wrong array type ", typeof(F))
         end
 
-        mappv = [i + nv_m for i in pv]
-        mappq = [i + nv_m for i in pq]
-        # Ordering for x is (θ_pv, θ_pq, v_pq)
         map = VI(structure.map)
-        nmap = size(map,1)
-
-        # Used for sparsity detection with randomized inputs
-
+        nmap = length(structure.map)
         # Need a host arrays for the sparsity detection below
         spmap = Vector(map)
         hybus_re = Spmat{Vector{Int}, Vector{Float64}}(ybus_re)
@@ -105,24 +102,34 @@ struct Jacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
         Vre = Float64.([i for i in 1:n])
         Vim = Float64.([i for i in n+1:2*n])
         V = Vre .+ 1im .* Vim
-        J = structure.sparsity(V, Y, pv, pq)
+        J = structure.sparsity(V, Y, ref, pv, pq)
         coloring = VI(matrix_colors(J))
         ncolor = size(unique(coloring),1)
         if F isa CuArray
             J = CuSparseMatrixCSR(J)
         end
         t1s{N} = ForwardDiff.Dual{Nothing,Float64, N} where N
-        x = VT(zeros(Float64, nv_m + nv_a))
-        t1sx = A{t1s{ncolor}}(x)
-        t1sF = A{t1s{ncolor}}(zeros(Float64, nmap))
+        if isa(type, StateJacobian) 
+            x = VT(zeros(Float64, nv_m + nv_a))
+            t1sx = A{t1s{ncolor}}(x)
+            t1sF = A{t1s{ncolor}}(zeros(Float64, nmap))
+            t1sseeds = A{ForwardDiff.Partials{ncolor,Float64}}(undef, nmap)
+            _init_seed!(t1sseeds, coloring, ncolor, nmap)
+            compressedJ = MT(zeros(Float64, ncolor, nmap))
+            varx = view(x, map)
+            t1svarx = view(t1sx, map)
+        end
+        if isa(type, ControlJacobian) 
+            x = VT(zeros(Float64, npbus + nv_a))
+            t1sx = A{t1s{ncolor}}(x)
+            t1sF = A{t1s{ncolor}}(zeros(Float64, length(F)))
+            t1sseeds = A{ForwardDiff.Partials{ncolor,Float64}}(undef, nmap)
+            _init_seed!(t1sseeds, coloring, ncolor, nmap)
+            compressedJ = MT(zeros(Float64, ncolor, length(F)))
+            varx = view(x, map)
+            t1svarx = view(t1sx, map)
+        end
 
-        t1sseeds = A{ForwardDiff.Partials{ncolor,Float64}}(undef, nmap)
-        _init_seed!(t1sseeds, coloring, ncolor, nmap)
-
-        compressedJ = MT(zeros(Float64, ncolor, nmap))
-        # Views
-        varx = view(x, map)
-        t1svarx = view(t1sx, map)
         VP = typeof(t1sseeds)
         VD = typeof(t1sx)
         return new{VI, VT, MT, SMT, VP, VD, typeof(varx), typeof(t1svarx)}(
@@ -131,221 +138,8 @@ struct Jacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
     end
 end
 
-"""
-    StateJacobian
-
-Creates an object for the state Jacobian
-
-* `J::SMT`: Sparse uncompressed Jacobian to be used by linear solver. This is either of type `SparseMatrixCSC` or `CuSparseMatrixCSR`.
-* `compressedJ::MT`: Dense compressed Jacobian used for updating values through AD either of type `Matrix` or `CuMatrix`.
-* `coloring::VI`: Row coloring of the Jacobian.
-* `t1sseeds::VP`: The seeding vector for AD built based on the coloring.
-* `t1sF::VD`: Output array of active (AD) type.
-* `x::VT`: Input array of passive type. This includes both state and control.
-* `t1sx::VD`: Input array of active type.
-* `map::VI`: State and control mapping to array `x`
-* `varx::SubT`: View of `map` on `x`
-* `t1svarx::SubD`: Active (AD) view of `map` on `x`
-"""
-struct StateJacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
-    J::SMT
-    compressedJ::MT
-    coloring::VI
-    t1sseeds::VP
-    t1sF::VD
-    x::VT
-    t1sx::VD
-    map::VI
-    # Cache views on x and its dual vector to avoid reallocating on the GPU
-    varx::SubT
-    t1svarx::SubD
-    function StateJacobian(F, v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus)
-        nv_m = size(v_m, 1)
-        nv_a = size(v_a, 1)
-        if F isa Array
-            VI = Vector{Int}
-            VT = Vector{Float64}
-            MT = Matrix{Float64}
-            SMT = SparseMatrixCSC
-            A = Vector
-        elseif F isa CuArray
-            VI = CuVector{Int}
-            VT = CuVector{Float64}
-            MT = CuMatrix{Float64}
-            SMT = CuSparseMatrixCSR
-            A = CuVector
-        else
-            error("Wrong array type ", typeof(F))
-        end
-
-        mappv = [i + nv_m for i in pv]
-        mappq = [i + nv_m for i in pq]
-        # Ordering for x is (θ_pv, θ_pq, v_pq)
-        map = VI(vcat(mappv, mappq, pq))
-        nmap = size(map,1)
-
-        # Used for sparsity detection with randomized inputs
-        function residual_jacobian(V, Ybus, pv, pq)
-            n = size(V, 1)
-            Ibus = Ybus*V
-            diagV       = sparse(1:n, 1:n, V, n, n)
-            diagIbus    = sparse(1:n, 1:n, Ibus, n, n)
-            diagVnorm   = sparse(1:n, 1:n, V./abs.(V), n, n)
-
-            dSbus_dVm = diagV * conj(Ybus * diagVnorm) + conj(diagIbus) * diagVnorm
-            dSbus_dVa = 1im * diagV * conj(diagIbus - Ybus * diagV)
-
-            j11 = real(dSbus_dVa[[pv; pq], [pv; pq]])
-            j12 = real(dSbus_dVm[[pv; pq], pq])
-            j21 = imag(dSbus_dVa[pq, [pv; pq]])
-            j22 = imag(dSbus_dVm[pq, pq])
-
-            J = [j11 j12; j21 j22]
-        end
-
-        # Need a host arrays for the sparsity detection below
-        spmap = Vector(map)
-        hybus_re = Spmat{Vector{Int}, Vector{Float64}}(ybus_re)
-        hybus_im = Spmat{Vector{Int}, Vector{Float64}}(ybus_im)
-        n = nv_a
-        Yre = SparseMatrixCSC{Float64,Int64}(n, n, hybus_re.colptr, hybus_re.rowval, hybus_re.nzval)
-        Yim = SparseMatrixCSC{Float64,Int64}(n, n, hybus_im.colptr, hybus_im.rowval, hybus_im.nzval)
-        Y = Yre .+ 1im .* Yim
-        # Randomized inputs
-        Vre = Float64.([i for i in 1:n])
-        Vim = Float64.([i for i in n+1:2*n])
-        V = Vre .+ 1im .* Vim
-        J = residual_jacobian(V, Y, pv, pq)
-        coloring = VI(matrix_colors(J))
-        ncolor = size(unique(coloring),1)
-        if F isa CuArray
-            J = CuSparseMatrixCSR(J)
-        end
-        t1s{N} = ForwardDiff.Dual{Nothing,Float64, N} where N
-        x = VT(zeros(Float64, nv_m + nv_a))
-        t1sx = A{t1s{ncolor}}(x)
-        t1sF = A{t1s{ncolor}}(zeros(Float64, nmap))
-
-        t1sseeds = A{ForwardDiff.Partials{ncolor,Float64}}(undef, nmap)
-        _init_seed!(t1sseeds, coloring, ncolor, nmap)
-
-        compressedJ = MT(zeros(Float64, ncolor, nmap))
-        # Views
-        varx = view(x, map)
-        t1svarx = view(t1sx, map)
-        VP = typeof(t1sseeds)
-        VD = typeof(t1sx)
-        return new{VI, VT, MT, SMT, VP, VD, typeof(varx), typeof(t1svarx)}(
-            J, compressedJ, coloring, t1sseeds, t1sF, x, t1sx, map, varx, t1svarx
-        )
-    end
-end
-
-"""
-    ControlJacobian
-
-Creates an object for the control Jacobian.
-
-* `J::SMT`: Sparse uncompressed Jacobian to be used by linear solver. This is either of type `SparseMatrixCSC` or `CuSparseMatrixCSR`.
-* `compressedJ::MT`: Dense compressed Jacobian used for updating values through AD either of type `Matrix` or `CuMatrix`.
-* `coloring::VI`: Row coloring of the Jacobian.
-* `t1sseeds::VP`: The seeding vector for AD built based on the coloring.
-* `t1sF::VD`: Output array of active (AD) type.
-* `x::VT`: Input array of passive type. This includes both state and control.
-* `t1sx::VD`: Input array of active type.
-* `map::VI`: State and control mapping to array `x`
-* `varx::SubT`: View of `map` on `x`
-* `t1svarx::SubD`: Active (AD) view of `map` on `x`
-"""
-struct ControlJacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
-    J::SMT
-    compressedJ::MT
-    coloring::VI
-    t1sseeds::VP
-    t1sF::VD
-    x::VT
-    t1sx::VD
-    map::VI
-    # Cache views on x and its dual vector to avoid reallocating on the GPU
-    varx::SubT
-    t1svarx::SubD
-    function ControlJacobian(F, v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus)
-        nv_m = size(v_m, 1)
-        nv_a = size(v_a, 1)
-        npbus = size(pinj, 1)
-        nref = size(ref, 1)
-        if F isa Array
-            VI = Vector{Int}
-            VT = Vector{Float64}
-            MT = Matrix{Float64}
-            SMT = SparseMatrixCSC
-            A = Vector
-        elseif F isa CuArray
-            VI = CuVector{Int}
-            VT = CuVector{Float64}
-            MT = CuMatrix{Float64}
-            SMT = CuSparseMatrixCSR
-            A = CuVector
-        else
-            error("Wrong array type ", typeof(F))
-        end
-
-        mappv =  [i + nv_a for i in pv]
-        map = VI(vcat(ref, mappv, pv))
-        nmap = size(map,1)
-
-        # Used for sparsity detection with randomized inputs
-        function residual_jacobian(V, Ybus, pinj, qinj, ref, pv, pq)
-            n = size(V, 1)
-            Ibus = Ybus*V
-            diagV       = sparse(1:n, 1:n, V, n, n)
-            diagIbus    = sparse(1:n, 1:n, Ibus, n, n)
-            diagVnorm   = sparse(1:n, 1:n, V./abs.(V), n, n)
-
-            dSbus_dVm = diagV * conj(Ybus * diagVnorm) + conj(diagIbus) * diagVnorm
-            dSbus_dpbus = diagV * conj(Ybus * diagVnorm) + conj(diagIbus) * diagVnorm
-
-            j11 = real(dSbus_dVm[[pv; pq], [ref; pv; pv]])
-            j21 = imag(dSbus_dVm[pq, [ref; pv; pv]])
-            J = [j11; j21]
-        end
-
-        # Need a host arrays for the sparsity detection below
-        spmap = Vector(map)
-        hybus_re = Spmat{Vector{Int}, Vector{Float64}}(ybus_re)
-        hybus_im = Spmat{Vector{Int}, Vector{Float64}}(ybus_im)
-        n = nv_a
-        Yre = SparseMatrixCSC{Float64,Int64}(n, n, hybus_re.colptr, hybus_re.rowval, hybus_re.nzval)
-        Yim = SparseMatrixCSC{Float64,Int64}(n, n, hybus_im.colptr, hybus_im.rowval, hybus_im.nzval)
-        Y = Yre .+ 1im .* Yim
-        # Randomized inputs
-        Vre = Float64.([i for i in 1:n])
-        Vim = Float64.([i for i in n+1:2*n])
-        V = Vre .+ 1im .* Vim
-        J = residual_jacobian(V, Y, pinj, qinj, ref, pv, pq)
-        coloring = VI(matrix_colors(J))
-        ncolor = size(unique(coloring),1)
-        if F isa CuArray
-            J = CuSparseMatrixCSR(J)
-        end
-        t1s{N} = ForwardDiff.Dual{Nothing,Float64, N} where N
-        x = xzeros(VT, npbus + nv_a)
-        t1sx = A{t1s{ncolor}}(x)
-        t1sF = A{t1s{ncolor}}(zeros(Float64, length(F)))
-        t1sseeds = A{ForwardDiff.Partials{ncolor,Float64}}(undef, nmap)
-        _init_seed!(t1sseeds, coloring, ncolor, nmap)
-
-        compressedJ = MT(zeros(Float64, ncolor, length(F)))
-        # Views
-        varx = view(x, map)
-        t1svarx = view(t1sx, map)
-        VP = typeof(t1sseeds)
-        VD = typeof(t1sx)
-        return new{VI, VT, MT, SMT, VP, VD, typeof(varx), typeof(t1svarx)}(
-            J, compressedJ, coloring, t1sseeds, t1sF, x, t1sx, map, varx, t1svarx
-        )
-    end
-end
+struct StateJacobian <: AbstractJacobian end
+struct ControlJacobian <: AbstractJacobian end
 
 """
     seed_kernel_cpu!
@@ -536,155 +330,52 @@ Update the sparse Jacobian entries using AutoDiff. No allocations are taking pla
 """
 function residual_jacobian!(arrays::Jacobian,
                              residual_polar!,
-                             range1, range2,
                              v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus,
-                             timer = nothing)
-    @timeit timer "Before" begin
-        @timeit timer "Setup" begin
-            nv_m = size(v_m, 1)
-            nv_a = size(v_a, 1)
-            nmap = size(arrays.map, 1)
-            n = nv_m + nv_a
-        end
-        @timeit timer "Arrays" begin
-            arrays.x[range1] .= v_m
-            arrays.x[range2] .= v_a
-            arrays.t1sx .= arrays.x
-            arrays.t1sF .= 0.0
-        end
-    end
-    @timeit timer "Seeding" begin
-        seed_kernel!(arrays.t1sseeds, arrays.varx, arrays.t1svarx, nbus)
+                             type::AbstractJacobian)
+    nvbus = length(v_m)
+    ninj = length(pinj)
+    if isa(type, StateJacobian) 
+        arrays.x[1:nvbus] .= v_m
+        arrays.x[nvbus+1:2*nvbus] .= v_a
+        arrays.t1sx .= arrays.x
+        arrays.t1sF .= 0.0
+    elseif isa(type, ControlJacobian)
+        arrays.x[1:nvbus] .= v_m
+        arrays.x[nvbus+1:nvbus+ninj] .= pinj
+        arrays.t1sx .= arrays.x
+        arrays.t1sF .= 0.0
+    else
+        error("Unsupported Jacobian structure")
     end
 
-    @timeit timer "Function" begin
+    seed_kernel!(arrays.t1sseeds, arrays.varx, arrays.t1svarx, nbus)
+
+    if isa(type, StateJacobian)
         residual_polar!(
             arrays.t1sF,
-            view(arrays.t1sx, range1),
-            view(arrays.t1sx, range2),
+            view(arrays.t1sx, 1:nvbus),
+            view(arrays.t1sx, nvbus+1:2*nvbus),
             ybus_re, ybus_im,
             pinj, qinj,
             pv, pq, nbus
         )
-    end
-
-    @timeit timer "Get partials" begin
-        getpartials_kernel!(arrays.compressedJ, arrays.t1sF, nbus)
-    end
-    @timeit timer "Uncompress" begin
-        uncompress_kernel!(arrays.J, arrays.compressedJ, arrays.coloring)
-    end
-    return nothing
-end
-"""
-    residual_jacobian!(arrays::StateJacobian,
-                        residual_polar!,
-                        v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus,
-                        timer = nothing)
-
-Update the sparse Jacobian entries using AutoDiff. No allocations are taking place in this function.
-
-* `arrays::StateJacobian`: Factory created Jacobian object to update
-* `residual_polar`: Primal function
-* `v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus`: Inputs both
-  active and passive parameters. Active inputs are mapped to `x` via the preallocated views.
-
-"""
-function residual_jacobian!(arrays::StateJacobian,
-                             residual_polar!,
-                             v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus,
-                             timer = nothing)
-    @timeit timer "Before" begin
-        @timeit timer "Setup" begin
-            nv_m = size(v_m, 1)
-            nv_a = size(v_a, 1)
-            nmap = size(arrays.map, 1)
-            n = nv_m + nv_a
-        end
-        @timeit timer "Arrays" begin
-            arrays.x[1:nv_m] .= v_m
-            arrays.x[nv_m+1:nv_m+nv_a] .= v_a
-            arrays.t1sx .= arrays.x
-            arrays.t1sF .= 0.0
-        end
-    end
-    @timeit timer "Seeding" begin
-        seed_kernel!(arrays.t1sseeds, arrays.varx, arrays.t1svarx, nbus)
-    end
-
-    @timeit timer "Function" begin
+    elseif isa(type, ControlJacobian)
         residual_polar!(
             arrays.t1sF,
-            view(arrays.t1sx, 1:nv_m),
-            view(arrays.t1sx, nv_m+1:nv_m+nv_a),
-            ybus_re, ybus_im,
-            pinj, qinj,
-            pv, pq, nbus
-        )
-    end
-
-    @timeit timer "Get partials" begin
-        getpartials_kernel!(arrays.compressedJ, arrays.t1sF, nbus)
-    end
-    @timeit timer "Uncompress" begin
-        uncompress_kernel!(arrays.J, arrays.compressedJ, arrays.coloring)
-    end
-    return nothing
-end
-
-"""
-    residual_jacobian!(arrays::ControlJacobian,
-                        residual_polar!,
-                        v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus,
-                        timer = nothing)
-
-Update the sparse Jacobian entries using AutoDiff. No allocations are taking place in this function.
-
-* `arrays::ControlJacobian`: Factory created Jacobian object to update
-* `residual_polar`: Primal function
-* `v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus`: Inputs both active and passive parameters. Active inputs are mapped to `x` via the preallocated views.
-
-"""
-function residual_jacobian!(arrays::ControlJacobian,
-                             residual_polar!,
-                             v_m, v_a, ybus_re, ybus_im, pinj, qinj, pv, pq, ref, nbus,
-                             timer = nothing)
-
-    @timeit timer "Before" begin
-        @timeit timer "Setup" begin
-            npinj = size(pinj , 1)
-            nv_m = size(v_m, 1)
-            nmap = size(arrays.map, 1)
-            n = npinj + nv_m
-        end
-        @timeit timer "Arrays" begin
-            arrays.x[1:nv_m] .= v_m
-            arrays.x[nv_m+1:nv_m+npinj] .= pinj
-            arrays.t1sx .= arrays.x
-            arrays.t1sF .= 0.0
-        end
-    end
-    @timeit timer "Seeding" begin
-        seed_kernel!(arrays.t1sseeds, arrays.varx, arrays.t1svarx, nbus)
-    end
-    @timeit timer "Function" begin
-        residual_polar!(
-            arrays.t1sF,
-            view(arrays.t1sx, 1:nv_m),
+            view(arrays.t1sx, 1:nvbus),
             v_a,
             ybus_re, ybus_im,
-            view(arrays.t1sx, nv_m+1:nv_m + npinj), qinj,
+            view(arrays.t1sx, nvbus+1:nvbus+ninj), qinj,
             pv, pq, nbus
         )
+    else
+        error("Unsupported Jacobian structure")
     end
 
-    @timeit timer "Get partials" begin
-        getpartials_kernel!(arrays.compressedJ, arrays.t1sF, nbus)
-    end
-    @timeit timer "Uncompress" begin
-        # Uncompress matrix. Sparse matrix elements have different names with CUDA
-        uncompress_kernel!(arrays.J, arrays.compressedJ, arrays.coloring)
-    end
+    getpartials_kernel!(arrays.compressedJ, arrays.t1sF, nbus)
+    uncompress_kernel!(arrays.J, arrays.compressedJ, arrays.coloring)
+
+    return nothing
 end
 
 function Base.show(io::IO, jacobian::AbstractJacobian)

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -2,6 +2,15 @@ export PolarForm, bounds, powerflow
 export State, Control, Parameters, NumberOfState, NumberOfControl
 
 """
+    AbstractJacobianStructure
+
+The user may specify a mapping to the single input vector x for AD.
+
+"""
+
+abstract type AbstractJacobianStructure end
+
+"""
     AbstractFormulation
 
 Second layer of the package, implementing the interface between

--- a/src/models/polar/kernels.jl
+++ b/src/models/polar/kernels.jl
@@ -32,7 +32,7 @@ balance function [`power_balance`](@ref).
 # Note
 Code adapted from MATPOWER.
 """
-function residual_jacobian(V, Ybus, pv, pq)
+function residual_jacobian(V, Ybus, ref, pv, pq)
     n = size(V, 1)
     Ibus = Ybus*V
     diagV       = sparse(1:n, 1:n, V, n, n)
@@ -62,7 +62,7 @@ function _state_jacobian(polar::PolarForm)
     Vre = rand(n)
     Vim = rand(n)
     V = Vre .+ 1im .* Vim
-    return residual_jacobian(V, Y, pv, pq)
+    return residual_jacobian(V, Y, ref, pv, pq)
 end
 _sparsity_pattern(polar::PolarForm) = findnz(_state_jacobian(polar))
 

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -277,7 +277,7 @@ function init_autodiff_factory(polar::PolarForm{T, IT, VT, AT}, buffer::PolarNet
     return statejacobian, controljacobian, objectiveAD
 end
 
-function jacobian(polar::PolarForm, jac::AutoDiff.Jacobian, buffer::PolarNetworkState)
+function jacobian(polar::PolarForm, jac::AutoDiff.Jacobian, buffer::PolarNetworkState, jac_type::AutoDiff.AbstractJacobian)
     nbus = PS.get(polar.network, PS.NumberOfBuses())
     ngen = PS.get(polar.network, PS.NumberOfGenerators())
     # Indexing
@@ -287,7 +287,7 @@ function jacobian(polar::PolarForm, jac::AutoDiff.Jacobian, buffer::PolarNetwork
     # Network state
     Vm, Va, pbus, qbus = buffer.vmag, buffer.vang, buffer.pinj, buffer.qinj
     AutoDiff.residual_jacobian!(jac, residual_polar!, Vm, Va,
-                           polar.ybus_re, polar.ybus_im, pbus, qbus, pv, pq, ref, nbus, AutoDiff.ControlJacobian())
+                           polar.ybus_re, polar.ybus_im, pbus, qbus, pv, pq, ref, nbus, jac_type)
     return jac.J
 end
 

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -4,12 +4,12 @@ abstract type AbstractJacobianStructure end
 
 struct StateJacobianStructure{IT} <: AbstractJacobianStructure where {IT}
     sparsity::Function
-    map::Vector
+    map::IT
 end
 
 struct ControlJacobianStructure{IT} <: AbstractJacobianStructure where {IT}
     sparsity::Function
-    map::Vector
+    map::IT
 end
 
 struct PolarForm{T, IT, VT, AT} <: AbstractFormulation where {T, IT, VT, AT}
@@ -146,7 +146,7 @@ function PolarForm(pf::PS.PowerNetwork, device; nocost=false)
     mappq = [i + nvbus for i in idx_pq]
     # Ordering for x is (θ_pv, θ_pq, v_pq)
     statemap = vcat(mappv, mappq, idx_pq)
-    state_jacobian_structure = StateJacobianStructure{IT}(state_jacobian, IT(statemap))
+    state_jacobian_structure = StateJacobianStructure(state_jacobian, IT(statemap))
 
     function control_jacobian(V, Ybus, ref, pv, pq)
         n = size(V, 1)

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -1,6 +1,5 @@
 # Polar formulation
 #
-abstract type AbstractJacobianStructure end
 
 struct StateJacobianStructure{IT} <: AbstractJacobianStructure where {IT}
     sparsity::Function

--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -362,8 +362,6 @@ function powerflow(
             AutoDiff.residual_jacobian!(jacobian, residual_polar!, 
                                    Vm, Va,
                                    polar.ybus_re, polar.ybus_im, pbus, qbus, pv, pq, ref, nbus, AutoDiff.StateJacobian())
-            # AutoDiff.residual_jacobian!(jacobian, residual_polar!, Vm, Va,
-            #                        polar.ybus_re, polar.ybus_im, pbus, qbus, pv, pq, ref, nbus, TIMER)
         end
         J = jacobian.J
 

--- a/test/powersystem.jl
+++ b/test/powersystem.jl
@@ -101,14 +101,14 @@ const PS = PowerSystem
     @testset "Computing Jacobian of residuals" begin
         F = zeros(Float64, npv + 2*npq)
         # Compute Jacobian at point V manually and use it as reference
-        J = residual_jacobian(V, Ybus, ref, pv, pq)
+        J = ExaPF.residual_jacobian(V, Ybus, ref, pv, pq)
         J♯ = copy(J)
         # Build the Jacobian structure
-        mappv = [i + npv for i in pv]
-        mappq = [i + npv for i in pq]
+        mappv = [i + nbus for i in pv]
+        mappq = [i + nbus for i in pq]
         # Ordering for x is (θ_pv, θ_pq, v_pq)
         statemap = vcat(mappv, mappq, pq)
-        jacobian_structure = ExaPF.StateJacobianStructure{Vector{Float64}}(residual_jacobian, statemap)
+        jacobian_structure = ExaPF.StateJacobianStructure{Vector{Float64}}(ExaPF.residual_jacobian, statemap)
 
         # Then, create a Jacobian object
         jacobianAD = ExaPF.AutoDiff.Jacobian(jacobian_structure, F, Vm, Va,

--- a/test/reduced_gradient.jl
+++ b/test/reduced_gradient.jl
@@ -40,7 +40,7 @@ const PS = PowerSystem
         # Test with Matpower's Jacobian
         V = cache.vmag .* exp.(im * cache.vang)
         Ybus = pf.Ybus
-        J = ExaPF.residual_jacobian(V, Ybus, pf.pv, pf.pq)
+        J = ExaPF.residual_jacobian(V, Ybus, pf.ref, pf.pv, pf.pq)
         @test isapprox(∇gₓ, J)
 
         # Test gradients

--- a/test/reduced_gradient.jl
+++ b/test/reduced_gradient.jl
@@ -32,9 +32,9 @@ const PS = PowerSystem
         ExaPF.get!(polar, State(), xk, cache)
         # No need to recompute ∇gₓ
         ∇gₓ = jx.J
-        ∇gᵤ = ExaPF.jacobian(polar, ju, cache)
+        ∇gᵤ = ExaPF.jacobian(polar, ju, cache, AutoDiff.ControlJacobian())
         # test jacobian wrt x
-        ∇gᵥ = ExaPF.jacobian(polar, jx, cache)
+        ∇gᵥ = ExaPF.jacobian(polar, jx, cache, AutoDiff.StateJacobian())
         @test isapprox(∇gₓ, ∇gᵥ)
 
         # Test with Matpower's Jacobian


### PR DESCRIPTION
* Same constructor and evaluation functions for state Jacobian and control Jacobian.
* Move indexing and sparsity to `model.jl`. This needs follow-up work. 