### PR TITLE
Update benchmark script and KA everywhere

### DIFF
--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+REV=`git rev-parse HEAD`
 JULIA_BIN=julia
 # CPU Solvers
 for i in `ls case*` 
 do
   for j in DirectSolver
   do
-    $JULIA_BIN --project=.. benchmarks.jl $j CPU $i | tail -1 >> cpu.log
+    $JULIA_BIN --project=.. benchmarks.jl $j CPU $i | tail -1 >> cpu_$REV.log
   done
 done
 
@@ -15,6 +16,6 @@ for i in `ls case*`
 do
   for j in KrylovBICGSTAB DQGMRES BICGSTAB EigenBICGSTAB DirectSolver
   do
-    $JULIA_BIN --project=.. benchmarks.jl $j CUDADevice $i | tail -1 >> gpu.log
+    $JULIA_BIN --project=.. benchmarks.jl $j CUDADevice $i | tail -1 >> gpu_$REV.log
   done
 done

--- a/src/ExaPF.jl
+++ b/src/ExaPF.jl
@@ -18,7 +18,7 @@ import CUDA.CUBLAS
 import CUDA.CUSPARSE
 import CUDA.CUSOLVER
 
-import KernelAbstractions
+using KernelAbstractions
 const KA = KernelAbstractions
 import MathOptInterface
 const MOI = MathOptInterface

--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -7,11 +7,11 @@ using SparseArrays
 import Base: show
 
 using CUDA
+using KernelAbstractions
 import CUDA.CUBLAS
 import CUDA.CUSOLVER
 import CUDA.CUSPARSE
 import IterativeSolvers
-import KernelAbstractions
 import Krylov
 import LightGraphs
 import Metis

--- a/src/LinearSolvers/preconditioners.jl
+++ b/src/LinearSolvers/preconditioners.jl
@@ -207,8 +207,8 @@ end
 
 function _update_gpu(j_rowptr, j_colval, j_nzval, p)
     nblocks = p.nblocks
-    fillblock_gpu_kernel! = fillblock_gpu!(KA.CUDADevice(), nblocks)
-    fillP_gpu_kernel! = fillP_gpu!(KA.CUDADevice(), nblocks)
+    fillblock_gpu_kernel! = fillblock_gpu!(KA.CUDADevice())
+    fillP_gpu_kernel! = fillP_gpu!(KA.CUDADevice())
     # Fill Block Jacobi" begin
     ev = fillblock_gpu_kernel!(p.cublocks, size(p.id,1), p.cupartitions, p.cumap, j_rowptr, j_colval, j_nzval, p.cupart, p.culpartitions, p.id, ndrange=nblocks)
     wait(ev)
