### PR TITLE
Evaluator: compute reduced Hessian on GPU

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -43,7 +43,7 @@ datafile = joinpath(dirname(@__FILE__), ARGS[3])
 pf = PowerSystem.PowerNetwork(datafile)
 polar = PolarForm(pf, device)
 cache = ExaPF.get(polar, ExaPF.PhysicalState())
-jx, ju, ∂obj = ExaPF.init_autodiff_factory(polar, cache)
+jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
 npartitions = ceil(Int64,(size(jx.J,1)/64))
 precond = ExaPF.LinearSolvers.BlockJacobiPreconditioner(jx.J, npartitions, device)
 # Retrieve initial state of network
@@ -55,9 +55,9 @@ powerflow_solver = NewtonRaphson(tol=ntol)
 nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0;
                                     linear_solver=algo, powerflow_solver=powerflow_solver)
 convergence = ExaPF.update!(nlp, u0)
-ExaPF.reset!(nlp)                             
+ExaPF.reset!(nlp)
 convergence = ExaPF.update!(nlp, u0)
-ExaPF.reset!(nlp)                             
+ExaPF.reset!(nlp)
 TimerOutputs.reset_timer!(ExaPF.TIMER)
 convergence = ExaPF.update!(nlp, u0)
 
@@ -68,7 +68,7 @@ convergence = ExaPF.update!(nlp, u0)
 prettytime = TimerOutputs.prettytime
 timers = ExaPF.TIMER.inner_timers
 inner_timer = timers["Newton"]
