### PR TITLE
Parallel CPU and improved GPU preconditioner

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -3,17 +3,22 @@ using ExaPF
 using KernelAbstractions
 using Test
 using Printf
+using TimerOutputs
 
-import ExaPF: PowerSystem, LinearSolvers, TimerOutputs
+import ExaPF: PowerSystem, LinearSolvers
+
+CUDA.device!(1)
 
 # For debugging in REPL use the following lines
-# empty!(ARGS)
-# push!(ARGS, "BICGSTAB")
-# push!(ARGS, "CUDADevice")
-# push!(ARGS, "caseGO30R-025.raw")
+empty!(ARGS)
+push!(ARGS, "KrylovBICGSTAB")
+push!(ARGS, "CUDADevice")
+# push!(ARGS, "case300.m")
+push!(ARGS, "caseGO30R-025.raw")
+
 
 # We do need the time in ms, and not with time units all over the place
-function ExaPF.TimerOutputs.prettytime(t)
+function TimerOutputs.prettytime(t)
     value = t / 1e6 # "ms"
 
     if round(value) >= 100
@@ -35,42 +40,41 @@ end
 linsolver = eval(Meta.parse("LinearSolvers.$(ARGS[1])"))
 device = eval(Meta.parse("$(ARGS[2])()"))
 datafile = joinpath(dirname(@__FILE__), ARGS[3])
-if endswith(datafile, ".m")
-    pf = PowerSystem.PowerNetwork(datafile, 1)
-else
-    pf = PowerSystem.PowerNetwork(datafile)
-end
+pf = PowerSystem.PowerNetwork(datafile)
 # Parameters
 tolerance = 1e-6
 polar = PolarForm(pf, device)
-jac = ExaPF._state_jacobian(polar)
-@show size(jac)
-@show npartitions = ceil(Int64,(size(jac,1)/64))
-precond = ExaPF.LinearSolvers.BlockJacobiPreconditioner(jac, npartitions, device)
+@show length(polar.statejacobianstructure.map)
+@show npartitions = ceil(Int64,(length(polar.statejacobianstructure.map)/64))
+cache = ExaPF.get(polar, ExaPF.PhysicalState())
+jx, ju, ∂obj = ExaPF.init_autodiff_factory(polar, cache)
+@show jx.J
+precond = ExaPF.LinearSolvers.BlockJacobiPreconditioner(jx.J, npartitions, device)
 # Retrieve initial state of network
 x0 = ExaPF.initial(polar, State())
 uk = ExaPF.initial(polar, Control())
-p = ExaPF.initial(polar, Parameters())
 
-algo = linsolver(precond)
+algo = linsolver(precond; rtol=1e-6, atol=1e-6, verbose=1)
 xk = copy(x0)
-nlp = ExaPF.ReducedSpaceEvaluator(polar, xk, uk, p;
-                                    ε_tol=tolerance, linear_solver=algo)
-convergence = ExaPF.update!(nlp, uk; verbose_level=ExaPF.VERBOSE_LEVEL_HIGH)
-nlp.x .= x0                                   
-convergence = ExaPF.update!(nlp, uk; verbose_level=ExaPF.VERBOSE_LEVEL_HIGH)
-nlp.x .= x0                                   
-ExaPF.reset_timer!(ExaPF.TIMER)
-convergence = ExaPF.update!(nlp, uk; verbose_level=ExaPF.VERBOSE_LEVEL_HIGH)
+powerflow_solver = NewtonRaphson(tol=1e-6, verbose=ExaPF.VERBOSE_LEVEL_HIGH)
+nlp = ExaPF.ReducedSpaceEvaluator(polar, xk, uk;
+                                    linear_solver=algo, powerflow_solver=powerflow_solver)
+convergence = ExaPF.update!(nlp, uk)
+ExaPF.reset!(nlp)                             
+convergence = ExaPF.update!(nlp, uk)
+ExaPF.reset!(nlp)                             
+TimerOutputs.reset_timer!(ExaPF.TIMER)
+convergence = ExaPF.update!(nlp, uk)
 
 # Make sure we are converged
 @assert(convergence.has_converged)
 
 # Output
-prettytime = ExaPF.TimerOutputs.prettytime
+prettytime = TimerOutputs.prettytime
 timers = ExaPF.TIMER.inner_timers
 inner_timer = timers["Newton"]
 println("$(ARGS[1]), $(ARGS[2]), $(ARGS[3]),", 
         printtimer(timers, "Newton"),",",
         printtimer(inner_timer, "Jacobian"),",",
         printtimer(inner_timer, "Linear Solver"))
+@show timers