@@ -287,7 +287,7 @@ Note that this implements the same algorithm as for the GPU and becomes very slo
 
 """
 function update(J::SparseMatrixCSC, p)
-    kernel! = update_cpu_kernel!(KA.CPU(), Threads.nthreads())
+    kernel! = update_cpu_kernel!(KA.CPU())
     p.P.nzval .= 0.0
     ev = kernel!(J.colptr, J.rowval, J.nzval, p, p.lpartitions, ndrange=p.nblocks)
     wait(ev)

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -116,7 +116,7 @@ struct Jacobian{VI, VT, MT, SMT, VP, VD, SubT, SubD}
         end
         t1s{N} = ForwardDiff.Dual{Nothing,Float64, N} where N
         # The seeding is always done on the CPU since it's faster
-        init_seed_kernel! = _init_seed!(KA.CPU(), 4)
+        init_seed_kernel! = _init_seed!(KA.CPU())
         t1sx = A{t1s{ncolor}}(x)
         t1sF = A{t1s{ncolor}}(zeros(Float64, length(F)))
         t1sseeds = Array{ForwardDiff.Partials{ncolor,Float64}}(undef, nmap)

--- a/src/polar/adjoints.jl
+++ b/src/polar/adjoints.jl
@@ -163,9 +163,9 @@ function put(
         put_active_power_injection!(bus, vmag, vang, adj_vmag, adj_vang, adj_inj, ybus_re, ybus_im)
     end
     if isa(adj_x, Array)
-        kernel! = put_adjoint_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = put_adjoint_kernel!(KA.CPU())
     else
-        kernel! = put_adjoint_kernel!(KA.CUDADevice(), 256)
+        kernel! = put_adjoint_kernel!(KA.CUDADevice())
     end
     ev = kernel!(adj_u, adj_x, adj_vmag, adj_vang, adj_pg,
                  index_pv, index_pq, index_ref, pv_to_gen,

--- a/src/polar/constraints.jl
+++ b/src/polar/constraints.jl
@@ -95,9 +95,9 @@ function power_constraints(polar::PolarForm, g, buffer)
         shift = nref
     end
     if isa(gg, Array)
-        kernel! = load_power_constraint_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = load_power_constraint_kernel!(KA.CPU())
     else
-        kernel! = load_power_constraint_kernel!(KA.CUDADevice(), 256)
+        kernel! = load_power_constraint_kernel!(KA.CUDADevice())
     end
     ev = kernel!(
         gg, buffer.qg, ref_to_gen, pv_to_gen, nref, npv, shift,
@@ -180,9 +180,9 @@ function jacobian(
         put_reactive_power_injection!(bus, vmag, vang, adj_vmag, adj_vang, adj_inj, ybus_re, ybus_im)
     end
     if isa(adj_x, Array)
-        kernel! = put_adjoint_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = put_adjoint_kernel!(KA.CPU())
     else
-        kernel! = put_adjoint_kernel!(KA.CUDADevice(), 256)
+        kernel! = put_adjoint_kernel!(KA.CUDADevice())
     end
     ev = kernel!(adj_u, adj_x, adj_vmag, adj_vang, adj_pg,
                  index_pv, index_pq, index_ref, pv_to_gen,
@@ -283,9 +283,9 @@ end
 # Branch flow constraints
 function flow_constraints(polar::PolarForm, cons, buffer)
     if isa(cons, CUDA.CuArray)
-        kernel! = branch_flow_kernel!(KA.CUDADevice(), 256)
+        kernel! = branch_flow_kernel!(KA.CUDADevice())
     else
-        kernel! = branch_flow_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = branch_flow_kernel!(KA.CPU())
     end
     nlines = PS.get(polar.network, PS.NumberOfLines())
     ev = kernel!(
@@ -302,9 +302,9 @@ end
 function flow_constraints_grad!(polar::PolarForm, cons_grad, buffer, weights)
     T = typeof(buffer.vmag)
     if isa(buffer.vmag, Array)
-        kernel! = accumulate_view!(KA.CPU(), Threads.nthreads())
+        kernel! = accumulate_view!(KA.CPU())
     else
-        kernel! = accumulate_view!(KA.CUDADevice(), 256)
+        kernel! = accumulate_view!(KA.CUDADevice())
     end
 
     nlines = PS.get(polar.network, PS.NumberOfLines())
@@ -381,9 +381,9 @@ function jtprod(
     copyto!(adj_vmag, ∇Jv[1:nbus])
     copyto!(adj_vang, ∇Jv[nbus+1:2*nbus])
     if isa(adj_x, Array)
-        kernel! = put_adjoint_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = put_adjoint_kernel!(KA.CPU())
     else
-        kernel! = put_adjoint_kernel!(KA.CUDADevice(), 256)
+        kernel! = put_adjoint_kernel!(KA.CUDADevice())
     end
     ev = kernel!(adj_u, adj_x, adj_vmag, adj_vang, adj_pg,
                  index_pv, index_pq, index_ref, pv_to_gen,

--- a/src/polar/kernels.jl
+++ b/src/polar/kernels.jl
@@ -101,9 +101,9 @@ function residual_polar!(F, v_m, v_a,
     npv = length(pv)
     npq = length(pq)
     if isa(F, Array)
-        kernel! = residual_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = residual_kernel!(KA.CPU())
     else
-        kernel! = residual_kernel!(KA.CUDADevice(), 256)
+        kernel! = residual_kernel!(KA.CUDADevice())
     end
     ev = kernel!(F, v_m, v_a,
                  ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
@@ -187,9 +187,9 @@ function residual_adj_polar!(F, adj_F, v_m, adj_v_m, v_a, adj_v_a,
     npv = length(pv)
     npq = length(pq)
     if isa(F, Array)
-        kernel! = residual_adj_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = residual_adj_kernel!(KA.CPU())
     else
-        kernel! = residual_adj_kernel!(KA.CUDADevice(), 256)
+        kernel! = residual_adj_kernel!(KA.CUDADevice())
     end
     ev = kernel!(F, adj_F, v_m, adj_v_m, v_a, adj_v_a,
                  ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
@@ -225,9 +225,9 @@ end
 # Transfer values in (x, u) to buffer
 function transfer!(polar::PolarForm, buffer::PolarNetworkState, u)
     if isa(u, CUDA.CuArray)
-        kernel! = transfer_kernel!(KA.CUDADevice(), 256)
+        kernel! = transfer_kernel!(KA.CUDADevice())
     else
-        kernel! = transfer_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = transfer_kernel!(KA.CPU())
     end
     nbus = length(buffer.vmag)
     pv = polar.indexing.index_pv
@@ -282,9 +282,9 @@ end
 # Refresh active power (needed to evaluate objective)
 function update!(polar::PolarForm, ::PS.Generators, ::PS.ActivePower, buffer::PolarNetworkState)
     if isa(buffer.vmag, Array)
-        kernel! = active_power_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = active_power_kernel!(KA.CPU())
     else
-        kernel! = active_power_kernel!(KA.CUDADevice(), 256)
+        kernel! = active_power_kernel!(KA.CUDADevice())
     end
     pv = polar.indexing.index_pv
     pq = polar.indexing.index_pq
@@ -342,9 +342,9 @@ end
 
 function update!(polar::PolarForm, ::PS.Generators, ::PS.ReactivePower, buffer::PolarNetworkState)
     if isa(buffer.vmag, Array)
-        kernel! = reactive_power_kernel!(KA.CPU(), Threads.nthreads())
+        kernel! = reactive_power_kernel!(KA.CPU())
     else
-        kernel! = reactive_power_kernel!(KA.CUDADevice(), 256)
+        kernel! = reactive_power_kernel!(KA.CUDADevice())
     end
     pv = polar.indexing.index_pv
     pq = polar.indexing.index_pq

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,3 +47,12 @@ end
     include("Evaluators/test_rgm.jl")
 end
 
+@testset "Benchmark script" begin
+    empty!(ARGS)
+    push!(ARGS, "KrylovBICGSTAB")
+    push!(ARGS, "CPU")
+    push!(ARGS, "case300.m")
+    include("../benchmark/benchmarks.jl")
+    @test convergence.has_converged
+end
+


### PR DESCRIPTION
* The script `benchmarks.sh` now creates a `CPU` and `GPU` logfile appended by the commit hash.
* KernelAbstractions is used everywhere in anticipation for `AMDGPU.jl` support in `KernelAbstractions.jl`.