-println("$(ARGS[1]), $(ARGS[2]), $(ARGS[3]),", 
+println("$(ARGS[1]), $(ARGS[2]), $(ARGS[3]),",
         printtimer(timers, "Newton"),",",
         printtimer(inner_timer, "Jacobian"),",",
         printtimer(inner_timer, "Linear Solver"))

--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -182,25 +182,12 @@ Store the result inplace, in the vector `hessvec` (with size `n`).
 function hessprod! end
 
 @doc raw"""
-    full_hessian_lagrangian(nlp::AbstractNLPEvaluator, u, y, σ)
-
-Evaluate the Hessian of the Lagrangian in the full-space
-```math
-∇²L(x, u, y) = σ ∇²f(x, u) + \sum_i y_i ∇²c_i(x, u)
-```
-Return `H::FullSpaceHessian`, with entries `H.xx` corresponding
-to `∇²Lₓₓ`, `H.xu` to `∇²Lₓᵤ` and `H.uu` to `∇²Lᵤᵤ`.
-
-"""
-function full_hessian_lagrangian end
-
-@doc raw"""
-    hessian_lagrangian_prod!(nlp::AbstractNLPEvaluator, hessvec, u, y, σ, v)
+    hessian_lagrangian_penalty_prod!(nlp::AbstractNLPEvaluator, hessvec, u, y, σ, v, d)
 
 Evaluate the Hessian-vector product of the Lagrangian
-function ``L(u, y) = f(u) + \sum_i y_i c_i(u)`` with a vector `v`:
+function ``L(u, y) = f(u) + \sum_i y_i c_i(u) + \frac{1}{2} d_i c_i(u)^2`` with a vector `v`:
 ```math
-∇²L(u, y) ⋅ v  = σ ∇²f(u) ⋅ v + \sum_i y_i ∇²c_i(u) ⋅ v
+∇²L(u, y) ⋅ v  = σ ∇²f(u) ⋅ v + \sum_i (y_i + d_i) ∇²c_i(u) ⋅ v + \sum_i d_i ∇c_i(u)^T ∇c_i(u)
 ```
 
 Store the result inplace, in the vector `hessvec`.
@@ -212,8 +199,9 @@ Store the result inplace, in the vector `hessvec`.
 * `y` is a `AbstractVector` with dimension `n`, storing the current constraints' multipliers
 * `σ` is a scalar
 * `v` is a vector with dimension `n`.
+* `d` is a vector with dimension `m`.
 """
-function hessian_lagrangian_prod! end
+function hessian_lagrangian_penalty_prod! end
 
 # Utilities
 """

--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -256,7 +256,6 @@ Reset evaluator `nlp` to default configuration.
 function reset! end
 
 include("common.jl")
-include("derivatives.jl")
 
 # Basic evaluators
 include("reduced_evaluator.jl")

--- a/src/Evaluators/Evaluators.jl
+++ b/src/Evaluators/Evaluators.jl
@@ -256,6 +256,7 @@ Reset evaluator `nlp` to default configuration.
 function reset! end
 
 include("common.jl")
+include("derivatives.jl")
 
 # Basic evaluators
 include("reduced_evaluator.jl")

--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -167,22 +167,6 @@ function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
     return
 end
 
-function hessian!(ag::AugLagEvaluator, hess, u)
-    ag.counter.hessian += 1
-    base_nlp = ag.inner
-    scaler = ag.scaler
-    # Import AutoDiff objects
-    autodiff = get(base_nlp, AutoDiffBackend())
-    cx = ag.cons
-    mask = abs.(cx) .> 0
-
-    σ = scaler.scale_obj
-    y = scaler.scale_cons .* ag.λc .* mask
-    z = ag.ρ .* scaler.scale_cons .* scaler.scale_cons .* mask
-
-    hessian_lagrangian_penalty!(base_nlp, hess, u, y, σ, z)
-end
-
 function estimate_multipliers(ag::AugLagEvaluator, u)
     J = Diagonal(ag.scaler.scale_cons) * jacobian(ag.inner, u)
     ∇f = gradient(ag.inner, u)

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -8,6 +8,7 @@ function Base.show(io::IO, nlp::AbstractNLPEvaluator)
     println(io, "    * #cons: ", m)
 end
 
+## Generic callbacks
 function constraint(nlp::AbstractNLPEvaluator, x)
     cons = similar(x, n_constraints(nlp)) ; fill!(cons, 0)
     constraint!(nlp, cons, x)

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -51,7 +51,7 @@ end
 # Build full Hessian matrix using `n` Hessian-vector product
 function hessian!(nlp::AbstractNLPEvaluator, H, x)
     n = n_variables(nlp)
-    v = zeros(n)
+    v = similar(x)
     for i in 1:n
         fill!(v, 0)
         v[i] = 1.0

--- a/src/Evaluators/proxal_evaluators.jl
+++ b/src/Evaluators/proxal_evaluators.jl
@@ -158,9 +158,10 @@ end
 function objective(nlp::ProxALEvaluator, w)
     u = @view w[1:nlp.nu]
     s = @view w[nlp.nu+1:end]
+    buffer = get(nlp.inner, PhysicalState())
     pg = get(nlp.inner, PS.ActivePower())
     # Operational costs
-    cost = nlp.scale_objective * cost_production(nlp.inner.model, pg)
+    cost = nlp.scale_objective * objective(nlp.inner.model, buffer)
     # Augmented Lagrangian penalty
     cost += 0.5 * nlp.τ * xnorm(pg .- nlp.pg_ref)^2
     if nlp.time != Origin

--- a/src/Evaluators/slack_evaluator.jl
+++ b/src/Evaluators/slack_evaluator.jl
@@ -172,21 +172,6 @@ function hessprod!(nlp::SlackEvaluator, hessvec, w, v)
     return
 end
 
-function hessian_lagrangian_prod!(nlp::SlackEvaluator, hessvec, x, y, σ, v)
-    # w.r.t. u
-    @views hessian_lagrangian_prod!(
-        nlp.inner,
-        hessvec[1:nlp.nv],
-        x[1:nlp.nv],
-        y,
-        σ,
-        v[1:nlp.nv]
-    )
-    # w.r.t. s
-    hus = @view hessvec[nlp.nv+1:end]
-    hus .= 0.0
-end
-
 # J = [Jᵤ -I] , hence
 # J' * J = [ Jᵤ' * Jᵤ    - Jᵤ']
 #          [ - Jᵤ           I ]

--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -83,6 +83,12 @@ function ldiv!(::DirectSolver,
     return 0
 end
 function ldiv!(::DirectSolver,
+    y::Vector, J::Factorization, x::Vector,
+)
+    LinearAlgebra.ldiv!(y, J, x)
+    return 0
+end
+function ldiv!(::DirectSolver,
     y::CUDA.CuVector, J::CUSPARSE.CuSparseMatrixCSR, x::CUDA.CuVector,
 )
     CUSOLVER.csrlsvqr!(J, x, y, 1e-8, one(Cint), 'O')

--- a/src/Polar/Constraints/active_power.jl
+++ b/src/Polar/Constraints/active_power.jl
@@ -9,6 +9,32 @@ function active_power_constraints(polar::PolarForm, cons, buffer)
     return
 end
 
+# Function for AutoDiff
+function active_power_constraints(polar::PolarForm, cons, vmag, vang, pinj, qinj)
+    kernel! = active_power_kernel!(polar.device)
+    ref = polar.indexing.index_ref
+    ref_to_gen = polar.indexing.index_ref_to_gen
+    ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
+
+    for i_ in 1:length(ref)
+        bus = ref[i_]
+        i_gen = ref_to_gen[i_]
+        inj = 0.0
+        @inbounds for c in ybus_re.colptr[bus]:ybus_re.colptr[bus+1]-1
+            to = ybus_re.rowval[c]
+            aij = vang[bus] - vang[to]
+            # f_re = a * cos + b * sin
+            # f_im = a * sin - b * cos
+            coef_cos = vmag[bus]*vmag[to]*ybus_re.nzval[c]
+            coef_sin = vmag[bus]*vmag[to]*ybus_im.nzval[c]
+            cos_val = cos(aij)
+            sin_val = sin(aij)
+            inj += coef_cos * cos_val + coef_sin * sin_val
+        end
+        cons[i_] = inj + polar.active_load[bus]
+    end
+end
+
 function size_constraint(polar::PolarForm{T, IT, VT, MT}, ::typeof(active_power_constraints)) where {T, IT, VT, MT}
     return PS.get(polar.network, PS.NumberOfSlackBuses())
 end
@@ -98,6 +124,30 @@ function matpower_jacobian(polar::PolarForm, X::Union{State,Control}, ::typeof(a
     gen2bus = polar.indexing.index_generators
     ngen = length(gen2bus)
     Ybus = pf.Ybus
+
+    dSbus_dVm, dSbus_dVa = PS.matpower_residual_jacobian(V, Ybus)
+    # w.r.t. state
+    if isa(X, State)
+        j11 = real(dSbus_dVa[ref, [pv; pq]])
+        j12 = real(dSbus_dVm[ref, pq])
+    # w.r.t. control
+    elseif isa(X, Control)
+        j11 = real(dSbus_dVm[ref, [ref; pv]])
+        j12 = spzeros(length(ref), npv)
+    end
+    return [j11 j12]::SparseMatrixCSC{Float64, Int}
+end
+
+function matpower_jacobian_old(polar::PolarForm, X::Union{State,Control}, ::typeof(active_power_constraints), buffer)
+    nbus = get(polar, PS.NumberOfBuses())
+    pf = polar.network
+    ref = pf.ref ; nref = length(ref)
+    pv = pf.pv ; npv = length(pv)
+    pq = pf.pq ; npq = length(pq)
+    gen2bus = polar.indexing.index_generators
+    ngen = length(gen2bus)
+    Ybus = pf.Ybus
+    V = buffer.vmag .* exp.(im .* buffer.vang)
 
     dSbus_dVm, dSbus_dVa = PS.matpower_residual_jacobian(V, Ybus)
     # w.r.t. state

--- a/src/Polar/Constraints/voltage_magnitude.jl
+++ b/src/Polar/Constraints/voltage_magnitude.jl
@@ -1,5 +1,7 @@
 is_constraint(::typeof(voltage_magnitude_constraints)) = true
 
+is_linear(polar::PolarForm, ::typeof(voltage_magnitude_constraints)) = true
+
 # We add constraint only on vmag_pq
 function voltage_magnitude_constraints(polar::PolarForm, cons, vm, va, pinj, qinj)
     index_pq = polar.indexing.index_pq

--- a/src/Polar/objective.jl
+++ b/src/Polar/objective.jl
@@ -77,8 +77,8 @@ function hessian_cost(polar::PolarForm, buffer::PolarNetworkState)
     # Evaluate Hess-vec of objective function f(x, u)
     ∂₂P = matpower_hessian(polar, active_power_constraints, buffer, ∂pg)::FullSpaceHessian{SparseMatrixCSC{Float64, Int}}
 
-    ∂Pₓ = matpower_jacobian(polar, active_power_constraints, State(), buffer)::SparseMatrixCSC{Float64, Int}
-    ∂Pᵤ = matpower_jacobian(polar, active_power_constraints, Control(), buffer)::SparseMatrixCSC{Float64, Int}
+    ∂Pₓ = matpower_jacobian_old(polar, State(), active_power_constraints, buffer)::SparseMatrixCSC{Float64, Int}
+    ∂Pᵤ = matpower_jacobian_old(polar, Control(), active_power_constraints, buffer)::SparseMatrixCSC{Float64, Int}
 
     D = Diagonal(∂²pg)
     ∇²fₓₓ = ∂₂P.xx + ∂Pₓ' * D * ∂Pₓ
@@ -118,7 +118,7 @@ function hessian_prod_objective!(
     ## Step 1: evaluate (∂f / ∂pg) * ∂²pg
     ∇f.∂pg .= c3 .+ 2.0 .* c4 .* buffer.pg
     ∂pg = @view ∇f.∂pg[ref2gen]
-    @time AutoDiff.adj_hessian_prod!(polar, ∇²f, hv, buffer, ∂pg, tgt)
+    AutoDiff.adj_hessian_prod!(polar, ∇²f, hv, buffer, ∂pg, tgt)
 
     ## Step 2: evaluate ∂pg' * (∂²f / ∂²pg) * ∂pg
     # Compute adjoint w.r.t. ∂pg_ref

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -29,6 +29,8 @@ abstract type AbstractHessian end
 
 abstract type AbstractAdjointStack end
 
+struct EmptyStack <: AbstractAdjointStack end
+
 function jacobian! end
 
 function adj_hessian_prod! end
@@ -87,7 +89,7 @@ Creates an object for computing Hessian adjoint tangent projections.
 * `varx::SubT`: View of `map` on `x`
 * `t1svarx::SubD`: Active (AD) view of `map` on `x`
 """
-struct Hessian{Func, VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractHessian
+struct Hessian{Func, VI, VT, VP, VD, SubT, SubD} <: AbstractHessian
     func::Func
     t1sseeds::VP
     t1sF::VD

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -25,9 +25,9 @@ This is currently not done because the abstraction of the indexing is not yet re
 
 """
 abstract type AbstractJacobian end
-struct StateJacobian <: AbstractJacobian end
-struct ControlJacobian <: AbstractJacobian end
 abstract type AbstractHessian end
+
+abstract type AbstractAdjointStack end
 
 function jacobian! end
 
@@ -70,8 +70,12 @@ struct Jacobian{Func, VI, VT, MT, SMT, VP, VD, SubT, SubD} <: AbstractJacobian
     t1svarx::SubD
 end
 
+struct ConstantJacobian{SMT} <: AbstractJacobian
+    J::SMT
+end
+
 """
-    Hessian
+    AutoDiff.Hessian
 
 Creates an object for computing Hessian adjoint tangent projections.
 

--- a/test/Evaluators/interface.jl
+++ b/test/Evaluators/interface.jl
@@ -34,7 +34,6 @@
         @test isa(get(nlp, ExaPF.Constraints()), Array{Function})
         @test isa(get(nlp, State()), AbstractVector)
         @test isa(buffer, ExaPF.AbstractBuffer)
-        @test isa(get(nlp, ExaPF.AutoDiffBackend()), ExaPF.AutoDiffFactory)
         @test ExaPF.constraints_type(nlp) in [:bound, :equality, :inequality]
 
         # setters

--- a/test/Evaluators/reduced_evaluator.jl
+++ b/test/Evaluators/reduced_evaluator.jl
@@ -63,7 +63,6 @@
         grad_fd = FiniteDiff.finite_difference_gradient(reduced_cost, u)
         @test isapprox(grad_fd, g, rtol=1e-6)
 
-        # Hessian (only supported on CPU)
         ExaPF.update!(nlp, u)
         hv = similar(u) ; fill!(hv, 0)
         w = similar(u) ; fill!(w, 0)

--- a/test/Polar/autodiff.jl
+++ b/test/Polar/autodiff.jl
@@ -93,6 +93,7 @@
             ExaPF.voltage_magnitude_constraints,
             ExaPF.power_balance,
             ExaPF.reactive_power_constraints,
+            ExaPF.active_power_constraints,
             ExaPF.flow_constraints,
         ]
             m = ExaPF.size_constraint(polar, cons)
@@ -102,6 +103,9 @@
             function test_fd(vvm)
                 cache.vmag .= vvm[1:nbus]
                 cache.vang .= vvm[1+nbus:2*nbus]
+                if isa(cons, typeof(ExaPF.active_power_constraints))
+                    ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
+                end
                 cons(polar, c, cache)
                 return dot(c, λ)
             end

--- a/test/Polar/autodiff.jl
+++ b/test/Polar/autodiff.jl
@@ -16,16 +16,19 @@
         xk = ExaPF.initial(polar, State())
         u = ExaPF.initial(polar, Control())
 
-        jx, ju, ∂obj = ExaPF.init_autodiff_factory(polar, cache)
+        jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
+        ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
 
         # solve power flow
         conv = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-12))
         V = cache.vmag .* exp.(im .* cache.vang)
