### PR TITLE
Implement Hessian-vector product in MOI wrapper

### DIFF
--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -257,9 +257,10 @@ function reset! end
 
 include("common.jl")
 
-# Based evaluators
+# Basic evaluators
 include("reduced_evaluator.jl")
 include("slack_evaluator.jl")
+include("feasibility_evaluator.jl")
 include("proxal_evaluators.jl")
 
 # Penalty evaluators

--- a/src/Evaluators/MOI_wrapper.jl
+++ b/src/Evaluators/MOI_wrapper.jl
@@ -12,8 +12,8 @@ Bridge from a `ExaPF.AbstractNLPEvaluator` to a `MOI.AbstractNLPEvaluator`.
 * `has_hess::Bool` (default: `false`): if `true`, pass a Hessian structure to MOI.
 
 """
-mutable struct MOIEvaluator <: MOI.AbstractNLPEvaluator
-    nlp::AbstractNLPEvaluator
+mutable struct MOIEvaluator{Evaluator<:AbstractNLPEvaluator} <: MOI.AbstractNLPEvaluator
+    nlp::Evaluator
     hash_x::UInt
     has_hess::Bool
 end
@@ -78,7 +78,6 @@ function MOI.eval_hessian_lagrangian(ev::MOIEvaluator, H, x, σ, μ)
     n = n_variables(ev.nlp)
     hess = zeros(n, n)
     g = @view hess[1, :]
-    gradient!(ev.nlp, g, x)
     hessian!(ev.nlp, hess, x)
     # Copy back to the MOI arrray
     rows, cols = hessian_structure(ev.nlp)

--- a/src/Evaluators/MOI_wrapper.jl
+++ b/src/Evaluators/MOI_wrapper.jl
@@ -89,6 +89,12 @@ function MOI.eval_hessian_lagrangian(ev::MOIEvaluator, H, x, σ, μ)
     end
 end
 
+function MOI.eval_hessian_lagrangian_product(ev::MOIEvaluator, hv, x, v, σ, μ)
+    _update!(ev, x)
+    hessprod!(ev.nlp, hv, x, v)
+    hv .*= σ
+end
+
 function MOI.NLPBlockData(nlp::AbstractNLPEvaluator)
     lb, ub = bounds(nlp, Constraints())
     ev = MOIEvaluator(nlp)

--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -166,6 +166,21 @@ function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
     return
 end
 
+function hessian!(ag::AugLagEvaluator, hess, u)
+    base_nlp = ag.inner
+    scaler = ag.scaler
+    # Import AutoDiff objects
+    autodiff = get(base_nlp, AutoDiffBackend())
+    cx = ag.cons
+    mask = abs.(cx) .> 0
+
+    σ = scaler.scale_obj
+    y = scaler.scale_cons .* ag.λc .* mask
+    z = ag.ρ .* scaler.scale_cons .* scaler.scale_cons .* mask
+
+    hessian_lagrangian_penalty!(base_nlp, hess, u, y, σ, z)
+end
+
 function estimate_multipliers(ag::AugLagEvaluator, u)
     J = Diagonal(ag.scaler.scale_cons) * jacobian(ag.inner, u)
     ∇f = gradient(ag.inner, u)

--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -166,6 +166,14 @@ function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
     return
 end
 
+function estimate_multipliers(ag::AugLagEvaluator, u)
+    J = Diagonal(ag.scaler.scale_cons) * jacobian(ag.inner, u)
+    ∇f = gradient(ag.inner, u)
+    ∇f .*= ag.scaler.scale_obj
+    λ = - (J * J') \ (J * ∇f)
+    return λ
+end
+
 function reset!(ag::AugLagEvaluator)
     reset!(ag.inner)
     empty!(ag.counter)

--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -154,6 +154,7 @@ function gradient!(ag::AugLagEvaluator, grad, u)
 end
 
 function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
+    ag.counter.hprod += 1
     scaler = ag.scaler
     cx = ag.cons
     mask = abs.(cx) .> 0
@@ -167,6 +168,7 @@ function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
 end
 
 function hessian!(ag::AugLagEvaluator, hess, u)
+    ag.counter.hessian += 1
     base_nlp = ag.inner
     scaler = ag.scaler
     # Import AutoDiff objects

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -1,3 +1,18 @@
+# Common interface for AbstractNLPEvaluator
+#
+function Base.show(io::IO, nlp::AbstractNLPEvaluator)
+    n = n_variables(nlp)
+    m = n_constraints(nlp)
+    println(io, "A Evaluator object")
+    println(io, "    * #vars: ", n)
+    println(io, "    * #cons: ", m)
+end
+
+function constraint(nlp::AbstractNLPEvaluator, x)
+    cons = similar(x, n_constraints(nlp)) ; fill!(cons, 0)
+    constraint!(nlp, cons, x)
+    return cons
+end
 
 function gradient(nlp::AbstractNLPEvaluator, x)
     ∇f = similar(x) ; fill!(∇f, 0)
@@ -68,6 +83,17 @@ struct AutoDiffFactory{VT} <: AbstractAutoDiffFactory
     Jgₓ::AutoDiff.Jacobian
     Jgᵤ::AutoDiff.Jacobian
     ∇f::AdjointStackObjective{VT}
+end
+
+struct HessianFactory{SpMT}
+    hashu::UInt64
+    fac::Factorization
+    ∇²f::FullSpaceHessian{SpMT}
+    ∇²g::FullSpaceHessian{SpMT}
+end
+struct JacobianFactory{MT}
+    hashu::UInt64
+    J::MT
 end
 
 # Counters

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -1,11 +1,24 @@
 
+function gradient(nlp::AbstractNLPEvaluator, x)
+    ∇f = similar(x) ; fill!(∇f, 0)
+    gradient!(nlp, ∇f, x)
+    return ∇f
+end
+
+function jacobian(nlp::AbstractNLPEvaluator, x)
+    n = n_variables(nlp)
+    m = n_constraints(nlp)
+    J = similar(x, m, n) ; fill!(J, 0)
+    jacobian!(nlp, J, x)
+    return J
+end
+
 # Default implementation of jprod!, using full Jacobian matrix
 function jprod!(nlp::AbstractNLPEvaluator, jv, u, v)
     nᵤ = length(u)
     m  = n_constraints(nlp)
     @assert nᵤ == length(v)
-    jac = similar(jv, m, nᵤ)
-    jacobian!(nlp, jac, u)
+    jac = jacobian(nlp, u)
     mul!(jv, jac, v)
     return
 end
@@ -28,6 +41,13 @@ function hessian!(nlp::AbstractNLPEvaluator, H, x)
         v[i] = 1.0
         hessprod!(nlp, view(H, :, i), x, v)
     end
+end
+
+function hessian(nlp::AbstractNLPEvaluator, x)
+    n = n_variables(nlp)
+    H = similar(x, n, n) ; fill!(H, 0)
+    hessian!(nlp, H, x)
+    return H
 end
 
 function hessian_lagrangian_penalty_prod!(

--- a/src/Evaluators/feasibility_evaluator.jl
+++ b/src/Evaluators/feasibility_evaluator.jl
@@ -1,0 +1,95 @@
+
+"""
+    FeasibilityEvaluator{T} <: AbstractNLPEvaluator
+
+TODO
+
+"""
+mutable struct FeasibilityEvaluator{T} <: AbstractNLPEvaluator
+    inner::AbstractNLPEvaluator
+    x_min::AbstractVector{T}
+    x_max::AbstractVector{T}
+    cons::AbstractVector{T}
+end
+function FeasibilityEvaluator(nlp::AbstractNLPEvaluator)
+    if !is_constrained(nlp)
+        error("Input problem must have inequality constraints")
+    end
+    x_min, x_max = bounds(nlp.inner, Variables())
+    cx = similar(x_min, n_constraints(nlp.inner))
+    return FeasibilityEvaluator(nlp, x_min, x_max, cx)
+end
+function FeasibilityEvaluator(datafile::String)
+    nlp = SlackEvaluator(datafile)
+    if !is_constrained(nlp)
+        error("Input problem must have inequality constraints")
+    end
+    x_min, x_max = bounds(nlp.inner, Variables())
+    cx = similar(x_min, n_constraints(nlp.inner))
+    return FeasibilityEvaluator(nlp, x_min, x_max, cx)
+end
+
+n_variables(nlp::FeasibilityEvaluator) = n_variables(nlp.inner)
+n_constraints(nlp::FeasibilityEvaluator) = 0
+
+constraints_type(::FeasibilityEvaluator) = :bound
+
+# Getters
+get(nlp::FeasibilityEvaluator, attr::AbstractNLPAttribute) = get(nlp.inner, attr)
+get(nlp::FeasibilityEvaluator, attr::AbstractVariable) = get(nlp.inner, attr)
+get(nlp::FeasibilityEvaluator, attr::PS.AbstractNetworkAttribute) = get(nlp.inner, attr)
+
+# Setters
+function setvalues!(nlp::FeasibilityEvaluator, attr::PS.AbstractNetworkValues, values)
+    setvalues!(nlp.inner, attr, values)
+end
+
+# Bounds
+bounds(nlp::FeasibilityEvaluator, ::Variables) = bounds(nlp.inner, Variables())
+bounds(nlp::FeasibilityEvaluator, ::Constraints) = (Float64[], Float64[])
+
+initial(nlp::FeasibilityEvaluator) = initial(nlp.inner)
+
+function update!(nlp::FeasibilityEvaluator, u)
+    conv = update!(nlp.inner, u)
+    constraint!(nlp.inner, nlp.cons, u)
+    return conv
+end
+
+# f(x) = 0.5 * || c(x) ||²
+function objective(nlp::FeasibilityEvaluator, u)
+    return 0.5 * dot(nlp.cons, nlp.cons)
+end
+
+function constraint!(nlp::FeasibilityEvaluator, cons, u)
+    @assert length(cons) == 0
+    return
+end
+
+# Gradient
+# ∇f = J' * c(x)
+function gradient!(nlp::FeasibilityEvaluator, grad, u)
+    σ = 0.0
+    ojtprod!(nlp.inner, grad, u, 0.0, nlp.cons)
+end
+
+# H = ∇²c(x) + J'*J
+function hessprod!(nlp::FeasibilityEvaluator, hessvec, u, v)
+    σ = 0.0
+    # Need to update the first-order adjoint λ first
+    hessian_lagrangian_prod!(nlp.inner, hessvec, u, nlp.cons, σ, v)
+    J = jacobian(nlp.inner, u)
+    hessvec .+= J' * J * v
+end
+
+function hessian_structure(nlp::FeasibilityEvaluator)
+    n = n_variables(nlp)
+    rows = Int[r for r in 1:n for c in 1:r]
+    cols = Int[c for r in 1:n for c in 1:r]
+    return rows, cols
+end
+
+function reset!(nlp::FeasibilityEvaluator)
+    reset!(nlp.inner)
+end
+

--- a/src/Evaluators/penalty.jl
+++ b/src/Evaluators/penalty.jl
@@ -36,6 +36,7 @@ function jacobian!(ag::AbstractPenaltyEvaluator, jac, u)
     return
 end
 
+jacobian_structure(ag::AbstractPenaltyEvaluator) = (Int[], Int[])
 function jacobian_structure!(ag::AbstractPenaltyEvaluator, rows, cols)
     @assert length(rows) == length(cols) == 0
 end

--- a/src/polar/adjoints.jl
+++ b/src/polar/adjoints.jl
@@ -186,7 +186,7 @@ function ∂cost(polar::PolarForm, ∂obj::AdjointStackObjective, buffer::PolarN
     return
 end
 
-function hessian_cost(polar::PolarForm, ∂obj::AdjointStackObjective, buffer::PolarNetworkState)
+function hessian_cost(polar::PolarForm, buffer::PolarNetworkState)
     coefs = polar.costs_coefficients
     c3 = @view coefs[:, 3]
     c4 = @view coefs[:, 4]

--- a/src/polar/constraints.jl
+++ b/src/polar/constraints.jl
@@ -55,7 +55,7 @@ function jtprod(polar::PolarForm, ::typeof(state_constraints), ∂jac, buffer, v
     fill!(∂jac.∇fₓ, 0)
     ∂jac.∇fₓ[fr_:end] .= v
 end
-function hessian(polar::PolarForm, ::typeof(state_constraints), ∂jac, buffer, λ)
+function hessian(polar::PolarForm, ::typeof(state_constraints), buffer, λ)
     nu = get(polar, NumberOfControl())
     nx = get(polar, NumberOfState())
     return FullSpaceHessian(
@@ -250,7 +250,7 @@ function jtprod(
     ∂jac.∇fᵤ .= jvu
 end
 
-function hessian(polar::PolarForm, ::typeof(power_constraints), ∂jac, buffer, λ)
+function hessian(polar::PolarForm, ::typeof(power_constraints), buffer, λ)
     ref = polar.indexing.index_ref
     pv = polar.indexing.index_pv
     pq = polar.indexing.index_pq

--- a/test/Evaluators/MOI_wrapper.jl
+++ b/test/Evaluators/MOI_wrapper.jl
@@ -33,6 +33,6 @@ const MOI = MathOptInterface
     MOI.empty!(optimizer)
     @test solution.status ∈ [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
     @test solution.minimum ≈ 3.7589338e+04
-    @test solution.minimizer ≈ CASE57_SOLUTION atol=1e-6
+    @test solution.minimizer ≈ CASE57_SOLUTION rtol=1e-5
 end
 

--- a/test/Evaluators/auglag.jl
+++ b/test/Evaluators/auglag.jl
@@ -98,7 +98,7 @@ end
             grad_fd = FiniteDiff.finite_difference_gradient(reduced_cost, u)
             @test isapprox(grad_fd, g, rtol=1e-6)
 
-            # Test Hessian only on ReducedSpaceEvaluator
+            # Test Hessian only on ReducedSpaceEvaluator and SlackEvaluator
             if isa(nlp, ExaPF.ReducedSpaceEvaluator) || isa(nlp, ExaPF.SlackEvaluator)
                 n = length(u)
                 ExaPF.update!(pen, u)
@@ -113,6 +113,10 @@ end
                 # Is Hessian correct?
                 hess_fd = FiniteDiff.finite_difference_hessian(reduced_cost, u)
                 @test isapprox(H, hess_fd, rtol=1e-6)
+            end
+            # Test estimation of multipliers only on SlackEvaluator
+            if isa(nlp, ExaPF.SlackEvaluator)
+                λ = @time ExaPF.estimate_multipliers(pen, u)
             end
         end
     end

--- a/test/Evaluators/auglag.jl
+++ b/test/Evaluators/auglag.jl
@@ -66,6 +66,7 @@ end
         w♭, w♯ = ExaPF.bounds(nlp, ExaPF.Variables())
         # Build penalty evaluator
         for scaling in [true, false]
+            ExaPF.reset!(nlp)
             pen = ExaPF.AugLagEvaluator(nlp, u0; scale=scaling)
             u = w♭
             # Update nlp to stay on manifold
@@ -109,7 +110,7 @@ end
                 H = similar(u, n, n) ; fill!(H, 0)
                 ExaPF.hessian!(pen, H, u)
                 # Is Hessian vector product relevant?
-                @test H * w == hv
+                @test H * w ≈ hv
                 # Is Hessian correct?
                 hess_fd = FiniteDiff.finite_difference_hessian(reduced_cost, u)
                 @test isapprox(H, hess_fd, rtol=1e-6)

--- a/test/Evaluators/auglag.jl
+++ b/test/Evaluators/auglag.jl
@@ -116,7 +116,7 @@ end
             end
             # Test estimation of multipliers only on SlackEvaluator
             if isa(nlp, ExaPF.SlackEvaluator)
-                λ = @time ExaPF.estimate_multipliers(pen, u)
+                λ = ExaPF.estimate_multipliers(pen, u)
             end
         end
     end

--- a/test/Evaluators/interface.jl
+++ b/test/Evaluators/interface.jl
@@ -4,6 +4,7 @@
     ExaPF.AugLagEvaluator,
     ExaPF.ProxALEvaluator,
     ExaPF.SlackEvaluator,
+    ExaPF.FeasibilityEvaluator,
 ]
     datafile = joinpath(INSTANCES_DIR, "case9.m")
     # Default constructor: should take as input path to instance
@@ -63,7 +64,7 @@
         g = similar(u) ; fill!(g, 0)
         ExaPF.gradient!(nlp, g, u)
         grad_fd = FiniteDiff.finite_difference_gradient(reduced_cost, u)
-        @test isapprox(grad_fd, g, rtol=1e-5)
+        @test isapprox(g, grad_fd, rtol=1e-5)
 
         # 4/ Constraint
         ## Evaluation of the constraints
@@ -81,7 +82,12 @@
                 return dot(v, cons)
             end
             jv_fd = FiniteDiff.finite_difference_gradient(reduced_cons, u)
+
             @test isapprox(jv, jv_fd, rtol=1e-5)
+
+            # Jacobian
+            J =  ExaPF.jacobian(nlp, u)
+            @test J' * v ≈ jv
         end
     end
 end


### PR DESCRIPTION
- allows to use Hv product in ExaTron and Knitro
- Hessians in full-space are cached to avoid recomputing them each time we compute a `Hv` prod
- The structure `HessianFactory` should be adapted once #99 is merged 
- implement a new evaluator to compute a feasible point (`FeasibleEvaluator`) 
- also, fix type inference in `MOIEvaluator` 