### PR TITLE
[Evaluators] Improve compile time by fixing type inference issue

### DIFF
--- a/src/Evaluators/proxal_evaluators.jl
+++ b/src/Evaluators/proxal_evaluators.jl
@@ -18,48 +18,46 @@ Evaluator wrapping a `ReducedSpaceEvaluator` for use inside
 decomposition algorithm implemented in [ProxAL.jl](https://github.com/exanauts/ProxAL.jl).
 
 """
-mutable struct ProxALEvaluator{T} <: AbstractNLPEvaluator
-    inner::ReducedSpaceEvaluator{T}
-    s_min::AbstractVector{T}
-    s_max::AbstractVector{T}
+mutable struct ProxALEvaluator{T, VI, VT, MT} <: AbstractNLPEvaluator
+    inner::ReducedSpaceEvaluator{T, VI, VT, MT}
+    s_min::VT
+    s_max::VT
     nu::Int
     ng::Int
     # Augmented penalties parameters
     time::ProxALTime
     scale_objective::T
     τ::T
-    λf::AbstractVector{T}
-    λt::AbstractVector{T}
+    λf::VT
+    λt::VT
     ρf::T
     ρt::T
-    pg_f::AbstractVector{T}
-    pg_ref::AbstractVector{T}
-    pg_t::AbstractVector{T}
+    pg_f::VT
+    pg_ref::VT
+    pg_t::VT
     # Buffer
-    ramp_link_prev::AbstractVector{T}
-    ramp_link_next::AbstractVector{T}
+    ramp_link_prev::VT
+    ramp_link_next::VT
 end
 function ProxALEvaluator(
-    nlp::ReducedSpaceEvaluator,
+    nlp::ReducedSpaceEvaluator{T, VI, VT, MT},
     time::ProxALTime;
     τ=0.1, ρf=0.1, ρt=0.1, scale_obj=1.0,
-)
-    S = type_array(nlp)
-
+) where {T, VI, VT, MT}
     nu = n_variables(nlp)
     ng = get(nlp, PS.NumberOfGenerators())
 
-    s_min = xzeros(S, ng)
-    s_max = xones(S, ng)
-    λf = xzeros(S, ng)
-    λt = xzeros(S, ng)
+    s_min = xzeros(VT, ng)
+    s_max = xones(VT, ng)
+    λf = xzeros(VT, ng)
+    λt = xzeros(VT, ng)
 
-    pgf = xzeros(S, ng)
-    pgc = xzeros(S, ng)
-    pgt = xzeros(S, ng)
+    pgf = xzeros(VT, ng)
+    pgc = xzeros(VT, ng)
+    pgt = xzeros(VT, ng)
 
-    ramp_link_prev = xzeros(S, ng)
-    ramp_link_next = xzeros(S, ng)
+    ramp_link_prev = xzeros(VT, ng)
+    ramp_link_next = xzeros(VT, ng)
 
     return ProxALEvaluator(
         nlp, s_min, s_max, nu, ng, time, scale_obj, τ, λf, λt, ρf, ρt,

--- a/src/ExaPF.jl
+++ b/src/ExaPF.jl
@@ -34,6 +34,7 @@ const VERBOSE_LEVEL_NONE = 0
 const TIMER = TimerOutput()
 
 include("utils.jl")
+include("architectures.jl")
 # Templates
 include("models.jl")
 

--- a/src/architectures.jl
+++ b/src/architectures.jl
@@ -1,0 +1,14 @@
+
+abstract type AbstractArchitecture end
+
+array_type(::KA.CPU) = Array
+array_type(::KA.CUDADevice) = CUDA.CuArray
+
+# norm
+xnorm(x::AbstractVector) = norm(x, 2)
+xnorm(x::CUDA.CuVector) = CUBLAS.nrm2(x)
+
+# Array initialization
+xzeros(S, n) = fill!(S(undef, n), zero(eltype(S)))
+xones(S, n) = fill!(S(undef, n), one(eltype(S)))
+

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -382,10 +382,5 @@ function residual_jacobian!(arrays::Jacobian,
     return nothing
 end
 
-function Base.show(io::IO, jacobian::AbstractJacobian)
-    ncolor = size(unique(jacobian.coloring), 1)
-    print(io, "Number of Jacobian colors: ", ncolor)
-end
-
 
 end

--- a/src/polar/getters.jl
+++ b/src/polar/getters.jl
@@ -1,10 +1,10 @@
 
 function get!(
-    polar::PolarForm{T, IT, VT, AT},
+    polar::PolarForm{T, IT, VT, MT},
     ::State,
     x::AbstractVector,
     buffer::PolarNetworkState
-) where {T, IT, VT, AT}
+) where {T, IT, VT, MT}
     npv = PS.get(polar.network, PS.NumberOfPVBuses())
     npq = PS.get(polar.network, PS.NumberOfPQBuses())
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())
@@ -19,13 +19,13 @@ function get!(
 end
 
 function get(
-    polar::PolarForm{T, IT, VT, AT},
+    polar::PolarForm{T, IT, VT, MT},
     ::State,
     vmag::VT,
     vang::VT,
     pbus::VT,
     qbus::VT,
-) where {T, IT, VT, AT}
+) where {T, IT, VT, MT}
     npv = PS.get(polar.network, PS.NumberOfPVBuses())
     npq = PS.get(polar.network, PS.NumberOfPQBuses())
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())
@@ -39,13 +39,13 @@ function get(
     return x
 end
 function get(
-    polar::PolarForm{T, IT, VT, AT},
+    polar::PolarForm{T, IT, VT, MT},
     ::Control,
     vmag::VT,
     vang::VT,
     pbus::VT,
     qbus::VT,
-) where {T, IT, VT, AT}
+) where {T, IT, VT, MT}
     npv = PS.get(polar.network, PS.NumberOfPVBuses())
     npq = PS.get(polar.network, PS.NumberOfPQBuses())
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())
@@ -61,8 +61,8 @@ function get(
     return u
 end
 function get(
-    polar::PolarForm{T, IT, VT, AT}, ::Control, buffer::PolarNetworkState,
-) where {T, IT, VT, AT}
+    polar::PolarForm{T, IT, VT, MT}, ::Control, buffer::PolarNetworkState,
+) where {T, IT, VT, MT}
     npv = PS.get(polar.network, PS.NumberOfPVBuses())
     npq = PS.get(polar.network, PS.NumberOfPQBuses())
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())

--- a/src/polar/gradients.jl
+++ b/src/polar/gradients.jl
@@ -1,3 +1,8 @@
+struct FullSpaceJacobian{SpM}
+    x::SpM
+    u::SpM
+end
+
 function _matpower_residual_jacobian(V, Ybus)
     n = size(V, 1)
     Ibus = Ybus*V

--- a/src/polar/hessians.jl
+++ b/src/polar/hessians.jl
@@ -1,3 +1,9 @@
+struct FullSpaceHessian{SpMT}
+    xx::SpMT
+    xu::SpMT
+    uu::SpMT
+end
+
 # Hessian vector-product H*λ, H = Jₓₓ (from Matpower)
 # Suppose ordering is correct
 function _matpower_hessian(V, Ybus, λ)
@@ -60,7 +66,7 @@ function residual_hessian(V, Ybus, λ, pv, pq, ref)
         H11  H12  H13
         H12' H22  H23
         H13' H23' H33
-    ]
+    ]::SparseMatrixCSC{Float64, Int}
 
     # w.r.t. uu
     H11 = Pvv[ref, ref] + Qvv[ref, ref]
@@ -71,7 +77,7 @@ function residual_hessian(V, Ybus, λ, pv, pq, ref)
          H11  H12 spzeros(nref, npv)
          H12' H22 spzeros(npv, npv)
          spzeros(npv, nref + 2 * npv)
-    ]
+    ]::SparseMatrixCSC{Float64, Int}
 
     # w.r.t. xu
     Pvθ = real.(transpose(Gp12))
@@ -87,9 +93,9 @@ function residual_hessian(V, Ybus, λ, pv, pq, ref)
         H11  H12  H13
         H21  H22  H23
         spzeros(npv, npv + 2 * npq)
-    ]
+    ]::SparseMatrixCSC{Float64, Int}
 
-    return (xx=Hxx, xu=Hxu, uu=Huu)
+    return FullSpaceHessian(Hxx, Hxu, Huu)
 end
 
 function residual_hessian(
@@ -134,7 +140,7 @@ function active_power_hessian(V, Ybus, pv, pq, ref)
         H11  H12  H13
         H12' H22  H23
         H13' H23' H33
-    ]
+    ]::SparseMatrixCSC{Float64, Int}
 
     # w.r.t. uu
     H11 = Pvv[ref, ref]
@@ -145,7 +151,7 @@ function active_power_hessian(V, Ybus, pv, pq, ref)
          H11  H12 spzeros(nref, npv)
          H12' H22 spzeros(npv, npv)
          spzeros(npv, nref + 2 * npv)
-    ]
+    ]::SparseMatrixCSC{Float64, Int}
 
     # w.r.t. xu
     Pvθ = real.(transpose(G12))
@@ -161,9 +167,9 @@ function active_power_hessian(V, Ybus, pv, pq, ref)
         H11  H12  H13
         H21  H22  H23
         spzeros(npv, npv + 2 * npq)
-    ]
+    ]::SparseMatrixCSC{Float64, Int}
 
-    return (xx=Hxx, xu=Hxu, uu=Huu)
+    return FullSpaceHessian(Hxx, Hxu, Huu)
 end
 
 function active_power_hessian(
@@ -200,7 +206,7 @@ function reactive_power_hessian(V, Ybus, λ, pv, pq, ref)
         H11  H12  H13
         H12' H22  H23
         H13' H23' H33
-    ]
+    ]::SparseMatrixCSC{Float64, Int}
 
     H11 = Qvv[ref, ref]
     H12 = Qvv[ref, pv]
@@ -210,7 +216,7 @@ function reactive_power_hessian(V, Ybus, λ, pv, pq, ref)
          H11  H12 spzeros(nref, npv)
          H12' H22 spzeros(npv, npv)
          spzeros(npv, nref + 2* npv)
-    ]
+    ]::SparseMatrixCSC{Float64, Int}
 
     Pvθ = real.(transpose(G12))
     Qvθ = imag.(transpose(G12))
@@ -225,8 +231,8 @@ function reactive_power_hessian(V, Ybus, λ, pv, pq, ref)
         H11  H12  H13
         H21  H22  H23
         spzeros(npv, 2*npq+npv)
-    ]
-    return (xx=Hxx, xu=Hxu, uu=Huu)
+    ]::SparseMatrixCSC{Float64, Int}
+    return FullSpaceHessian(Hxx, Hxu, Huu)
 end
 
 function reactive_power_hessian(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,14 +33,6 @@ mutable struct Spmat{VTI<:AbstractVector, VTF<:AbstractVector}
     end
 end
 
-# norm
-xnorm(x::AbstractVector) = norm(x, 2)
-xnorm(x::CUDA.CuVector) = CUBLAS.nrm2(x)
-
-# Array initialization
-xzeros(S, n) = fill!(S(undef, n), zero(eltype(S)))
-xones(S, n) = fill!(S(undef, n), one(eltype(S)))
-
 # projection operator
 function project!(w::VT, u::VT, u♭::VT, u♯::VT) where VT<:AbstractArray
     w .= max.(min.(u, u♯), u♭)

--- a/test/Evaluators/proxal_evaluator.jl
+++ b/test/Evaluators/proxal_evaluator.jl
@@ -18,7 +18,7 @@ import ExaPF: PS
 
     # Build reference evaluator
     nlp = ExaPF.ReducedSpaceEvaluator(datafile)
-    S = ExaPF.type_array(nlp)
+    S = ExaPF.array_type(nlp)
 
     u0 = ExaPF.initial(nlp)
     # Build ProxAL evaluator
@@ -64,12 +64,12 @@ import ExaPF: PS
 
     @testset "Constraints" begin
         m_I = ExaPF.n_constraints(prox)
-        cons = ExaPF.xzeros(S, m_I)
+        cons = similar(w, m_I) ; fill!(cons, 0)
         # Evaluate constraints
         ExaPF.constraint!(prox, cons, w)
         # Transpose Jacobian vector product
-        v = ExaPF.xzeros(S, m_I)
-        jv = ExaPF.xzeros(S, n)
+        v = similar(w, m_I) ; fill!(v, 0)
+        jv = similar(w, n) ; fill!(jv, 0)
         ExaPF.jtprod!(prox, jv, w, v)
 
         # Jacobian structure

--- a/test/Evaluators/reduced_evaluator.jl
+++ b/test/Evaluators/reduced_evaluator.jl
@@ -8,12 +8,6 @@
     @testset "Constructor" for (device, M) in ITERATORS
         powerflow_solver = NewtonRaphson(; tol=1e-11)
         nlp = ExaPF.ReducedSpaceEvaluator(datafile; device=device, powerflow_solver=powerflow_solver)
-        TNLP = typeof(nlp)
-        for (fn, ft) in zip(fieldnames(TNLP), fieldtypes(TNLP))
-            if ft <: AbstractArray{Float64, P} where P
-                @test isa(getfield(nlp, fn), M)
-            end
-        end
         # Test that arguments are passed as expected in the constructor:
         @test nlp.powerflow_solver == powerflow_solver
     end
@@ -29,14 +23,6 @@
         # Test printing
         println(devnull, nlp)
 
-        # Test evaluator is well instantiated on target device
-        TNLP = typeof(nlp)
-        for (fn, ft) in zip(fieldnames(TNLP), fieldtypes(TNLP))
-            if ft <: AbstractArray{Float64, P} where P
-                @test isa(getfield(nlp, fn), M)
-            end
-        end
-
         # Test consistence
         n_state = get(polar, NumberOfState())
         @test length(nlp.λ) == n_state
@@ -44,7 +30,6 @@
         m = ExaPF.n_constraints(nlp)
         @test n == length(u0)
         @test isless(nlp.u_min, nlp.u_max)
-        @test isless(nlp.x_min, nlp.x_max)
         @test isless(nlp.g_min, nlp.g_max)
         @test length(nlp.g_min) == m
 


### PR DESCRIPTION
Before that PR, the compile time was on Julia 1.6: 
```julia
julia> @time ExaPF.hessprod!(nlp, hv, u, v)
106.405218 seconds (490.52 M allocations: 30.982 GiB, 6.66% gc time, 99.99% compilation time) 
```

After that PR: 
```julia
julia> @time ExaPF.hessprod!(nlp, hv, u, v)
  6.306416 seconds (6.84 M allocations: 388.304 MiB, 3.07% gc time, 99.91% compilation time)   
```

For some reason, the compile time is still reasonable in Julia 1.5.3...