+        ∂cons = ExaPF.AdjointPolar(polar)
 
         # Test Jacobian w.r.t. State
         for cons in [
             ExaPF.voltage_magnitude_constraints,
             ExaPF.power_balance,
+            ExaPF.active_power_constraints,
             ExaPF.reactive_power_constraints,
             ExaPF.flow_constraints,
         ]
@@ -37,7 +40,7 @@
             Jmat = ExaPF.matpower_jacobian(polar, State(), cons, V)
             # Evaluate Jacobian transpose vector product
             tgt = rand(m)
-            ExaPF.jtprod(polar, cons, ∂obj, cache, tgt)
+            ExaPF.jtprod!(polar, cons, ∂cons, cache, tgt)
 
             # Compare with FiniteDiff
             function jac_fd_x(x)
@@ -45,20 +48,22 @@
                 cache.vang[pq] .= x[npv+1:npv+npq]
                 cache.vmag[pq] .= x[npv+npq+1:end]
                 c = zeros(m)
-                cons(polar, c, cache)
+                cons(polar, c, cache.vmag, cache.vang, cache.pinj, cache.qinj)
                 return c
             end
             x = [cache.vang[pv]; cache.vang[pq]; cache.vmag[pq]]
             Jd = FiniteDiff.finite_difference_jacobian(jac_fd_x, x)
