### PR TITLE
Compute reduced Jacobian on GPU

### DIFF
--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -169,6 +169,19 @@ function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
     return
 end
 
+function hessian!(ag::AugLagEvaluator, H, u)
+    ag.counter.hessian += 1
+    scaler = ag.scaler
+    cx = ag.cons
+    mask = abs.(cx) .> 0
+
+    σ = scaler.scale_obj
+    y = (scaler.scale_cons .* ag.λc .* mask)
+    ρ = ag.ρ .* (scaler.scale_cons .* scaler.scale_cons .* mask)
+    hessian_lagrangian_penalty!(ag.inner, H, u, y, σ, ρ)
+    return
+end
+
 function estimate_multipliers(ag::AugLagEvaluator, u)
     J = Diagonal(ag.scaler.scale_cons) * jacobian(ag.inner, u)
     ∇f = gradient(ag.inner, u)

--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -163,9 +163,9 @@ function hessprod!(ag::AugLagEvaluator, hessvec, u, w)
 
     σ = scaler.scale_obj
     y = (scaler.scale_cons .* ag.λc .* mask)
-    z = ag.ρ .* (scaler.scale_cons .* scaler.scale_cons .* mask)
+    ρ = ag.ρ .* (scaler.scale_cons .* scaler.scale_cons .* mask)
 
-    hessian_lagrangian_penalty_prod!(ag.inner, hessvec, u, y, σ, w, z)::Nothing
+    hessian_lagrangian_penalty_prod!(ag.inner, hessvec, u, y, σ, w, ρ)::Nothing
     return
 end
 

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -66,17 +66,6 @@ function hessian(nlp::AbstractNLPEvaluator, x)
     return H
 end
 
-function hessian_lagrangian_penalty_prod!(
-    nlp::AbstractNLPEvaluator, hessvec, u, y, σ, v, w,
-)
-    jv = similar(u) ; fill!(jv, 0)
-    hessian_lagrangian_prod!(nlp, hessvec, u, y, σ, v)
-    jprod!(nlp, jv, u, v)
-    jv .*= w
-    jtprod!(nlp, hessvec, u, jv)
-    return
-end
-
 # AutoDiff Factory
 abstract type AbstractAutoDiffFactory end
 

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -53,14 +53,22 @@ function hessian!(nlp::AbstractNLPEvaluator, H, x)
     n = n_variables(nlp)
     v = similar(x)
     hv = similar(x)
-    th = 0.0
     for i in 1:n
         fill!(v, 0)
         v[i] = 1.0
-        th += @elapsed hessprod!(nlp, hv, x, v)
+        hessprod!(nlp, hv, x, v)
         H[:, i] .= hv
     end
-    println(th / n)
+end
+
+function hessian_lagrangian_penalty!(nlp::AbstractNLPEvaluator, H, x, y, σ, D,)
+    n = n_variables(nlp)
+    v = similar(x)
+    for i in 1:n
+        fill!(v, 0)
+        v[i] = 1.0
+        hessian_lagrangian_penalty_prod!(nlp, view(H, :, i), x, y, σ, v, D)
+    end
 end
 
 function hessian(nlp::AbstractNLPEvaluator, x)

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -52,11 +52,15 @@ end
 function hessian!(nlp::AbstractNLPEvaluator, H, x)
     n = n_variables(nlp)
     v = similar(x)
+    hv = similar(x)
+    th = 0.0
     for i in 1:n
         fill!(v, 0)
         v[i] = 1.0
-        hessprod!(nlp, view(H, :, i), x, v)
+        th += @elapsed hessprod!(nlp, hv, x, v)
+        H[:, i] .= hv
     end
+    println(th / n)
 end
 
 function hessian(nlp::AbstractNLPEvaluator, x)

--- a/src/Evaluators/feasibility_evaluator.jl
+++ b/src/Evaluators/feasibility_evaluator.jl
@@ -82,19 +82,13 @@ end
 function hessprod!(nlp::FeasibilityEvaluator, hessvec, u, v)
     σ = 0.0
     # Need to update the first-order adjoint λ first
