### PR TITLE
Implement reduced Hessian for ReducedSpaceEvaluator

### DIFF
--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -129,13 +129,46 @@ Let `(n, m) = n_variables(nlp), n_constraints(nlp)`.
 function ojtprod! end
 
 """
-    hessian!(nlp::AbstractNLPEvaluator, hess, u)
+    hessian!(nlp::AbstractNLPEvaluator, H, u)
 
-Evaluate the Hessian of the problem at point `u`. Store
-the result inplace, in the vector `hess`.
+Evaluate the Hessian `∇²f(u)` of the objective `f(u)` at point `u`. Store
+the result inplace, in the `n x n` matrix `H`.
 
 """
 function hessian! end
+
+"""
+    hessian_lagrangian!(nlp::AbstractNLPEvaluator, H, u, y)
+
+Evaluate the Hessian of the Lagrangian
+```math
+∇²L(u, y) = ∇²f(u) + \sum_i yᵢ ∇²hᵢ(u),
+```
+at `(u, y)`. Stores the result inplace, in `n x n` matrix `H`.
+
+"""
+function hessian_lagrangian! end
+
+"""
+    hessprod!(nlp::AbstractNLPEvaluator, hessvec, u, v)
+
+Evaluate the Hessian-vector product `∇²f(u) * v` of the objective at `u`. Store
+the result inplace, in the vector `hessvec`.
+
+"""
+function hessprod! end
+
+"""
+    hessprod_lagrangian!(nlp::AbstractNLPEvaluator, hessvec, u, y, v)
+
+Evaluate the Hessian-vector product of the Lagrangian
+```math
+∇²L(u, y) * v = \Big( ∇²f(u) + \sum_i yᵢ ∇²hᵢ(u) \Big) * v ,
+```
+at `(u, y)`. Store the result inplace, in the vector `hessvec`.
+
+"""
+function hessprod! end
 
 # Utilities
 """

--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -60,9 +60,9 @@ function objective end
 """
     gradient!(nlp::AbstractNLPEvaluator, g, u)
 
-Evaluate the gradient of the objective at point `u`. Store
-the result inplace in the vector `g`, which should have the same
-dimension as `u`.
+Evaluate the gradient of the objective in the reduced space, at
+given control `u`. Store the result inplace in the vector `g`, which should
+have the same dimension as `u`.
 
 """
 function gradient! end
@@ -90,8 +90,8 @@ function jacobian_structure! end
 """
     jacobian!(nlp::ReducedSpaceEvaluator, jac, u)
 
-Evaluate the Jacobian of the constraints ``J`` at position `u`. Store
-the result inplace, in the `m x n` matrix `jac`.
+Evaluate the Jacobian of the constraints in the reduced space,
+at control `u`. Store the result inplace, in the `m x n` matrix `jac`.
 """
 function jacobian! end
 
@@ -131,38 +131,36 @@ function ojtprod! end
 """
     hessian!(nlp::AbstractNLPEvaluator, H, u)
 
-Evaluate the Hessian `∇²f(u)` of the objective `f(u)` at point `u`. Store
+Evaluate the Hessian `∇²f(u)` of the objective `f(u)` in the
+reduced space, at control `u`. Store
 the result inplace, in the `n x n` matrix `H`.
 
 """
 function hessian! end
 
 """
-    hessian_lagrangian!(nlp::AbstractNLPEvaluator, H, u, y)
-
-Evaluate the Hessian of the Lagrangian
-at `(u, y)`. Stores the result inplace, in `n x n` matrix `H`.
-
-"""
-function hessian_lagrangian! end
-
-"""
     hessprod!(nlp::AbstractNLPEvaluator, hessvec, u, v)
 
-Evaluate the Hessian-vector product `∇²f(u) * v` of the objective at `u`. Store
+Evaluate the Hessian-vector product `∇²f(u) * v` of the objective in
+the reduced space, at given control `u`. Store
 the result inplace, in the vector `hessvec`.
 
 """
 function hessprod! end
 
-"""
-    hessprod_lagrangian!(nlp::AbstractNLPEvaluator, hessvec, u, y, v)
+@doc raw"""
+    hessian_lagrangian_full(nlp::AbstractNLPEvaluator, u, y, σ)
 
-Evaluate the Hessian-vector product of the Lagrangian
-at `(u, y)`. Store the result inplace, in the vector `hessvec`.
+Evaluate the Hessian of the Lagrangian in the full-space
+```math
+∇²L(x, u, y) = σ ∇²f(x, u) + \sum_i y_i ∇²c_i(x, u)
+```
+Return a named-tuple `H`, with entries `H.xx` corresponding
+to `∇²Lₓₓ`, `H.xu` to `∇²Lₓᵤ` and `H.uu` to `∇²Lᵤᵤ`.
 
 """