+            @test size(J) == (m, length(x))
             @test isapprox(Jd, xjacobianAD.J, rtol=1e-5)
             @test isapprox(Jmat, xjacobianAD.J, rtol=1e-5)
-            @test isapprox(∂obj.∇fₓ, xjacobianAD.J' * tgt, rtol=1e-6)
+            @test isapprox(∂cons.∂x, xjacobianAD.J' * tgt, rtol=1e-6)
         end
 
         # Test Jacobian w.r.t. Control
         for cons in [
             # ExaPF.voltage_magnitude_constraints, # TODO: handle case where Jacobian is zero
             ExaPF.power_balance,
+            ExaPF.active_power_constraints,
             ExaPF.reactive_power_constraints,
             ExaPF.flow_constraints,
         ]
@@ -70,7 +75,7 @@
             Jmat = ExaPF.matpower_jacobian(polar, Control(), cons, V)
             # Evaluate Jacobian transpose vector product
             adj = rand(m)
-            ExaPF.jtprod(polar, cons, ∂obj, cache, adj)
+            ExaPF.jtprod!(polar, cons, ∂cons, cache, adj)
 
             # Compare with FiniteDiff
             function jac_fd_u(u)
@@ -78,14 +83,15 @@
                 cache.vmag[pv] .= u[nref+1:npv+nref]
                 cache.pinj[pv] .= u[nref+npv+1:end]
                 c = zeros(m)
-                cons(polar, c, cache)
+                cons(polar, c, cache.vmag, cache.vang, cache.pinj, cache.qinj)
                 return c
             end
             u = [cache.vmag[ref]; cache.vmag[pv]; cache.pinj[pv]]
             Jd = FiniteDiff.finite_difference_jacobian(jac_fd_u, u)
+            @test size(J) == (m, length(u))
             @test isapprox(Jd, ujacobianAD.J, rtol=1e-5)
             @test isapprox(Jmat, ujacobianAD.J, rtol=1e-6)
-            @test isapprox(∂obj.∇fᵤ, ujacobianAD.J' * adj, rtol=1e-6)
+            @test isapprox(∂cons.∂u, ujacobianAD.J' * adj, rtol=1e-6)
         end
 
         # Test adjoint
@@ -99,20 +105,17 @@
             m = ExaPF.size_constraint(polar, cons)
             λ = rand(m)
             c = zeros(m)
-            ExaPF.adjoint!(polar, cons, λ, c, ∂obj, cache)
+            ExaPF.adjoint!(polar, cons, λ, c, ∂cons, cache)
             function test_fd(vvm)
                 cache.vmag .= vvm[1:nbus]
                 cache.vang .= vvm[1+nbus:2*nbus]
-                if isa(cons, typeof(ExaPF.active_power_constraints))
-                    ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
-                end
-                cons(polar, c, cache)
+                cons(polar, c, cache.vmag, cache.vang, cache.pinj, cache.qinj)
                 return dot(c, λ)
             end
             vv = [cache.vmag; cache.vang]
             vv_fd = FiniteDiff.finite_difference_gradient(test_fd, vv)
-            @test isapprox(vv_fd[1:nbus], ∂obj.∂vm, rtol=1e-6)
-            @test isapprox(vv_fd[1+nbus:2*nbus], ∂obj.∂va, rtol=1e-6)
+            @test isapprox(vv_fd[1:nbus], ∂cons.∂vm, rtol=1e-6)
+            @test isapprox(vv_fd[1+nbus:2*nbus], ∂cons.∂va, rtol=1e-6)
         end
     end
 end

--- a/test/Polar/gradient.jl
+++ b/test/Polar/gradient.jl
@@ -50,7 +50,7 @@ const KA = KernelAbstractions
             ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
             # We need uk here for the closure
             uk = copy(u)
-            ExaPF.adjoint_objective!(polar, ∂obj, cache)
+            ExaPF.gradient_objective!(polar, ∂obj, cache)
             ∇fₓ = ∂obj.∇fₓ
             ∇fᵤ = ∂obj.∇fᵤ
 

--- a/test/Polar/gradient.jl
+++ b/test/Polar/gradient.jl
@@ -26,7 +26,9 @@ const KA = KernelAbstractions
         xk = ExaPF.initial(polar, State())
         u = ExaPF.initial(polar, Control())
 
-        jx, ju, ∂obj = ExaPF.init_autodiff_factory(polar, cache)
+        jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
+        ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
+        ∂obj = ExaPF.AdjointStackObjective(polar)
 
         # solve power flow
         conv = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-12))

--- a/test/Polar/gradient.jl
+++ b/test/Polar/gradient.jl
@@ -48,7 +48,7 @@ const KA = KernelAbstractions
             ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
             # We need uk here for the closure
             uk = copy(u)
-            ExaPF.∂cost(polar, ∂obj, cache)
+            ExaPF.adjoint_objective!(polar, ∂obj, cache)
             ∇fₓ = ∂obj.∇fₓ
             ∇fᵤ = ∂obj.∇fᵤ
 
@@ -67,7 +67,7 @@ const KA = KernelAbstractions
                 ExaPF.transfer!(polar, cache, u_)
                 convergence = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-14))
                 ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