--- a/src/polar/adjoints.jl
+++ b/src/polar/adjoints.jl
@@ -163,7 +163,7 @@ function put(
         put_active_power_injection!(bus, vmag, vang, adj_vmag, adj_vang, adj_inj, ybus_re, ybus_im)
     end
     if isa(adj_x, Array)
-        kernel! = put_adjoint_kernel!(KA.CPU(), 1)
+        kernel! = put_adjoint_kernel!(KA.CPU(), Threads.nthreads())
     else
         kernel! = put_adjoint_kernel!(KA.CUDADevice(), 256)
     end

--- a/src/polar/constraints.jl
+++ b/src/polar/constraints.jl
@@ -95,7 +95,7 @@ function power_constraints(polar::PolarForm, g, buffer)
         shift = nref
     end
     if isa(gg, Array)
-        kernel! = load_power_constraint_kernel!(KA.CPU(), 4)
+        kernel! = load_power_constraint_kernel!(KA.CPU(), Threads.nthreads())
     else
         kernel! = load_power_constraint_kernel!(KA.CUDADevice(), 256)
     end
@@ -180,7 +180,7 @@ function jacobian(
         put_reactive_power_injection!(bus, vmag, vang, adj_vmag, adj_vang, adj_inj, ybus_re, ybus_im)
     end
     if isa(adj_x, Array)
-        kernel! = put_adjoint_kernel!(KA.CPU(), 1)
+        kernel! = put_adjoint_kernel!(KA.CPU(), Threads.nthreads())
     else
         kernel! = put_adjoint_kernel!(KA.CUDADevice(), 256)
     end
@@ -285,7 +285,7 @@ function flow_constraints(polar::PolarForm, cons, buffer)
     if isa(cons, CUDA.CuArray)
         kernel! = branch_flow_kernel!(KA.CUDADevice(), 256)
     else
-        kernel! = branch_flow_kernel!(KA.CPU(), 1)
+        kernel! = branch_flow_kernel!(KA.CPU(), Threads.nthreads())
     end
     nlines = PS.get(polar.network, PS.NumberOfLines())
     ev = kernel!(
@@ -302,7 +302,7 @@ end
 function flow_constraints_grad!(polar::PolarForm, cons_grad, buffer, weights)
     T = typeof(buffer.vmag)
     if isa(buffer.vmag, Array)
-        kernel! = accumulate_view!(KA.CPU(), 1)
+        kernel! = accumulate_view!(KA.CPU(), Threads.nthreads())
     else
         kernel! = accumulate_view!(KA.CUDADevice(), 256)
     end
@@ -381,7 +381,7 @@ function jtprod(
     copyto!(adj_vmag, ∇Jv[1:nbus])
     copyto!(adj_vang, ∇Jv[nbus+1:2*nbus])
     if isa(adj_x, Array)
-        kernel! = put_adjoint_kernel!(KA.CPU(), 1)
+        kernel! = put_adjoint_kernel!(KA.CPU(), Threads.nthreads())
     else
         kernel! = put_adjoint_kernel!(KA.CUDADevice(), 256)
     end

--- a/src/polar/kernels.jl
+++ b/src/polar/kernels.jl
@@ -101,7 +101,7 @@ function residual_polar!(F, v_m, v_a,
     npv = length(pv)
     npq = length(pq)
     if isa(F, Array)
-        kernel! = residual_kernel!(KA.CPU(), 4)
+        kernel! = residual_kernel!(KA.CPU(), Threads.nthreads())
     else
         kernel! = residual_kernel!(KA.CUDADevice(), 256)
     end
@@ -187,7 +187,7 @@ function residual_adj_polar!(F, adj_F, v_m, adj_v_m, v_a, adj_v_a,
     npv = length(pv)
     npq = length(pq)
     if isa(F, Array)
-        kernel! = residual_adj_kernel!(KA.CPU(), 4)
+        kernel! = residual_adj_kernel!(KA.CPU(), Threads.nthreads())
     else
         kernel! = residual_adj_kernel!(KA.CUDADevice(), 256)
     end
@@ -227,7 +227,7 @@ function transfer!(polar::PolarForm, buffer::PolarNetworkState, u)
     if isa(u, CUDA.CuArray)
         kernel! = transfer_kernel!(KA.CUDADevice(), 256)
     else
-        kernel! = transfer_kernel!(KA.CPU(), 1)
+        kernel! = transfer_kernel!(KA.CPU(), Threads.nthreads())
     end
     nbus = length(buffer.vmag)
     pv = polar.indexing.index_pv
@@ -282,7 +282,7 @@ end
 # Refresh active power (needed to evaluate objective)
 function update!(polar::PolarForm, ::PS.Generator, ::PS.ActivePower, buffer::PolarNetworkState)
     if isa(buffer.vmag, Array)
-        kernel! = active_power_kernel!(KA.CPU(), 1)
+        kernel! = active_power_kernel!(KA.CPU(), Threads.nthreads())
     else
         kernel! = active_power_kernel!(KA.CUDADevice(), 256)
     end
@@ -342,7 +342,7 @@ end
 
 function update!(polar::PolarForm, ::PS.Generator, ::PS.ReactivePower, buffer::PolarNetworkState)
     if isa(buffer.vmag, Array)
-        kernel! = reactive_power_kernel!(KA.CPU(), 1)
+        kernel! = reactive_power_kernel!(KA.CPU(), Threads.nthreads())
     else
         kernel! = reactive_power_kernel!(KA.CUDADevice(), 256)
     end


### PR DESCRIPTION
* Set default number of threads for CPU KA to `Threads.nthreads()`
* GPU preconditioner is now one kernel per step instead of `nblock` kernels
* CPU preconditioner now also uses threads

This still requires some regression testing for performance. I hope it's an improvement.