### PR TITLE
Cache physical values only in buffer in ReducedSpaceEvaluator

### DIFF
--- a/src/PowerSystem/power_network.jl
+++ b/src/PowerSystem/power_network.jl
@@ -94,6 +94,14 @@ get(pf::PowerNetwork, ::NumberOfSlackBuses) = length(pf.ref)
 ## Loads
 get(pf::PowerNetwork, ::ActiveLoad) = real.(pf.sload)
 get(pf::PowerNetwork, ::ReactiveLoad) = imag.(pf.sload)
+function get(pf::PowerNetwork, ::ActivePower)
+    GEN_BUS, PG, QG, _ = IndexSet.idx_gen()
+    return pf.generators[:, PG] ./ pf.baseMVA
+end
+function get(pf::PowerNetwork, ::ReactivePower)
+    GEN_BUS, PG, QG, _ = IndexSet.idx_gen()
+    return pf.generators[:, QG] ./ pf.baseMVA
+end
 
 ## Indexing
 function get(pf::PowerNetwork, ::GeneratorIndexes)

--- a/src/models/caches.jl
+++ b/src/models/caches.jl
@@ -11,7 +11,24 @@ struct IndexingCache{IVT} <: AbstractBuffer
     index_ref_to_gen::IVT
 end
 
-struct PolarNetworkState{VT} <: AbstractNetworkBuffer
+"""
+    PolarNetworkState{VI,VT} <: AbstractNetworkBuffer
+
+Buffer to store current values of all the variables describing
+the network, in polar formulation. Attributes are:
+
+- `vmag` (length: nbus): voltage magnitude at each bus
+- `vang` (length: nbus): voltage angle at each bus
+- `pinj` (length: nbus): power injection RHS. Equal to `Cg * Pg - Pd`
+- `qinj` (length: nbus): power injection RHS. Equal to `Cg * Qg - Qd`
+- `pg`   (length: ngen): active power of generators
+- `qg`   (length: ngen): reactive power of generators
+- `dx`   (length: nstates): cache the difference between two consecutive states (used in power flow resolution)
+- `balance` (length: nstates): cache for current power imbalance (used in power flow resolution)
+- `bus_gen` (length: ngen): generator-bus incidence matrix `Cg`
+
+"""
+struct PolarNetworkState{VI,VT} <: AbstractNetworkBuffer
     vmag::VT
     vang::VT
     pinj::VT
@@ -20,9 +37,64 @@ struct PolarNetworkState{VT} <: AbstractNetworkBuffer
     qg::VT
     balance::VT
     dx::VT
+    bus_gen::VI   # Generator-Bus incidence matrix
+end
+
+function PolarNetworkState{VT}(nbus::Int, ngen::Int, nstates::Int, bus_gen::VI) where {VI, VT}
+    # Bus variables
+    pbus = xzeros(VT, nbus)
+    qbus = xzeros(VT, nbus)
+    vmag = xzeros(VT, nbus)
+    vang = xzeros(VT, nbus)
+    # Generators variables
+    pg = xzeros(VT, ngen)
+    qg = xzeros(VT, ngen)
+    # Buffers
+    balance = xzeros(VT, nstates)
+    dx = xzeros(VT, nstates)
+    return PolarNetworkState{VI,VT}(vmag, vang, pbus, qbus, pg, qg, balance, dx, bus_gen)
 end
 
 setvalues!(buf::PolarNetworkState, ::PS.VoltageMagnitude, values) = copyto!(buf.vmag, values)
 setvalues!(buf::PolarNetworkState, ::PS.VoltageAngle, values) = copyto!(buf.vang, values)
-setvalues!(buf::PolarNetworkState, ::PS.ActivePower, values) = copyto!(buf.pg, values)
-setvalues!(buf::PolarNetworkState, ::PS.ReactivePower, values) = copyto!(buf.qg, values)
+function setvalues!(buf::PolarNetworkState, ::PS.ActivePower, values)
+    pgenbus = view(buf.pinj, buf.bus_gen)
+    # Remove previous values
+    pgenbus .-= buf.pg
+    # Add new values
+    copyto!(buf.pg, values)
+    pgenbus .+= buf.pg
+end
+function setvalues!(buf::PolarNetworkState, ::PS.ReactivePower, values)
+    qgenbus = view(buf.qinj, buf.bus_gen)
+    # Remove previous values
+    qgenbus .-= buf.qg
+    # Add new values
+    copyto!(buf.qg, values)
+    qgenbus .+= buf.qg
+end
+function setvalues!(buf::PolarNetworkState, ::PS.ActiveLoad, values)
+    fill!(buf.pinj, 0)
+    # Pbus = Cg * Pg - Pd
+    buf.pinj .-= values
+    pgenbus = view(buf.pinj, buf.bus_gen)
+    pgenbus .+= buf.pg
+end
+function setvalues!(buf::PolarNetworkState, ::PS.ReactiveLoad, values)
+    fill!(buf.qinj, 0)
+    # Qbus = Cg * Qg - Qd
+    buf.qinj .-= values
+    qgenbus = view(buf.qinj, buf.bus_gen)
+    qgenbus .+= buf.qg
+end
+
+function Base.iszero(buf::PolarNetworkState)
+    return iszero(buf.pinj) &&
+        iszero(buf.qinj) &&
+        iszero(buf.vmag) &&
+        iszero(buf.vang) &&
+        iszero(buf.pg) &&
+        iszero(buf.qg) &&
+        iszero(buf.balance) &&
+        iszero(buf.dx)
+end