-    hessian_lagrangian_prod!(nlp.inner, hessvec, u, nlp.cons, σ, v)
-    J = jacobian(nlp.inner, u)
-    hessvec .+= J' * J * v
-    return
-end
-
-function hessian!(nlp::FeasibilityEvaluator, hess, u)
-    σ = 0.0 # remove objective
-    w = zeros() # remove penalties
-    y = nlp.cons
-    hessian_lagrangian_penalty!(nlp.inner, hess, u, y, σ, w)
-    J = jacobian(nlp.inner, u)
-    hess .+= J' * J
+    hessian_lagrangian_penalty_prod!(nlp.inner, hessvec, u, nlp.cons, σ, v, 0.0)
+    # J' * J * v
+    jv = similar(nlp.cons)
+    jtv = similar(u)
+    jprod!(nlp.inner, jv, u, v)
+    jtprod!(nlp.inner, jtv, u, jv)
+    hessvec .+= jtv
     return
 end
 

--- a/src/Evaluators/proxal_evaluators.jl
+++ b/src/Evaluators/proxal_evaluators.jl
@@ -273,6 +273,12 @@ function jacobian!(nlp::ProxALEvaluator, jac, w)
     jacobian!(nlp.inner, Jᵤ, u)
 end
 
+function jprod!(nlp::ProxALEvaluator, jv, w, v)
+    u = @view w[1:nlp.nu]
+    vu = @view v[1:nlp.nu]
+    jprod!(nlp.inner, jv, u, vu)
+end
+
 ## Transpose Jacobian-vector product
 ## ProxAL does not add any constraint to the reduced model
 function jtprod!(nlp::ProxALEvaluator, jv, w, v)

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -354,16 +354,17 @@ function jacobian!(nlp::ReducedSpaceEvaluator, jac, u)
     Jx = ∇cons.Jx
     Ju = ∇cons.Ju
     m, nₓ = size(Jx)
+    m, nᵤ = size(Ju)
     ∇gᵤ = nlp.state_jacobian.u.J
     ∇gₓ = nlp.state_jacobian.x.J
     # Compute factorization with UMFPACK
     ∇gfac = nlp.factorization
     # Compute adjoints all in once, using the same factorization
-    μ = zeros(nₓ, m)
-    ldiv!(μ, ∇gfac', Jx')
+    μ = zeros(nₓ, nᵤ)
+    ldiv!(μ, ∇gfac, ∇gᵤ)
     # Compute reduced Jacobian
     copy!(jac, Ju)
