### PR TITLE
Create system image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+data/* linguist-documentation
+scripts/* linguist-documentation
+docs/* linguist-documentation

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+SOURCES := $(wildcard src/*/*.jl) $(wildcard test/*/*.jl)
+
+image: exapf.so
+
+exapf.so: $(SOURCES)
+	julia --project deps/createsysimage.jl
+
+.PHONY: image

--- a/deps/createsysimage.jl
+++ b/deps/createsysimage.jl
@@ -1,0 +1,3 @@
+using PackageCompiler
+@warn "Manually uncomment MOI test in runtests.jl. This test breaks PackageCompiler."
+create_sysimage([:CUDA, :ExaPF]; sysimage_path="exapf.so", precompile_execution_file="test/runtests.jl")


### PR DESCRIPTION
This creates a system image via `make image`. The image will be the file `exapf.so` and it will only be created if a julia source file in `src` is newer than the image file.

Big caveat: The MOI test breaks the image creating. So, this test will have to be manually uncommented. Unfortunately, I have not found a way to detect from within the tests whether they are called from `PackageCompiler`. I tried `stacktrace()` etc.