--- a/src/models/polar/constraints.jl
+++ b/src/models/polar/constraints.jl
@@ -60,7 +60,7 @@ function power_constraints(polar::PolarForm, g, buffer)
     g[cnt] = buffer.pg[ref_to_gen[1]]
     cnt += 1
     # Refresh reactive power generation in buffer
-    refresh!(polar, PS.Generator(), PS.ReactivePower(), buffer)
+    update!(polar, PS.Generator(), PS.ReactivePower(), buffer)
     # Constraint on Q_ref (generator) (Q_inj = Q_g - Q_load)
     # Careful: g could be a view
     if isa(g, SubArray)

--- a/src/models/polar/kernels.jl
+++ b/src/models/polar/kernels.jl
@@ -235,7 +235,7 @@ end
 end
 
 # Refresh active power (needed to evaluate objective)
-function refresh!(polar::PolarForm, ::PS.Generator, ::PS.ActivePower, buffer::PolarNetworkState)
+function update!(polar::PolarForm, ::PS.Generator, ::PS.ActivePower, buffer::PolarNetworkState)
     if isa(buffer.vmag, Array)
         kernel! = active_power_kernel!(CPU(), 1)
     else
@@ -294,7 +294,7 @@ end
     qg[i_gen] = inj + qload[bus]
 end
 
-function refresh!(polar::PolarForm, ::PS.Generator, ::PS.ReactivePower, buffer::PolarNetworkState)
+function update!(polar::PolarForm, ::PS.Generator, ::PS.ReactivePower, buffer::PolarNetworkState)
     if isa(buffer.vmag, Array)
         kernel! = reactive_power_kernel!(CPU(), 1)
     else

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -24,7 +24,7 @@ import ExaPF: ParseMAT, PowerSystem, IndexSet
     u = ExaPF.initial(polar, Control())
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
-    ExaPF.init!(polar, cache)
+    ExaPF.init_buffer!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
     convergence = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
@@ -50,7 +50,7 @@ end
     u = ExaPF.initial(polar, Control())
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
-    ExaPF.init!(polar, cache)
+    ExaPF.init_buffer!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
     conv = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
@@ -75,7 +75,7 @@ end
     u = ExaPF.initial(polar, Control())
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
-    ExaPF.init!(polar, cache)
+    ExaPF.init_buffer!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
     conv = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
@@ -98,7 +98,7 @@ end
     u = ExaPF.initial(polar, Control())
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
-    ExaPF.init!(polar, cache)
+    ExaPF.init_buffer!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
     conv = ExaPF.powerflow(polar, jx, cache, verbose_level=0)

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -24,6 +24,7 @@ import ExaPF: ParseMAT, PowerSystem, IndexSet
     u = ExaPF.initial(polar, Control())
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
+    ExaPF.init!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
     convergence = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
@@ -49,6 +50,7 @@ end
     u = ExaPF.initial(polar, Control())
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
+    ExaPF.init!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
     conv = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
@@ -73,6 +75,7 @@ end
     u = ExaPF.initial(polar, Control())
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
+    ExaPF.init!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
     conv = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
@@ -95,6 +98,7 @@ end
     u = ExaPF.initial(polar, Control())
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
+    ExaPF.init!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
     conv = ExaPF.powerflow(polar, jx, cache, verbose_level=0)

--- a/test/polar_form.jl
+++ b/test/polar_form.jl
@@ -48,9 +48,10 @@ const PS = PowerSystem
         end
 
         cache = ExaPF.get(polar, ExaPF.PhysicalState())
+        ExaPF.init!(polar, cache)
         @testset "NetworkState cache" begin
             @test isa(cache.vmag, M)