-    mul!(jac, μ', ∇gᵤ, -1.0, 1.0)
+    mul!(jac, Jx, μ, -1.0, 1.0)
     return
 end
 

--- a/src/Evaluators/slack_evaluator.jl
+++ b/src/Evaluators/slack_evaluator.jl
@@ -206,38 +206,6 @@ function hessian_lagrangian_penalty_prod!(
     end
     return
 end
-
-function hessian_lagrangian_penalty!(
-    nlp::SlackEvaluator, hess, x, y, σ, w,
-)
-    n = n_variables(nlp)
-    @views begin
-        u   = x[1:nlp.nv]
-        Hᵤᵤ = hess[1:nlp.nv, 1:nlp.nv]
-        Hᵤᵥ = hess[1:nlp.nv, 1+nlp.nv:n]
-        Hᵥᵤ = hess[1+nlp.nv:n, 1:nlp.nv]
-        Hᵥᵥ = hess[1+nlp.nv:n, 1+nlp.nv:n]
-    end
-    # w.r.t. uu
-    # ∇²L + ρ Jᵤ' * Jᵤ
-    hessian_lagrangian_penalty!(nlp.inner, Hᵤᵤ, u, y, σ, w)
-
-    if !iszero(w)
-        D = Diagonal(w)
-        Jᵤ = jacobian(nlp.inner, u)
-        copy!(Hᵤᵥ, - Jᵤ' * D)
-        copy!(Hᵥᵤ, - D * Jᵤ)
-        fill!(Hᵥᵥ, 0)
-        for i in 1:nlp.ns
-            Hᵥᵥ[i, i] = w[i]
-        end
-    else
-        fill!(Hᵤᵥ, 0)
-        fill!(Hᵥᵤ, 0)
-        fill!(Hᵥᵥ, 0)
-    end
-end
-
 # TODO: return sparse sparsity pattern for bottom-left block
 function hessian_structure(nlp::SlackEvaluator)
     n = n_variables(nlp)

--- a/src/Polar/Constraints/active_power.jl
+++ b/src/Polar/Constraints/active_power.jl
@@ -52,13 +52,15 @@ function _put_active_power_injection!(fr, v_m, v_a, adj_v_m, adj_v_a, adj_P, ybu
     @inbounds for c in ybus_re.colptr[fr]:ybus_re.colptr[fr+1]-1
         to = ybus_re.rowval[c]
         aij = v_a[fr] - v_a[to]
-        cθ = ybus_re.nzval[c]*cos(aij)
-        sθ = ybus_im.nzval[c]*sin(aij)
+        cosθ = cos(aij)
+        sinθ = sin(aij)
+        cθ = ybus_re.nzval[c]*cosθ
+        sθ = ybus_im.nzval[c]*sinθ
         adj_v_m[fr] += v_m[to] * (cθ + sθ) * adj_P
         adj_v_m[to] += v_m[fr] * (cθ + sθ) * adj_P
 
-        adj_aij = -(v_m[fr]*v_m[to]*(ybus_re.nzval[c]*sin(aij)))
-        adj_aij += v_m[fr]*v_m[to]*(ybus_im.nzval[c]*cos(aij))
+        adj_aij = -(v_m[fr]*v_m[to]*(ybus_re.nzval[c]*sinθ))
+        adj_aij += v_m[fr]*v_m[to]*(ybus_im.nzval[c]*cosθ)
         adj_aij *= adj_P
         adj_v_a[to] += -adj_aij
         adj_v_a[fr] += adj_aij

--- a/src/Polar/Constraints/constraints.jl
+++ b/src/Polar/Constraints/constraints.jl
@@ -5,17 +5,6 @@ is_constraint(::Function) = false
 # Is the function linear in the polar formulation?
 is_linear(polar::PolarForm, ::Function) = false
 
-struct FullSpaceJacobian{Jac}
-    x::Jac
-    u::Jac
-end
-
-struct FullSpaceHessian{SpMT}
-    xx::SpMT
-    xu::SpMT
-    uu::SpMT
-end
-
 
 include("power_balance.jl")
 include("voltage_magnitude.jl")
@@ -108,13 +97,13 @@ end
 
 _build_hessian(polar::PolarForm, cons::Function) = AutoDiff.Hessian(polar, cons)
 
-function JacobianStorage(
+function FullSpaceJacobian(
     polar::PolarForm{T, VI, VT, MT},
     cons::Function,
 ) where {T, VI, VT, MT}
     @assert is_constraint(cons)
     Jx = _build_jacobian(polar, cons, State())
     Ju = _build_jacobian(polar, cons, Control())
-    return JacobianStorage(Jx, Ju)
+    return FullSpaceJacobian(Jx, Ju)
 end
 

--- a/src/Polar/Constraints/constraints.jl
+++ b/src/Polar/Constraints/constraints.jl
@@ -15,7 +15,6 @@ include("line_flow.jl")
 # Generic functions
 
 ## Adjoint
-# TODO: port to new stack
 function adjoint!(
     polar::PolarForm,
     func::Function,
@@ -23,8 +22,8 @@ function adjoint!(
     stack, buffer,
 )
     @assert is_constraint(func)
-    ∂pinj = similar(buffer.vmag) ; fill!(∂pinj, 0.0)
     ∂qinj = nothing # TODO
+    fill!(stack.∂pinj, 0.0)
     fill!(stack.∂vm, 0)
     fill!(stack.∂va, 0)
     adjoint!(
@@ -32,7 +31,7 @@ function adjoint!(
         cons, ∂cons,
         buffer.vmag, stack.∂vm,
         buffer.vang, stack.∂va,
-        buffer.pinj, ∂pinj,
+        buffer.pinj, stack.∂pinj,
         buffer.qinj, ∂qinj,
     )
 end

--- a/src/Polar/objective.jl
+++ b/src/Polar/objective.jl
@@ -50,11 +50,10 @@ function put(
     adj_u = obj_autodiff.∇fᵤ
     adj_vmag = obj_autodiff.∂vm
     adj_vang = obj_autodiff.∂va
-    # TODO
-    adj_pinj = similar(adj_vmag)  ; fill!(adj_pinj, 0.0)
+    adj_pinj = obj_autodiff.∂pinj
 
     # Adjoint w.r.t Slack nodes
-    adjoint!(polar, active_power_constraints, adj_pg[ref2gen] , buffer.pg, obj_autodiff, buffer)
+    adjoint!(polar, active_power_constraints, view(adj_pg, ref2gen), buffer.pg, obj_autodiff, buffer)
     # Adjoint w.r.t. PV nodes
     adj_pinj[index_pv] .= @view adj_pg[pv2gen]
 

--- a/src/Polar/objective.jl
+++ b/src/Polar/objective.jl
@@ -52,13 +52,11 @@ function put(
     adj_vang = obj_autodiff.∂va
     # TODO
     adj_pinj = similar(adj_vmag)  ; fill!(adj_pinj, 0.0)
-    fill!(adj_vmag, 0.0)
-    fill!(adj_vang, 0.0)
 
     # Adjoint w.r.t Slack nodes
     adjoint!(polar, active_power_constraints, adj_pg[ref2gen] , buffer.pg, obj_autodiff, buffer)
     # Adjoint w.r.t. PV nodes
-    adj_pinj[index_pv] .= adj_pg[pv2gen]
+    adj_pinj[index_pv] .= @view adj_pg[pv2gen]
 
     # Adjoint w.r.t. x and u
     fill!(adj_x, 0.0)

--- a/test/Evaluators/MOI_wrapper.jl
+++ b/test/Evaluators/MOI_wrapper.jl
@@ -27,7 +27,7 @@ const MOI = MathOptInterface
     MOI.set(optimizer, MOI.RawParameter("print_level"), 0)
     MOI.set(optimizer, MOI.RawParameter("limited_memory_max_history"), 50)
     MOI.set(optimizer, MOI.RawParameter("hessian_approximation"), "limited-memory")
-    MOI.set(optimizer, MOI.RawParameter("tol"), 1e-2)
+    MOI.set(optimizer, MOI.RawParameter("tol"), 1e-4)
 
     solution = ExaPF.optimize!(optimizer, nlp)
     MOI.empty!(optimizer)

--- a/test/Evaluators/proxal_evaluator.jl
+++ b/test/Evaluators/proxal_evaluator.jl
@@ -91,6 +91,10 @@ import ExaPF: PS
         ExaPF.jacobian!(prox, jac, w)
         # Check correctness of transpose Jacobian vector product
         @test jv == jac' * v
+
+        # Jacobian vector product
+        ExaPF.jprod!(prox, v, w, jv)
+        @test v == jac * jv
     end
 
     ExaPF.reset!(prox)

--- a/test/Evaluators/reduced_evaluator.jl
+++ b/test/Evaluators/reduced_evaluator.jl
@@ -22,6 +22,7 @@
             ExaPF.voltage_magnitude_constraints,
             ExaPF.active_power_constraints,
             ExaPF.reactive_power_constraints,
+            ExaPF.flow_constraints,
         ]
         nlp = ExaPF.ReducedSpaceEvaluator(polar, x0, u0; constraints=constraints)
         # Test printing


### PR DESCRIPTION
The reduced Jacobian is now compatible with the GPU, allowing to evaluate the Hessian of all Augmented Lagrangian on the GPU. 

* compute the Jacobians `Jx` and `Ju` in the full-space, using AutoDiff. Store the results inplace, in a pre-allocated sparse matrix. 
* Store the constraints Jacobian in a `ReducedSpaceEvaluator` attribute
* add an efficient `jprod!` function in `ReducedSpaceEvaluator`, with one direct solve
* add a new struct `ConstraintsJacobianStorage` to store AD backend and sparse matrices for constraints' Jacobian