-                return ExaPF.cost_production(polar, cache.pg)
+                return ExaPF.objective(polar, cache)
             end
 
             grad_fd = FiniteDiff.finite_difference_gradient(reduced_cost, uk)

--- a/test/Polar/matpower.jl
+++ b/test/Polar/matpower.jl
@@ -25,7 +25,7 @@ import ExaPF: ParseMAT, PowerSystem, IndexSet
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
     ExaPF.init_buffer!(polar, cache)
-    jx, ju = ExaPF.init_autodiff_factory(polar, cache)
+    jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
     # solve power flow
     convergence = ExaPF.powerflow(polar, jx, cache, NewtonRaphson())
     ExaPF.get!(polar, State(), x, cache)
@@ -51,7 +51,7 @@ end
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
     ExaPF.init_buffer!(polar, cache)
-    jx, ju = ExaPF.init_autodiff_factory(polar, cache)
+    jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
     # solve power flow
     conv = ExaPF.powerflow(polar, jx, cache, NewtonRaphson())
     ExaPF.get!(polar, State(), x, cache)
@@ -76,7 +76,7 @@ end
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
     ExaPF.init_buffer!(polar, cache)
-    jx, ju = ExaPF.init_autodiff_factory(polar, cache)
+    jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
     # solve power flow
     conv = ExaPF.powerflow(polar, jx, cache, NewtonRaphson())
     ExaPF.get!(polar, State(), x, cache)