-function hessprod_lagrangian! end
+function hessian_lagrangian_full end
+
 
 # Utilities
 """

--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -132,8 +132,8 @@ function ojtprod! end
     hessian!(nlp::AbstractNLPEvaluator, H, u)
 
 Evaluate the Hessian `∇²f(u)` of the objective `f(u)` in the
-reduced space, at control `u`. Store
-the result inplace, in the `n x n` matrix `H`.
+reduced space, at control `u`.
+Store the result inplace, in the `n x n` matrix `H`.
 
 """
 function hessian! end
@@ -142,8 +142,8 @@ function hessian! end
     hessprod!(nlp::AbstractNLPEvaluator, hessvec, u, v)
 
 Evaluate the Hessian-vector product `∇²f(u) * v` of the objective in
-the reduced space, at given control `u`. Store
-the result inplace, in the vector `hessvec`.
+the reduced space, at control `u`.
+Store the result inplace, in the vector `hessvec` (with size `n`).
 
 """
 function hessprod! end
@@ -159,7 +159,7 @@ Return a named-tuple `H`, with entries `H.xx` corresponding
 to `∇²Lₓₓ`, `H.xu` to `∇²Lₓᵤ` and `H.uu` to `∇²Lᵤᵤ`.
 
 """
-function hessian_lagrangian_full end
+function full_hessian_lagrangian end
 
 
 # Utilities
@@ -184,6 +184,14 @@ function primal_infeasibility! end
 "Return `true` if the problem is constrained, `false` otherwise."
 is_constrained(nlp::AbstractNLPEvaluator) = n_constraints(nlp) > 0
 
+"""
+    constraints_type(nlp::AbstractNLPEvaluator)
+
+Return the type of the non-linear constraints of the evaluator `nlp`,
+as a `Symbol`. Result could be `:inequality` if problem has only
+inequality constraints, `:equality` if problem has only equality
+constraints, or `:mixed` if problem has both types of constraints.
+"""
 function constraints_type end
 
 """

--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -141,9 +141,6 @@ function hessian! end
     hessian_lagrangian!(nlp::AbstractNLPEvaluator, H, u, y)
 
 Evaluate the Hessian of the Lagrangian
-```math
-∇²L(u, y) = ∇²f(u) + \sum_i yᵢ ∇²hᵢ(u),
-```
 at `(u, y)`. Stores the result inplace, in `n x n` matrix `H`.
 
 """
@@ -162,13 +159,10 @@ function hessprod! end
     hessprod_lagrangian!(nlp::AbstractNLPEvaluator, hessvec, u, y, v)
 
 Evaluate the Hessian-vector product of the Lagrangian
-```math
-∇²L(u, y) * v = \Big( ∇²f(u) + \sum_i yᵢ ∇²hᵢ(u) \Big) * v ,
-```
 at `(u, y)`. Store the result inplace, in the vector `hessvec`.
 
 """
-function hessprod! end
+function hessprod_lagrangian! end
 
 # Utilities
 """

--- a/src/Evaluators/MOI_wrapper.jl
+++ b/src/Evaluators/MOI_wrapper.jl
@@ -83,7 +83,7 @@ function MOI.eval_hessian_lagrangian(ev::MOIEvaluator, H, x, σ, μ)
     # Copy back to the MOI arrray
     rows, cols = hessian_structure(ev.nlp)
     k = 1
-    for j = 1:n, i = 1:j #(i, j) in zip(rows, cols)
+    for (i, j) in zip(rows, cols)
         H[k] = σ * hess[i, j]
         k += 1
     end

--- a/src/Evaluators/MOI_wrapper.jl
+++ b/src/Evaluators/MOI_wrapper.jl
@@ -77,12 +77,14 @@ function MOI.eval_hessian_lagrangian(ev::MOIEvaluator, H, x, σ, μ)
     _update!(ev, x)
     n = n_variables(ev.nlp)
     hess = zeros(n, n)