-            ExaPF.transfer!(polar, cache, x0, u0)
+            ExaPF.transfer!(polar, cache, u0)
         end
         @testset "Polar model API" begin
             xₖ = copy(x0)

--- a/test/reduced_evaluator.jl
+++ b/test/reduced_evaluator.jl
@@ -102,6 +102,12 @@
         ExaPF.reset!(nlp)
         @test get(nlp, State()) == x0
         @test iszero(nlp.λ)
+
+        # setters
+        nbus = get(nlp, PS.NumberOfBuses())
+        loads = similar(u, nbus) ; fill!(loads, 1)
+        ExaPF.setvalues!(nlp, PS.ActiveLoad(), loads)
+        ExaPF.setvalues!(nlp, PS.ReactiveLoad(), loads)
     end
 end
 

--- a/test/reduced_evaluator.jl
+++ b/test/reduced_evaluator.jl
@@ -38,6 +38,8 @@
         end
 
         # Test consistence
+        n_state = get(polar, NumberOfState())
+        @test length(nlp.λ) == n_state
         n = ExaPF.n_variables(nlp)
         m = ExaPF.n_constraints(nlp)
         @test n == length(u0)
@@ -98,7 +100,7 @@
 
         # test reset!
         ExaPF.reset!(nlp)
-        @test nlp.x == x0
+        @test get(nlp, State()) == x0
         @test iszero(nlp.λ)
     end
 end

--- a/test/reduced_gradient.jl
+++ b/test/reduced_gradient.jl
@@ -20,6 +20,7 @@ const PS = PowerSystem
 
         polar = PolarForm(pf, CPU())
         cache = ExaPF.get(polar, ExaPF.PhysicalState())
+        ExaPF.init!(polar, cache)
 
         xk = ExaPF.initial(polar, State())
         u = ExaPF.initial(polar, Control())
@@ -64,7 +65,7 @@ const PS = PowerSystem
             # Compare with finite difference
             function reduced_cost(u_)
                 # Ensure we remain in the manifold
-                ExaPF.transfer!(polar, cache, xk, u_)
+                ExaPF.transfer!(polar, cache, u_)
                 convergence = powerflow(polar, jx, cache, tol=1e-14)
                 ExaPF.refresh!(polar, PS.Generator(), PS.ActivePower(), cache)
                 return ExaPF.cost_production(polar, cache.pg)

--- a/test/reduced_gradient.jl
+++ b/test/reduced_gradient.jl
@@ -20,7 +20,7 @@ const PS = PowerSystem
 
         polar = PolarForm(pf, CPU())
         cache = ExaPF.get(polar, ExaPF.PhysicalState())
-        ExaPF.init!(polar, cache)
+        ExaPF.init_buffer!(polar, cache)
 
         xk = ExaPF.initial(polar, State())
         u = ExaPF.initial(polar, Control())
@@ -46,7 +46,7 @@ const PS = PowerSystem
         # Test gradients
         @testset "Reduced gradient" begin
             # Refresh cache with new values of vmag and vang
-            ExaPF.refresh!(polar, PS.Generator(), PS.ActivePower(), cache)
+            ExaPF.update!(polar, PS.Generator(), PS.ActivePower(), cache)
             # We need uk here for the closure
             uk = copy(u)
             ExaPF.∂cost(polar, ∂obj, cache)
@@ -67,7 +67,7 @@ const PS = PowerSystem
                 # Ensure we remain in the manifold
                 ExaPF.transfer!(polar, cache, u_)
                 convergence = powerflow(polar, jx, cache, tol=1e-14)
-                ExaPF.refresh!(polar, PS.Generator(), PS.ActivePower(), cache)
+                ExaPF.update!(polar, PS.Generator(), PS.ActivePower(), cache)
                 return ExaPF.cost_production(polar, cache.pg)
             end
 


### PR DESCRIPTION
Before this PR, when using a `ReducedSpaceEvaluator` object `nlp`, values were cached both in `nlp.buffer` and in a state `nlp.x`. This introduced confusion and redundancy. This PR refactors the object `ReducedSpaceEvaluator` to keep only `nlp.buffer` as a cache. 

Additional details about this PR:
- **Warning**: it introduces a breaking change in the constructor of `ReducedSpaceEvaluator`, as we do not need anymore to pass an initial state to instantiate the evaluator object. 
- it improves the interface of the cache object `PolarNetworkState`, to ensure that `pinj` is always equal to `Cg * Pg - Pd`, and equivalently for `qinj`. That was not the case before. 
- hence, it should fix a few bugs we observed in  the ProxAL/ExaPF wrapper, and the convergence of the Newton-Raphson algorithm should be improved. 