### PR TITLE
Add a NewtonRaphson object storing all arguments for the powerflow solver

### DIFF
--- a/src/models/polar/polar.jl
+++ b/src/models/polar/polar.jl
@@ -322,11 +322,9 @@ end
 function powerflow(
     polar::PolarForm{T, IT, VT, AT},
     jacobian::AutoDiff.Jacobian,
-    buffer::PolarNetworkState{IT,VT};
+    buffer::PolarNetworkState{IT,VT},
+    algo::NewtonRaphson;
     solver=DirectSolver(),
-    tol=1e-7,
-    maxiter=20,
-    verbose_level=0,
 ) where {T, IT, VT, AT}
     # Retrieve parameter and initial voltage guess
     Vm, Va, pbus, qbus = buffer.vmag, buffer.vang, buffer.pinj, buffer.qinj
@@ -367,10 +365,10 @@ function powerflow(
 
     # check for convergence
     normF = norm(F, Inf)
-    if verbose_level >= VERBOSE_LEVEL_LOW
+    if algo.verbose >= VERBOSE_LEVEL_LOW
         @printf("Iteration %d. Residual norm: %g.\n", iter, normF)
     end
-    if normF < tol
+    if normF < algo.tol
         converged = true
     end
 
@@ -382,7 +380,7 @@ function powerflow(
     dx34 = view(dx, j3:j4) # Vapq
     dx56 = view(dx, j1:j2) # Vapv
 
-    @timeit TIMER "Newton" while ((!converged) && (iter < maxiter))
+    @timeit TIMER "Newton" while ((!converged) && (iter < algo.maxiter))
 
         iter += 1
 
@@ -423,16 +421,16 @@ function powerflow(
         end
 
         @timeit TIMER "Norm" normF = xnorm(F)
-        if verbose_level >= VERBOSE_LEVEL_LOW
+        if algo.verbose >= VERBOSE_LEVEL_LOW
             @printf("Iteration %d. Residual norm: %g.\n", iter, normF)
         end
 
-        if normF < tol
+        if normF < algo.tol
             converged = true
         end
     end
 
-    if verbose_level >= VERBOSE_LEVEL_HIGH
+    if algo.verbose >= VERBOSE_LEVEL_HIGH
         if converged
             @printf("N-R converged in %d iterations.\n", iter)
         else
@@ -441,12 +439,11 @@ function powerflow(
     end
 
     # Timer outputs display
-    if verbose_level >= VERBOSE_LEVEL_MEDIUM
+    if algo.verbose >= VERBOSE_LEVEL_MEDIUM
         show(TIMER)
         println("")
     end
-    conv = ConvergenceStatus(converged, iter, normF, sum(linsol_iters))
-    return conv
+    return ConvergenceStatus(converged, iter, normF, sum(linsol_iters))
 end
 
 # Cost function

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,14 @@
+export NewtonRaphson
+
+abstract type AbstractNonLinearSolver end
+
+struct NewtonRaphson <: AbstractNonLinearSolver
+    maxiter::Int
+    tol::Float64
+    verbose::Int
+end
+NewtonRaphson(; maxiter=20, tol=1e-8, verbose=VERBOSE_LEVEL_NONE) = NewtonRaphson(maxiter, tol, verbose)
+
 struct ConvergenceStatus
     has_converged::Bool
     n_iterations::Int

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -27,7 +27,7 @@ import ExaPF: ParseMAT, PowerSystem, IndexSet
     ExaPF.init_buffer!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
-    convergence = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
+    convergence = ExaPF.powerflow(polar, jx, cache, NewtonRaphson())
     ExaPF.get!(polar, State(), x, cache)
 
     x_sol = [0.16875136481876485, 0.0832709533581424,
@@ -53,7 +53,7 @@ end
     ExaPF.init_buffer!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
-    conv = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
+    conv = ExaPF.powerflow(polar, jx, cache, NewtonRaphson())
     ExaPF.get!(polar, State(), x, cache)
 
     @test conv.n_iterations == 2
@@ -78,7 +78,7 @@ end
     ExaPF.init_buffer!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
-    conv = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
+    conv = ExaPF.powerflow(polar, jx, cache, NewtonRaphson())
     ExaPF.get!(polar, State(), x, cache)
 
     @test conv.n_iterations == 3
@@ -101,7 +101,7 @@ end
     ExaPF.init_buffer!(polar, cache)
     jx, ju = ExaPF.init_autodiff_factory(polar, cache)
     # solve power flow
-    conv = ExaPF.powerflow(polar, jx, cache, verbose_level=0)
+    conv = ExaPF.powerflow(polar, jx, cache, NewtonRaphson())
     ExaPF.get!(polar, State(), x, cache)
 
     @test conv.n_iterations == 5

--- a/test/polar_form.jl
+++ b/test/polar_form.jl
@@ -97,7 +97,7 @@ const PS = PowerSystem
             jx, ju, ∂obj = ExaPF.init_autodiff_factory(polar, cache)
 
             # Test powerflow with cache signature
-            conv = powerflow(polar, jx, cache, tol=tolerance)
+            conv = powerflow(polar, jx, cache, NewtonRaphson(tol=tolerance))
             ExaPF.get!(polar, State(), xₖ, cache)
             # Refresh power of generators in cache
             for Power in [PS.ActivePower, PS.ReactivePower]

--- a/test/powerflow.jl
+++ b/test/powerflow.jl
@@ -28,9 +28,12 @@ import ExaPF: PowerSystem
         @testset "Powerflow solver $(LinSolver)" for LinSolver in ExaPF.list_solvers(device)
             algo = LinSolver(precond)
             xk = copy(x0)
-            nlp = ExaPF.ReducedSpaceEvaluator(polar, xk, uk;
-                                              ε_tol=tolerance, linear_solver=algo)
-            convergence = ExaPF.update!(nlp, uk; verbose_level=ExaPF.VERBOSE_LEVEL_NONE)
+            nlp = ExaPF.ReducedSpaceEvaluator(
+                polar, xk, uk;
+                powerflow_solver=NewtonRaphson(tol=tolerance, verbose=0),
+                linear_solver=algo
+            )
+            convergence = ExaPF.update!(nlp, uk)
             @test convergence.has_converged
             @test convergence.norm_residuals < tolerance
             @test convergence.n_iterations == 2

--- a/test/proxal_evaluator.jl
+++ b/test/proxal_evaluator.jl
@@ -8,11 +8,12 @@ import ExaPF: PS
     @testset "PowerNetwork Constructor" begin
         pf = PS.PowerNetwork(datafile)
         eps = 1e-10
-        prox0 = ExaPF.ProxALEvaluator(pf, time; ε_tol=eps)
+        powerflow_solver = NewtonRaphson(tol=eps)
+        prox0 = ExaPF.ProxALEvaluator(pf, time; powerflow_solver=powerflow_solver)
         @test isa(prox0, ExaPF.ProxALEvaluator)
         @test isa(prox0.inner, ExaPF.ReducedSpaceEvaluator)
         # Test that argument was correctly set
-        @test prox0.inner.ε_tol == eps
+        @test prox0.inner.powerflow_solver == powerflow_solver
     end
 
     # Build reference evaluator

--- a/test/reduced_evaluator.jl
+++ b/test/reduced_evaluator.jl
@@ -6,8 +6,8 @@
     end
     datafile = joinpath(dirname(@__FILE__), "..", "data", case)
     @testset "Constructor" for (device, M) in ITERATORS
-        tol = 1e-11
-        nlp = ExaPF.ReducedSpaceEvaluator(datafile; device=device, ε_tol=tol)
+        powerflow_solver = NewtonRaphson(; tol=1e-11)
+        nlp = ExaPF.ReducedSpaceEvaluator(datafile; device=device, powerflow_solver=powerflow_solver)
         TNLP = typeof(nlp)
         for (fn, ft) in zip(fieldnames(TNLP), fieldtypes(TNLP))
             if ft <: AbstractArray{Float64, P} where P
@@ -15,7 +15,7 @@
             end
         end
         # Test that arguments are passed as expected in the constructor:
-        @test nlp.ε_tol == tol
+        @test nlp.powerflow_solver == powerflow_solver
     end
 
     pf = PowerSystem.PowerNetwork(datafile)

--- a/test/reduced_gradient.jl
+++ b/test/reduced_gradient.jl
@@ -28,7 +28,7 @@ const PS = PowerSystem
         jx, ju, ∂obj = ExaPF.init_autodiff_factory(polar, cache)
 
         # solve power flow
-        conv = powerflow(polar, jx, cache, tol=1e-12)
+        conv = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-12))
         ExaPF.get!(polar, State(), xk, cache)
         # No need to recompute ∇gₓ
         ∇gₓ = jx.J
@@ -66,7 +66,7 @@ const PS = PowerSystem
             function reduced_cost(u_)
                 # Ensure we remain in the manifold
                 ExaPF.transfer!(polar, cache, u_)
-                convergence = powerflow(polar, jx, cache, tol=1e-14)
+                convergence = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-14))
                 ExaPF.update!(polar, PS.Generator(), PS.ActivePower(), cache)
                 return ExaPF.cost_production(polar, cache.pg)
             end

--- a/test/test_rgm.jl
+++ b/test/test_rgm.jl
@@ -33,7 +33,7 @@ import ExaPF: ParseMAT, PowerSystem, IndexSet
     fill!(grad, 0)
 
     while norm_grad > norm_tol && iter < iter_max
-        ExaPF.update!(nlp, uk; verbose_level=ExaPF.VERBOSE_LEVEL_NONE)
+        ExaPF.update!(nlp, uk)
         c = ExaPF.objective(nlp, uk)
         ExaPF.gradient!(nlp, grad, uk)
         # compute control step


### PR DESCRIPTION
I think that would allow greater modularity. It would also help implementing other powerflow algorithm (e.g. `DecoupledLoadFlow` :smile: ), as we could now dispatch on the algorithm we are using. 