-    hessian_lagrangian!(ev.nlp, hess, x, μ, σ)
+    g = @view hess[1, :]
+    gradient!(ev.nlp, g, x)
+    hessian!(ev.nlp, hess, x)
     # Copy back to the MOI arrray
     rows, cols = hessian_structure(ev.nlp)
     k = 1
-    for (i, j) in zip(rows, cols)
-        H[k] = hess[i, j]
+    for j = 1:n, i = 1:j #(i, j) in zip(rows, cols)
+        H[k] = σ * hess[i, j]
         k += 1
     end
 end

--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -135,10 +135,14 @@ function gradient!(ag::AugLagEvaluator, grad, u)
     base_nlp = ag.inner
     scaler = ag.scaler
     σ = scaler.scale_obj
-    v = scaler.scale_cons .* ag.λc
+    mask = abs.(ag.cons) .> 0
+    v = scaler.scale_cons .* ag.λc .* mask
     ojtprod!(base_nlp, grad, u, σ, v)
 end
 
+# TODO: currently, hessprod! works only with the `ReducedSpaceEvaluator`
+# We should implement something equivalent to `ojtprod!`, but for computing
+# second order information.
 function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
     base_nlp = ag.inner
     scaler = ag.scaler
@@ -148,10 +152,10 @@ function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
     mask = abs.(cx) .> 1e-10
 
     σ = scaler.scale_obj
-    y = scaler.scale_cons .* ag.λc
+    y = scaler.scale_cons .* ag.λc .* mask
     # Hessian of Lagrangian L(u, y) = f(u) + y' * h(u)
-    ∇²L = hessian_lagrangian_full(base_nlp, u, y, σ)
-    J = jacobian_full(base_nlp, u)
+    ∇²L = full_hessian_lagrangian(base_nlp, u, y, σ)
+    J = full_jacobian(base_nlp, u)
     D = Diagonal(scaler.scale_cons .* scaler.scale_cons .* mask)
     ∇²L.xx .+= ag.ρ .* J.x' * D * J.x
     ∇²L.xu .+= ag.ρ .* J.u' * D * J.x
@@ -160,30 +164,9 @@ function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
     reduced_hessian!(base_nlp, hessvec, ∇²L.xx, ∇²L.xu, ∇²L.uu, w)
 end
 
-function hessian!(nlp::AugLagEvaluator, H, u)
-    nu = n_variables(nlp)
-    w = zeros(nu)
-    for i in 1:nu
-        fill!(w, 0)
-        w[i] = 1.0
-        hessprod!(nlp, view(H, :, i), u, w)
-    end
-end
-
-function constraint!(ag::AugLagEvaluator, cons, u)
-    @assert length(cons) == 0
-    return
-end
-
-function jacobian!(ag::AugLagEvaluator, jac, u)
-    @assert length(jac) == 0
-    return
-end
-
 function reset!(ag::AugLagEvaluator)
     reset!(ag.inner)
     empty!(ag.counter)
-    fill!(ag.cons, 0)
     fill!(ag.cons, 0)
     fill!(ag.λ, 0)
     fill!(ag.λc, 0)

--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -144,7 +144,7 @@ function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
     scaler = ag.scaler
     # Import AutoDiff objects
     autodiff = get(base_nlp, AutoDiffBackend())
-    cx = ag.infeasibility
+    cx = ag.cons
     mask = abs.(cx) .> 1e-10
 
     σ = scaler.scale_obj

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -1,4 +1,15 @@
 
+# Common interface for Hessian
+function hessian!(nlp::AbstractNLPEvaluator, H, x)
+    n = n_variables(nlp)
+    v = zeros(n)
+    for i in 1:n
+        fill!(v, 0)
+        v[i] = 1.0
+        hessprod!(nlp, view(H, :, i), x, v)
+    end
+end
+
 # AutoDiff Factory
 abstract type AbstractAutoDiffFactory end
 

--- a/src/Evaluators/penalty.jl
+++ b/src/Evaluators/penalty.jl
@@ -40,6 +40,10 @@ function jacobian_structure!(ag::AbstractPenaltyEvaluator, rows, cols)
     @assert length(rows) == length(cols) == 0
 end
 