@@ -99,7 +99,7 @@ end
 
     cache = ExaPF.get(polar, ExaPF.PhysicalState())
     ExaPF.init_buffer!(polar, cache)
-    jx, ju = ExaPF.init_autodiff_factory(polar, cache)
+    jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
     # solve power flow
     conv = ExaPF.powerflow(polar, jx, cache, NewtonRaphson())
     ExaPF.get!(polar, State(), x, cache)

--- a/test/Polar/polar_form.jl
+++ b/test/Polar/polar_form.jl
@@ -94,7 +94,7 @@ const PS = PowerSystem
         @testset "Polar model API" begin
             xₖ = copy(x0)
             # Init AD factory
-            jx, ju, ∂obj = ExaPF.init_autodiff_factory(polar, cache)
+            jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
 
             # Test powerflow with cache signature
             conv = powerflow(polar, jx, cache, NewtonRaphson(tol=tolerance))

--- a/test/Polar/polar_form.jl
+++ b/test/Polar/polar_form.jl
@@ -122,7 +122,7 @@ const PS = PowerSystem
             @test norm(cons, Inf) < tolerance
 
             ## Cost Production
-            c2 = ExaPF.cost_production(polar, cache.pg)
+            c2 = ExaPF.objective(polar, cache)
             @test isa(c2, Real)
 
             ## Inequality constraint

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using TimerOutputs
 using FiniteDiff
 
 import ExaPF: ParsePSSE, PowerSystem, IndexSet
+import ExaPF: AutoDiff
 
 Random.seed!(2713)
 


### PR DESCRIPTION
Allow to evaluate Hessian on the GPU directly

ReducedSpaceEvaluator:
* implement hessprod! with AutoDiff
* implement hessprod_lagrangian_penalty! with AutoDiff
* replace MATPOWER's Jacobian with AutoDiff's Jacobian
* remove old attribute `autodiff` in ReducedSpaceEvaluator
* improve type inference for AutoDiff
* remove method `get(nlp, AutoDiffBackend())`, which
  was ambiguous
* remove Hessian and Jacobian caches in ReducedSpaceEvaluator

Polar:
 * new function to compute Hessian of objective with AutoDiff,
  via Hessian-vector product
* remove init_autodiff_factory in Polar/
* add a new ConstantJacobian structure for linear function
* add a new function `is_linear` to state whether a constraint is linear
* add new storage types `JacobianStorage` and `HessianStorage`
* rename `cost_production` as `objective`
* rename `\partial cost()` as `adjoint_objective!`