+function hessian_structure(ag::AbstractPenaltyEvaluator)
+    return hessian_structure(ag.inner)
+end
+
 primal_infeasibility!(ag::AbstractPenaltyEvaluator, cons, u) = primal_infeasibility!(ag.inner, cons, u)
 primal_infeasibility(ag::AbstractPenaltyEvaluator, u) = primal_infeasibility(ag.inner, u)
 

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -283,7 +283,7 @@ function jacobian!(nlp::ReducedSpaceEvaluator, jac, u)
     end
 end
 
-function jacobian_full(nlp::ReducedSpaceEvaluator, u)
+function full_jacobian(nlp::ReducedSpaceEvaluator, u)
     jacobians_x = [] ; jacobians_u = []
     for cons in nlp.constraints
         J = jacobian(nlp.model, cons, nlp.buffer)
@@ -370,17 +370,7 @@ function hessprod!(nlp::ReducedSpaceEvaluator, hessvec, u, w)
     reduced_hessian!(nlp, hessvec, ∇²f.xx, ∇²f.xu, ∇²f.uu, w)
 end
 
-function hessian!(nlp::ReducedSpaceEvaluator, H, u)
-    nu = n_variables(nlp)
-    w = zeros(nu)
-    for i in 1:nu
-        fill!(w, 0)
-        w[i] = 1.0
-        hessprod!(nlp, view(H, :, i), u, w)
-    end
-end
-
-function hessian_lagrangian_full(nlp::ReducedSpaceEvaluator, u, y, σ)
+function full_hessian_lagrangian(nlp::ReducedSpaceEvaluator, u, y, σ)
     nu = n_variables(nlp)
     buffer = nlp.buffer
     ∂f = nlp.autodiff.∇f
@@ -407,8 +397,8 @@ end
 # Return lower-triangular matrix
 function hessian_structure(nlp::ReducedSpaceEvaluator)
     n = n_variables(nlp)
-    rows = Int[r for c in 1:n for r in 1:c]
-    cols = Int[c for c in 1:n for r in 1:c]
+    rows = Int[r for r in 1:n for c in 1:r]
+    cols = Int[c for r in 1:n for c in 1:r]
     return rows, cols
 end
 

--- a/src/polar/adjoints.jl
+++ b/src/polar/adjoints.jl
@@ -2,9 +2,9 @@
 #
 
 """
-    AdjointStackObjective
+    AdjointStackObjective{VT}
 
-An object for storing the adjoint stack in the adjoint objective computation
+An object for storing the adjoint stack in the adjoint objective computation.
 
 """
 struct AdjointStackObjective{VT}
@@ -195,18 +195,16 @@ function hessian_cost(polar::PolarForm, ∂obj::AdjointStackObjective, buffer::P
     ∂pg = (c3 .+ 2.0 .* c4 .* buffer.pg)[ref2gen]
     ∂²pg = 2.0 .* c4[[ref2gen; pv2gen]]
 
-    # Evaluate Hess-vec of objective function f(x, u) = 0
-    ∂₂Pₓₓ = active_power_hessian(polar, State(), State(), buffer)
-    ∂₂Pₓᵤ = active_power_hessian(polar, State(), Control(), buffer)
-    ∂₂Pᵤᵤ = active_power_hessian(polar, Control(), Control(), buffer)
+    # Evaluate Hess-vec of objective function f(x, u)
+    ∂₂P = active_power_hessian(polar, buffer)
 
     ∂Pₓ = active_power_jacobian(polar, State(), buffer)
     ∂Pᵤ = active_power_jacobian(polar, Control(), buffer)
 
     D = Diagonal(∂²pg)
-    ∇²fₓₓ = ∂pg .* ∂₂Pₓₓ + ∂Pₓ' * D * ∂Pₓ
-    ∇²fᵤᵤ = ∂pg .* ∂₂Pᵤᵤ + ∂Pᵤ' * D * ∂Pᵤ
-    ∇²fₓᵤ = ∂pg .* ∂₂Pₓᵤ + ∂Pᵤ' * D * ∂Pₓ
+    ∇²fₓₓ = ∂pg .* ∂₂P.xx + ∂Pₓ' * D * ∂Pₓ
+    ∇²fᵤᵤ = ∂pg .* ∂₂P.uu + ∂Pᵤ' * D * ∂Pᵤ
+    ∇²fₓᵤ = ∂pg .* ∂₂P.xu + ∂Pᵤ' * D * ∂Pₓ
 
     return (xx=∇²fₓₓ, xu=∇²fₓᵤ, uu=∇²fᵤᵤ)
 end

--- a/src/polar/constraints.jl
+++ b/src/polar/constraints.jl
@@ -267,20 +267,16 @@ function hessian(polar::PolarForm, ::typeof(power_constraints), ∂jac, buffer, 
 
     # First constraint is on active power generation at slack node
     λₚ = λ[1]
-    ∂₂Pₓₓ = λₚ .* active_power_hessian(State(), State(), V, Ybus, pv, pq, ref)
-    ∂₂Pₓᵤ = λₚ .* active_power_hessian(State(), Control(), V, Ybus, pv, pq, ref)
-    ∂₂Pᵤᵤ = λₚ .* active_power_hessian(Control(), Control(), V, Ybus, pv, pq, ref)
+    ∂₂P = active_power_hessian(V, Ybus, pv, pq, ref)
 
     λq = zeros(length(V))
     λq[ref] .= λ[2]
     λq[pv] .= λ[3:end]
-    ∂₂Qₓₓ = reactive_power_hessian(State(), State(), V, Ybus, λq, pv, pq, ref)
-    ∂₂Qₓᵤ = reactive_power_hessian(State(), Control(), V, Ybus, λq, pv, pq, ref)
-    ∂₂Qᵤᵤ = reactive_power_hessian(Control(), Control(), V, Ybus, λq, pv, pq, ref)
+    ∂₂Q = reactive_power_hessian(V, Ybus, λq, pv, pq, ref)
     return (
-        xx=∂₂Qₓₓ + ∂₂Pₓₓ,
-        xu=∂₂Qₓᵤ + ∂₂Pₓᵤ,
-        uu=∂₂Qᵤᵤ + ∂₂Pᵤᵤ,
+        xx=∂₂Q.xx + λₚ .* ∂₂P.xx,
+        xu=∂₂Q.xu + λₚ .* ∂₂P.xu,
+        uu=∂₂Q.uu + λₚ .* ∂₂P.uu,
     )
 end
 

--- a/src/polar/hessians.jl
+++ b/src/polar/hessians.jl
@@ -86,8 +86,9 @@ function residual_hessian(::Control, ::Control, V, Ybus, λ, pv, pq, ref)
     H22 = Pvv[pv,   pv] + Qvv[pv,   pv]
 
     H = [
-        H11  H12
-        H12' H22
+         H11  H12 spzeros(nref, npv)
+         H12' H22 spzeros(npv, npv)
+         spzeros(npv, nref + 2 * npv)
     ]
 
     return H
@@ -123,10 +124,26 @@ function residual_hessian(::State, ::Control, V, Ybus, λ, pv, pq, ref)
     H = [
         H11  H12  H13
         H21  H22  H23
+        spzeros(npv, npv + 2 * npq)
     ]
 
     return H
 end
+
+function residual_hessian(
+    polar::PolarForm,
+    r::AbstractVariable,
+    s::AbstractVariable,
+    buffer::PolarNetworkState,
+    λ::AbstractVector,
+)
+    ref = polar.indexing.index_ref
+    pv = polar.indexing.index_pv
+    pq = polar.indexing.index_pq
+    V = buffer.vmag .* exp.(im .* buffer.vang)
+    return residual_hessian(r, s, V, polar.network.Ybus, λ, pv, pq, ref)
+end
+
 
 # ∂²pg_ref / ∂²x
 function active_power_hessian(::State, ::State, V, Ybus, pv, pq, ref)
@@ -180,8 +197,9 @@ function active_power_hessian(::Control, ::Control, V, Ybus, pv, pq, ref)
     H22 = Pvv[pv, pv]
 
     H = [
-        H11  H12
-        H12' H22
+         H11  H12 spzeros(nref, npv)
+         H12' H22 spzeros(npv, npv)
+         spzeros(npv, nref + 2 * npv)
     ]
 
     return H
@@ -214,9 +232,23 @@ function active_power_hessian(::State, ::Control, V, Ybus, pv, pq, ref)
     H = [
         H11  H12  H13
         H21  H22  H23
+        spzeros(npv, npv + 2 * npq)
     ]
 
     return H
+end
+
+function active_power_hessian(
+    polar::PolarForm,
+    r::AbstractVariable,
+    s::AbstractVariable,
+    buffer::PolarNetworkState,
+)
+    ref = polar.indexing.index_ref
+    pv = polar.indexing.index_pv
+    pq = polar.indexing.index_pq
+    V = buffer.vmag .* exp.(im .* buffer.vang)
+    return active_power_hessian(r, s, V, polar.network.Ybus, pv, pq, ref)
 end
 
 # ∂²qg / ∂²x * λ
@@ -270,8 +302,9 @@ function reactive_power_hessian(::Control, ::Control, V, Ybus, λ, pv, pq, ref, 
     H22 = Qvv[pv, pv]
 
     H = [
-        H11  H12
-        H12' H22
+         H11  H12 spzeros(nref, npv)
+         H12' H22 spzeros(npv, npv)
+         spzeros(npv, nref + 2* npv)
     ]
 
     return H
@@ -304,8 +337,23 @@ function reactive_power_hessian(::State, ::Control, V, Ybus, λ, pv, pq, ref, ig
     H = [
         H11  H12  H13
         H21  H22  H23
+        spzeros(npv, 2*npq+npv)
     ]
 
     return H
+end
+
+function reactive_power_hessian(
+    polar::PolarForm,
+    r::AbstractVariable,
+    s::AbstractVariable,
+    buffer::PolarNetworkState,
+    λ::AbstractVector,
+)
+    ref = polar.indexing.index_ref
+    pv = polar.indexing.index_pv
+    pq = polar.indexing.index_pq
+    V = buffer.vmag .* exp.(im .* buffer.vang)
+    return reactive_power_hessian(r, s, V, polar.network.Ybus, λ, pv, pq, ref, igen)
 end
 

--- a/src/polar/hessians.jl
+++ b/src/polar/hessians.jl
@@ -252,17 +252,13 @@ function active_power_hessian(
 end
 
 # ∂²qg / ∂²x * λ
-function reactive_power_hessian(::State, ::State, V, Ybus, λ, pv, pq, ref, igen)
+function reactive_power_hessian(::State, ::State, V, Ybus, λ, pv, pq, ref)
     n = length(V)
     npv = length(pv)
     npq = length(pq)
     nref = length(ref)
 
-    λp = zeros(n)
-    # Take only components wrt generators
-    λp[igen] .= λ
-
-    G11, G12, G22 = _matpower_hessian(V, Ybus, λp)
+    G11, G12, G22 = _matpower_hessian(V, Ybus, λ)
     Qθθ = imag.(G11)
     Qvθ = imag.(G12)
     Qvv = imag.(G22)
@@ -283,18 +279,14 @@ function reactive_power_hessian(::State, ::State, V, Ybus, λ, pv, pq, ref, igen
 end
 
 # ∂²qg / ∂²u * λ
-function reactive_power_hessian(::Control, ::Control, V, Ybus, λ, pv, pq, ref, igen)
+function reactive_power_hessian(::Control, ::Control, V, Ybus, λ, pv, pq, ref)
     # decompose vector
     n = length(V)
     npv = length(pv)
     npq = length(pq)
     nref = length(ref)
 
-    λp = zeros(n)
-    # Take only components wrt generators
-    λp[igen] .= λ
-
-    G11, G12, G22 = _matpower_hessian(V, Ybus, λp)
+    G11, G12, G22 = _matpower_hessian(V, Ybus, λ)
     Qvv = imag.(G22)
 
     H11 = Qvv[ref, ref]
@@ -311,18 +303,14 @@ function reactive_power_hessian(::Control, ::Control, V, Ybus, λ, pv, pq, ref, 
 end
 
 # ∂²qg / ∂x∂u * λ
-function reactive_power_hessian(::State, ::Control, V, Ybus, λ, pv, pq, ref, igen)
+function reactive_power_hessian(::State, ::Control, V, Ybus, λ, pv, pq, ref)
     # decompose vector
     n = length(V)
     npv = length(pv)
     npq = length(pq)
     nref = length(ref)
 
-    λp = zeros(n)
-    # Take only components wrt generators
-    λp[igen] .= λ
-
-    G11, G12, G22 = _matpower_hessian(V, Ybus, λp)
+    G11, G12, G22 = _matpower_hessian(V, Ybus, λ)
     Qθθ = imag.(G11)
     Qvθ = imag.(transpose(G12))
     Qvv = imag.(G22)

--- a/test/Evaluators/auglag.jl
+++ b/test/Evaluators/auglag.jl
@@ -98,20 +98,22 @@ end
             grad_fd = FiniteDiff.finite_difference_gradient(reduced_cost, u)
             @test isapprox(grad_fd, g, rtol=1e-6)
 
-            # Test Hessian only on AugLagEvaluator
-            n = length(u)
-            ExaPF.update!(pen, u)
-            hv = similar(u) ; fill!(hv, 0)
-            w = similar(u) ; fill!(w, 0)
-            w[1] = 1
-            ExaPF.hessprod!(pen, hv, u, w)
-            H = similar(u, n, n) ; fill!(H, 0)
-            ExaPF.hessian!(pen, H, u)
-            # Is Hessian vector product relevant?
-            @test H * w == hv
-            # Is Hessian correct?
-            hess_fd = FiniteDiff.finite_difference_hessian(reduced_cost, u)
-            @test isapprox(H, hess_fd, rtol=1e-6)
+            # Test Hessian only on ReducedSpaceEvaluator
+            if isa(nlp, ExaPF.ReducedSpaceEvaluator)
+                n = length(u)
+                ExaPF.update!(pen, u)
+                hv = similar(u) ; fill!(hv, 0)
+                w = similar(u) ; fill!(w, 0)
+                w[1] = 1
+                ExaPF.hessprod!(pen, hv, u, w)
+                H = similar(u, n, n) ; fill!(H, 0)
+                ExaPF.hessian!(pen, H, u)
+                # Is Hessian vector product relevant?
+                @test H * w == hv
+                # Is Hessian correct?
+                hess_fd = FiniteDiff.finite_difference_hessian(reduced_cost, u)
+                @test isapprox(H, hess_fd, rtol=1e-6)
+            end
         end
     end
 end

--- a/test/Evaluators/auglag.jl
+++ b/test/Evaluators/auglag.jl
@@ -99,7 +99,7 @@ end
             @test isapprox(grad_fd, g, rtol=1e-6)
 
             # Test Hessian only on ReducedSpaceEvaluator
-            if isa(nlp, ExaPF.ReducedSpaceEvaluator)
+            if isa(nlp, ExaPF.ReducedSpaceEvaluator) || isa(nlp, ExaPF.SlackEvaluator)
                 n = length(u)
                 ExaPF.update!(pen, u)
                 hv = similar(u) ; fill!(hv, 0)

--- a/test/Evaluators/reduced_evaluator.jl
+++ b/test/Evaluators/reduced_evaluator.jl
@@ -24,7 +24,8 @@
         x0 = ExaPF.initial(polar, State())
         u0 = ExaPF.initial(polar, Control())
 
-        nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0)
+        constraints = Function[ExaPF.state_constraint]
+        nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0; constraints=constraints)
         # Test printing
         println(devnull, nlp)
 
@@ -72,7 +73,7 @@
             return ExaPF.objective(nlp, u_)
         end
         grad_fd = FiniteDiff.finite_difference_gradient(reduced_cost, u)
-        @test isapprox(grad_fd, g, rtol=1e-4)
+        @test isapprox(grad_fd, g, rtol=1e-6)
 
         # Hessian
         ExaPF.update!(nlp, u)
@@ -86,13 +87,7 @@
         @test H * w == hv
         # Is Hessian correct?
         hess_fd = FiniteDiff.finite_difference_hessian(reduced_cost, u)
-        @test isapprox(H, hess_fd, rtol=1e-2)
-
-        # Hessian-Lagrangian
-        y = similar(u, m) ; fill!(y, 1)
-        ExaPF.hessprod_lagrangian!(nlp, hv, u, y, w)
-        ExaPF.hessian_lagrangian!(nlp, H, u, y)
-        @test H * w == hv
+        @test isapprox(H, hess_fd, rtol=1e-6)
 
         # Constraint
         ## Evaluation of the constraints

--- a/test/Evaluators/reduced_evaluator.jl
+++ b/test/Evaluators/reduced_evaluator.jl
@@ -75,19 +75,21 @@
         grad_fd = FiniteDiff.finite_difference_gradient(reduced_cost, u)
         @test isapprox(grad_fd, g, rtol=1e-6)
 
-        # Hessian
-        ExaPF.update!(nlp, u)
-        hv = similar(u) ; fill!(hv, 0)
-        w = similar(u) ; fill!(w, 0)
-        w[1] = 1
-        ExaPF.hessprod!(nlp, hv, u, w)
-        H = similar(u, n, n) ; fill!(H, 0)
-        ExaPF.hessian!(nlp, H, u)
-        # Is Hessian vector product relevant?
-        @test H * w == hv
-        # Is Hessian correct?
-        hess_fd = FiniteDiff.finite_difference_hessian(reduced_cost, u)
-        @test isapprox(H, hess_fd, rtol=1e-6)
+        # Hessian (only supported on CPU)
+        if isa(device, CPU)
+            ExaPF.update!(nlp, u)
+            hv = similar(u) ; fill!(hv, 0)
+            w = similar(u) ; fill!(w, 0)
+            w[1] = 1
+            ExaPF.hessprod!(nlp, hv, u, w)
+            H = similar(u, n, n) ; fill!(H, 0)
+            ExaPF.hessian!(nlp, H, u)
+            # Is Hessian vector product relevant?
+            @test H * w == hv
+            # Is Hessian correct?
+            hess_fd = FiniteDiff.finite_difference_hessian(reduced_cost, u)
+            @test isapprox(H, hess_fd, rtol=1e-6)
+        end
 
         # Constraint
         ## Evaluation of the constraints

--- a/test/Evaluators/reduced_evaluator.jl
+++ b/test/Evaluators/reduced_evaluator.jl
@@ -108,14 +108,20 @@
         ## Evaluation of the Jacobian (only on CPU)
         if isa(device, CPU)
             jac = M{Float64, 2}(undef, m, n)
-            fill!(jac, 0)
             ExaPF.jacobian!(nlp, jac, u)
+            # Test transpose Jacobian vector product
             @test isapprox(g, transpose(jac) * v)
+            # Test Jacobian vector product
+            S = typeof(u)
+            jv = ExaPF.xzeros(S, m)
+            v = ExaPF.xzeros(S, n)
+            ExaPF.jprod!(nlp, jv, u, v)
+            @test jac * v == jv
         end
 
         # Utils
         inf_pr1 = ExaPF.primal_infeasibility(nlp, u)
-        inf_pr2 = ExaPF.primal_infeasibility!(nlp, v, u)
+        inf_pr2 = ExaPF.primal_infeasibility!(nlp, cons, u)
         @test inf_pr1 == inf_pr2
 
         # test reset!

--- a/test/Polar/hessian.jl
+++ b/test/Polar/hessian.jl
@@ -195,11 +195,34 @@ const PS = PowerSystem
         ##################################################
         # h1 (state)      : xl <= x <= xu
         # h2 (by-product) : yl <= y <= yu
+        # Test sequential evaluation of Hessian
+        local ∂₂Q
         for cons in [ExaPF.state_constraint, ExaPF.power_constraints]
             m = ExaPF.size_constraint(polar, cons)
             λq = ones(m)
             ∂₂Q = ExaPF.hessian(polar, cons, ∂obj, cache, λq)
         end
+
+        μ = rand(ngen+1)
+        ∂₂Q = ExaPF.hessian(polar, ExaPF.power_constraints, ∂obj, cache, μ)
+        function jac_x(z)
+            x_ = z[1:nx]
+            u_ = z[1+nx:end]
+            # Transfer control
+            ExaPF.transfer!(polar, cache, u_)
+            # Transfer state (manually)
+            cache.vang[pv] .= x_[1:npv]
+            cache.vang[pq] .= x_[npv+1:npv+npq]
+            cache.vmag[pq] .= x_[npv+npq+1:end]
+            ExaPF.update!(polar, PS.Generator(), PS.ActivePower(), cache)
+            J = ExaPF.jacobian(polar, ExaPF.power_constraints, cache)
+            return [J.x J.u]' * μ
+        end
+
+        H_fd = FiniteDiff.finite_difference_jacobian(jac_x, [x; u])
+        @test isapprox(∂₂Q.uu, H_fd[nx+1:end, nx+1:end], rtol=1e-6)
+        @test isapprox(∂₂Q.xx, H_fd[1:nx, 1:nx], rtol=1e-6)
+        @test isapprox(∂₂Q.xu, H_fd[nx+1:end, 1:nx], rtol=1e-6)
     end
 end
 


### PR DESCRIPTION
- implement the reduced Hessian for the `ReducedSpaceEvaluator`, using the second order derivatives of Matpower
- add a function to compute the Hessian of the `AugLagEvaluator`, in case we have *only* inequality constraints. This is not satisfactory, and should be resolved in a future PR.
- currently works only on the CPU, and is not well optimized. Future improvements are expected.

