### PR TITLE
Non-allocating kernels for adjoints

### DIFF
--- a/src/Evaluators/proxal_evaluators.jl
+++ b/src/Evaluators/proxal_evaluators.jl
@@ -209,14 +209,14 @@ function full_gradient!(nlp::ProxALEvaluator, jx, ju, w)
     u = @view w[1:nlp.nu]
 
     ## Compute adjoint of objective
-    _adjoint_objective!(nlp, ∂obj.∂pg, pg)
+    _adjoint_objective!(nlp, ∂obj.stack.∂pg, pg)
 
     ## Evaluate conjointly
     # ∇fₓ = v' * J,  with J = ∂pg / ∂x
     # ∇fᵤ = v' * J,  with J = ∂pg / ∂u
     put(model, PS.Generators(), PS.ActivePower(), ∂obj, buffer)
-    copyto!(jx, ∂obj.∇fₓ)
-    copyto!(ju, ∂obj.∇fᵤ)
+    copyto!(jx, ∂obj.stack.∇fₓ)
+    copyto!(ju, ∂obj.stack.∇fᵤ)
 end
 
 function gradient_slack!(nlp::ProxALEvaluator, grad, w)
@@ -240,7 +240,7 @@ function gradient!(nlp::ProxALEvaluator, g, w)
     # Import AutoDiff objects
     ∂obj = nlp.inner.obj_stack
 
-    jvu = ∂obj.∇fᵤ ; jvx = ∂obj.∇fₓ
+    jvu = ∂obj.stack.∇fᵤ ; jvx = ∂obj.stack.∇fₓ
     fill!(jvx, 0)  ; fill!(jvu, 0)
     full_gradient!(nlp, jvx, jvu, w)
 
@@ -294,8 +294,8 @@ end
 
 function ojtprod!(nlp::ProxALEvaluator, jv, u, σ, v)
     ∂obj = nlp.inner.obj_stack
-    jvx = ∂obj.jvₓ ; fill!(jvx, 0)
-    jvu = ∂obj.jvᵤ ; fill!(jvu, 0)
+    jvx = ∂obj.stack.jvₓ ; fill!(jvx, 0)
+    jvu = ∂obj.stack.jvᵤ ; fill!(jvu, 0)
     # compute gradient of objective
     full_gradient!(nlp, jvx, jvu, u)
     jvx .*= σ

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -42,8 +42,8 @@ mutable struct ReducedSpaceEvaluator{T, VI, VT, MT, Jacx, Jacu, JacCons, Hess} <
     buffer::PolarNetworkState{VI, VT}
     # AutoDiff
     state_jacobian::FullSpaceJacobian{Jacx, Jacu}
-    obj_stack::AutoDiff.PullbackMemory{typeof(active_power_constraints), AdjointStackObjective{VT}, Nothing}
-    cons_stacks::Vector{AutoDiff.PullbackMemory} # / constraints
+    obj_stack::AutoDiff.TapeMemory{typeof(active_power_constraints), AdjointStackObjective{VT}, Nothing}
+    cons_stacks::Vector{AutoDiff.TapeMemory} # / constraints
     constraint_jacobians::JacCons
     hessians::Hess
 
@@ -85,9 +85,9 @@ function ReducedSpaceEvaluator(
     obj_ad = pullback_objective(model)
     state_ad = FullSpaceJacobian(model, power_balance)
     VT = typeof(g_min)
-    cons_ad = AutoDiff.PullbackMemory[]
+    cons_ad = AutoDiff.TapeMemory[]
     for cons in constraints
-        push!(cons_ad, AutoDiff.PullbackMemory(model, cons, VT))
+        push!(cons_ad, AutoDiff.TapeMemory(model, cons, VT))
     end
 
     # Jacobians

--- a/src/Polar/Constraints/active_power.jl
+++ b/src/Polar/Constraints/active_power.jl
@@ -70,13 +70,12 @@ end
 # Adjoint
 function adjoint!(
     polar::PolarForm,
-    ::typeof(active_power_constraints),
+    pbm::AutoDiff.PullbackMemory{F, S, I},
     pg, ∂pg,
     vm, ∂vm,
     va, ∂va,
     pinj, ∂pinj,
-    qinj, ∂qinj,
-)
+) where {F<:typeof(active_power_constraints), S, I}
     nbus = PS.get(polar.network, PS.NumberOfBuses())
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())
     index_ref = polar.indexing.index_ref

--- a/src/Polar/Constraints/constraints.jl
+++ b/src/Polar/Constraints/constraints.jl
@@ -31,19 +31,19 @@ function _get_intermediate_stack(
 end
 
 # Generic functions
-function AutoDiff.PullbackMemory(
+function AutoDiff.TapeMemory(
     polar::PolarForm, func::Function, VT; with_stack=true,
 )
     @assert is_constraint(func)
     stack = (with_stack) ? AdjointPolar(polar) : nothing
     intermediate = _get_intermediate_stack(polar, func, VT)
-    return AutoDiff.PullbackMemory(func, stack, intermediate)
+    return AutoDiff.TapeMemory(func, stack, intermediate)
 end
 
 ## Adjoint
 function adjoint!(
     polar::PolarForm,
-    pbm::AutoDiff.PullbackMemory,
+    pbm::AutoDiff.TapeMemory,
     ∂cons, cons,
     buffer,
 )
@@ -61,7 +61,7 @@ end
 ## Jacobian-transpose vector product
 function jtprod!(
     polar::PolarForm,
-    pbm::AutoDiff.PullbackMemory,
+    pbm::AutoDiff.TapeMemory,
     buffer::PolarNetworkState,
     v::AbstractVector,
 )

--- a/src/Polar/Constraints/line_flow.jl
+++ b/src/Polar/Constraints/line_flow.jl
@@ -56,7 +56,7 @@ end
 
 function adjoint!(
     polar::PolarForm,
-    pbm::AutoDiff.PullbackMemory{F, S, I},
+    pbm::AutoDiff.TapeMemory{F, S, I},
     cons, ∂cons,
     vm, ∂vm,
     va, ∂va,

--- a/src/Polar/Constraints/power_balance.jl
+++ b/src/Polar/Constraints/power_balance.jl
@@ -69,7 +69,7 @@ function adjoint!(
         cons, ∂cons,
         vm, ∂vm,
         va, ∂va,
-        ybus_re, ybus_im,
+        ybus_re, ybus_im, polar.topology.sortperm,
         pinj, ∂pinj,
         qinj, pv, pq, nbus,
     )

--- a/src/Polar/Constraints/power_balance.jl
+++ b/src/Polar/Constraints/power_balance.jl
@@ -52,7 +52,7 @@ end
 # Adjoint
 function adjoint!(
     polar::PolarForm,
-    pbm::AutoDiff.PullbackMemory{F, S, I},
+    pbm::AutoDiff.TapeMemory{F, S, I},
     cons, ∂cons,
     vm, ∂vm,
     va, ∂va,

--- a/src/Polar/Constraints/reactive_power.jl
+++ b/src/Polar/Constraints/reactive_power.jl
@@ -78,7 +78,7 @@ function adjoint!(
         cons, ∂cons,
         vm, ∂vm,
         va, ∂va,
-        ybus_re, ybus_im,
+        ybus_re, ybus_im, polar.topology.sortperm,
         pinj, ∂pinj,
         qinj, ∂qinj,
         polar.reactive_load,

--- a/src/Polar/Constraints/voltage_magnitude.jl
+++ b/src/Polar/Constraints/voltage_magnitude.jl
@@ -28,13 +28,12 @@ end
 
 function adjoint!(
     polar::PolarForm,
-    ::typeof(voltage_magnitude_constraints),
+    pbm::AutoDiff.PullbackMemory{F, S, I},
     cons, ∂cons,
     vm, ∂vm,
     va, ∂va,
     pinj, ∂pinj,
-    qinj, ∂qinj,
-)
+) where {F<:typeof(voltage_magnitude_constraints), S, I}
     index_pq = polar.indexing.index_pq
     ∂vm[index_pq] .= ∂cons
 end

--- a/src/Polar/caches.jl
+++ b/src/Polar/caches.jl
@@ -118,10 +118,12 @@ struct NetworkTopology{VTI, VTD}
     # Correspondence
     f_buses::VTI # nl
     t_buses::VTI # nl
+    sortperm::VTI # nnz
 end
 
 function NetworkTopology{VTI, VTD}(pf::PS.PowerNetwork) where {VTI, VTD}
-    ybus_re, ybus_im = Spmat{VTI, VTD}(pf.Ybus)
+    Y = pf.Ybus
+    ybus_re, ybus_im = Spmat{VTI, VTD}(Y)
     lines = pf.lines
     yff_re = real.(lines.Yff) |> VTD
     yft_re = real.(lines.Yft) |> VTD
@@ -135,12 +137,14 @@ function NetworkTopology{VTI, VTD}(pf::PS.PowerNetwork) where {VTI, VTD}
 
     f = lines.from_buses |> VTI
     t = lines.to_buses   |> VTI
+    i, j, _ = findnz(Y)
+    sp = sortperm(i) |> VTI
 
     return NetworkTopology(
         ybus_re, ybus_im,
         yff_re, yft_re, ytf_re, ytt_re,
         yff_im, yft_im, ytf_im, ytt_im,
-        f, t,
+        f, t, sp,
     )
 end
 

--- a/src/Polar/derivatives.jl
+++ b/src/Polar/derivatives.jl
@@ -186,7 +186,7 @@ function AutoDiff.Hessian(polar::PolarForm{T, VI, VT, MT}, func) where {T, VI, V
     VD = typeof(t1sx)
     adj_t1sx = similar(t1sx)
     adj_t1sF = similar(t1sF)
-    buffer = AutoDiff.PullbackMemory(polar, func, VD; with_stack=false)
+    buffer = AutoDiff.TapeMemory(polar, func, VD; with_stack=false)
     return AutoDiff.Hessian{typeof(func), VI, VT, VHP, VP, VD, typeof(varx), typeof(t1svarx), typeof(buffer)}(
         func, host_t1sseeds, t1sseeds, x, t1sF, adj_t1sF, t1sx, adj_t1sx, map, varx, t1svarx, buffer,
     )

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -162,19 +162,19 @@ end
 This kernel accumulates the adjoint of the voltage magnitude `adj_vm`
 and `adj_va` from the edges of the graph stored as CSC matrices.
 """
-KA.@kernel function cpu_adj_node_kernel!(
+function cpu_adj_node_kernel!(
     F, adj_F, vm, adj_vm, va, adj_va,
     colptr, rowval,
     edge_vm_from, edge_vm_to,
     edge_va_from, edge_va_to
 )
-
-    i = @index(Global, Linear)
-    @inbounds for c in colptr[i]:colptr[i+1]-1
-        adj_vm[i] += edge_vm_from[c]
-        adj_vm[i] += edge_vm_to[c]
-        adj_va[i] += edge_va_from[c]
-        adj_va[i] += edge_va_to[c]
+    for i in 1:length(adj_vm)
+        @inbounds for c in colptr[i]:colptr[i+1]-1
+            adj_vm[i] += edge_vm_from[c]
+            adj_vm[i] += edge_vm_to[c]
+            adj_va[i] += edge_va_from[c]
+            adj_va[i] += edge_va_to[c]
+        end
     end
 end
 
@@ -224,7 +224,7 @@ This is the CUDA wrapper of the adjoint kernel that computes the adjoint of the 
 """
 function adj_residual_polar!(
     F::CUDA.CuVector{T}, adj_F::CUDA.CuVector{T}, vm, adj_vm, va, adj_va,
-    ybus_re, ybus_im,
+    ybus_re, ybus_im, transpose_perm,
     pinj, adj_pinj, qinj, pv, pq, nbus
 ) where {T}
     npv = length(pv)
@@ -281,7 +281,7 @@ This is the CPU wrapper of the adjoint kernel that computes the adjoint of the v
 """
 function adj_residual_polar!(
     F::Vector{T}, adj_F::Vector{T}, vm, adj_vm, va, adj_va,
-    ybus_re, ybus_im,
+    ybus_re, ybus_im, transpose_perm,
     pinj, adj_pinj, qinj, pv, pq, nbus
 ) where {T}
     npv = length(pv)
@@ -299,7 +299,6 @@ function adj_residual_polar!(
     adj_pinj .= 0.0
 
     kernel_edge! = adj_residual_edge_kernel!(KA.CPU())
-    kernel_node! = cpu_adj_node_kernel!(KA.CPU())
     ev = kernel_edge!(F, adj_F, vm, adj_vm, va, adj_va,
                  ybus_re.colptr, ybus_re.rowval,
                  ybus_re.nzval, ybus_im.nzval,
@@ -309,21 +308,14 @@ function adj_residual_polar!(
                  ndrange=npv+npq)
     wait(ev)
 
-    spedge_vm_to = SparseMatrixCSC{T, Int64}(nvbus, nvbus, colptr, rowval, edge_vm_to)
-    spedge_va_to = SparseMatrixCSC{T, Int64}(nvbus, nvbus, colptr, rowval, edge_va_to)
-    spedge_vm_to.nzval .= edge_vm_to
-    spedge_va_to.nzval .= edge_va_to
-    transpose!(spedge_vm_to, copy(spedge_vm_to))
-    transpose!(spedge_va_to, copy(spedge_va_to))
-    vm_to_nzval = spedge_vm_to.nzval
-    va_to_nzval = spedge_va_to.nzval
+    vm_to_nzval = @view edge_vm_to[transpose_perm]
+    va_to_nzval = @view edge_va_to[transpose_perm]
 
-    ev = kernel_node!(F, adj_F, vm, adj_vm, va, adj_va,
-            ybus_re.colptr, ybus_re.rowval,
-            edge_vm_from, vm_to_nzval,
-            edge_va_from, va_to_nzval,
-            ndrange=nvbus)
-    wait(ev)
+    cpu_adj_node_kernel!(F, adj_F, vm, adj_vm, va, adj_va,
+        ybus_re.colptr, ybus_re.rowval,
+        edge_vm_from, vm_to_nzval,
+        edge_va_from, va_to_nzval
+    )
 end
 
 KA.@kernel function transfer_kernel!(
@@ -470,93 +462,6 @@ function update!(polar::PolarForm, ::PS.Generators, ::PS.ActivePower, buffer::Po
         ndrange=range_
     )
     wait(ev)
-end
-
-KA.@kernel function adj_active_power_edge_kernel!(
-    pg, adj_pg,
-    vmag, adj_vmag, vang, adj_vang,
-    pinj, adj_pinj, qinj, adj_qinj,
-    pv, ref, pv_to_gen, ref_to_gen,
-    edge_vmag_bus, edge_vmag_to,
-    ybus_re_nzval, ybus_re_colptr, ybus_re_rowval,
-    ybus_im_nzval, pload
-)
-    i = @index(Global, Linear)
-    npv = length(pv)
-    nref = length(ref)
-    # Evaluate active power at PV nodes
-    if i <= npv
-        bus = pv[i]
-        i_gen = pv_to_gen[i]
-        pg[i_gen] = pinj[bus] + pload[bus]
-    # Evaluate active power at slack nodes
-    elseif i <= npv + nref
-        i_ = i - npv
-        bus = ref[i_]
-        i_gen = ref_to_gen[i_]
-        inj = 0
-        @inbounds for c in ybus_re_colptr[bus]:ybus_re_colptr[bus+1]-1
-            to = ybus_re_rowval[c]
-            aij = vang[bus] - vang[to]
-            # f_re = a * cos + b * sin
-            # f_im = a * sin - b * cos
-            coef_cos = vmag[bus]*vmag[to]*ybus_re_nzval[c]
-            coef_sin = vmag[bus]*vmag[to]*ybus_im_nzval[c]
-            cos_val = cos(aij)
-            sin_val = sin(aij)
-            inj += coef_cos * cos_val + coef_sin * sin_val
-        end
-        pg[i_gen] = inj + pload[bus]
-    end
-    if i <= npv
-        bus = pv[i]
-        i_gen = pv_to_gen[i]
-        adj_pinj[bus] = adj_pg[i_gen]
-        adj_pload[bus] = adj_pg[i_gen]
-    # Evaluate active power at slack nodes
-    elseif i <= npv + nref
-        i_ = i - npv
-        bus = ref[i_]
-        i_gen = ref_to_gen[i_]
-        inj = 0
-        @inbounds for c in ybus_re_colptr[bus]:ybus_re_colptr[bus+1]-1
-            to = ybus_re_rowval[c]
-            aij = vang[bus] - vang[to]
-            # f_re = a * cos + b * sin
-            # f_im = a * sin - b * cos
-            coef_cos = vmag[bus]*vmag[to]*ybus_re_nzval[c]
-            coef_sin = vmag[bus]*vmag[to]*ybus_im_nzval[c]
-            cos_val = cos(aij)
-            sin_val = sin(aij)
-            inj += coef_cos * cos_val + coef_sin * sin_val
-        end
-
-        adj_inj = adj_pg[i_gen]
-        adj_pload[bus] = adj_pg[i_gen]
-        @inbounds for c in ybus_re_colptr[bus]:ybus_re_colptr[bus+1]-1
-            to = ybus_re_rowval[c]
-            aij = vang[bus] - vang[to]
-            # f_re = a * cos + b * sin
-            # f_im = a * sin - b * cos
-            coef_cos = vmag[bus]*vmag[to]*ybus_re_nzval[c]
-            coef_sin = vmag[bus]*vmag[to]*ybus_im_nzval[c]
-            cos_val = cos(aij)
-            sin_val = sin(aij)
-
-            adj_coef_cos = cos_val  * adj_inj
-            adj_cos_val  = coef_cos * adj_inj
-            adj_coef_sin = sin_val  * adj_inj
-            adj_sin_val  = coef_sin * adj_inj
-
-            adj_aij =   cos_val*adj_sin_val
-            adj_aij += -sin_val*adj_cos_val
-
-            edge_vmag_bus[c] += vmag[to] *ybus_re_nzval[c]*adj_coef_cos
-            edge_vmag_to[c]  += vmag[bus]*ybus_re_nzval[c]*adj_coef_cos
-            edge_vmag_bus[c] += vmag[to] *ybus_im_nzval[c]*adj_coef_sin
-            edge_vmag_to[c]  += vmag[bus]*ybus_im_nzval[c]*adj_coef_sin
-        end
-    end
 end
 
 KA.@kernel function reactive_power_kernel!(
@@ -746,7 +651,7 @@ end
 
 function adj_reactive_power!(
     F::Vector{T}, adj_F, vm, adj_vm, va, adj_va,
-    ybus_re, ybus_im,
+    ybus_re, ybus_im, transpose_perm,
     pinj, adj_pinj, qinj, adj_qinj, reactive_load,
     pv, pq, ref, pv_to_gen, ref_to_gen, nbus
 ) where {T}
@@ -772,9 +677,6 @@ function adj_reactive_power!(
     rowval = ybus_re.rowval
 
     kernel_edge! = adj_reactive_power_edge_kernel!(KA.CPU())
-    kernel_node! = cpu_adj_node_kernel!(KA.CPU())
-    spedge_vmag_to = SparseMatrixCSC{T, Int64}(nvbus, nvbus, colptr, rowval, edge_vmag_to)
-    spedge_vang_to = SparseMatrixCSC{T, Int64}(nvbus, nvbus, colptr, rowval, edge_vang_to)
 
     range_ = length(pv) + length(ref)
 
@@ -793,21 +695,17 @@ function adj_reactive_power!(
     )
     wait(ev)
 
-    spedge_vmag_to.nzval .= edge_vmag_to
-    spedge_vang_to.nzval .= edge_vang_to
-    transpose!(spedge_vmag_to, copy(spedge_vmag_to))
-    transpose!(spedge_vang_to, copy(spedge_vang_to))
+    edge_vmag_to_t = @view edge_vmag_to[transpose_perm]
+    edge_vang_to_t = @view edge_vang_to[transpose_perm]
 
-    ev = kernel_node!(
+    cpu_adj_node_kernel!(
         F, adj_F,
         vm, adj_vm,
         va, adj_va,
         ybus_re.colptr, ybus_re.rowval,
-        edge_vmag_bus, spedge_vmag_to.nzval,
-        edge_vang_bus, spedge_vang_to.nzval,
-        ndrange=nvbus
+        edge_vmag_bus, edge_vmag_to_t,
+        edge_vang_bus, edge_vang_to_t,
     )
-    wait(ev)
 end
 
 KA.@kernel function branch_flow_kernel!(

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -6,7 +6,7 @@ import KernelAbstractions: @index
     function residual_kernel!(F, vm, va,
                                   colptr, rowval,
                                   ybus_re_nzval, ybus_im_nzval,
-                                  pinj, qinj, pv, pq, nbus)
+                                  pinj, qload, pv, pq, nbus)
 
 The residual CPU/GPU kernel of the powerflow residual.
 """
@@ -14,7 +14,7 @@ KA.@kernel function residual_kernel!(
     F, vm, va,
     colptr, rowval,
     ybus_re_nzval, ybus_im_nzval,
-    pinj, qinj, pv, pq, nbus
+    pinj, qload, pv, pq, nbus
 )
 
     npv = size(pv, 1)
@@ -27,7 +27,7 @@ KA.@kernel function residual_kernel!(
     fr = (i <= npv) ? pv[i] : pq[i - npv]
     F[i] -= pinj[fr]
     if i > npv
-        F[i + npq] -= qinj[fr]
+        F[i + npq] -= qload[fr]
     end
     @inbounds for c in colptr[fr]:colptr[fr+1]-1
         to = rowval[c]
@@ -46,13 +46,13 @@ KA.@kernel function residual_kernel!(
 end
 
 """
-    function residual_polar!(F, vm, va, pinj, qinj,
+    function residual_polar!(F, vm, va, pinj, qload,
                          ybus_re, ybus_im,
                          pv, pq, ref, nbus)
 
 The wrapper for the powerflow residual calling the CPU and GPU kernels.
 """
-function residual_polar!(F, vm, va, pinj, qinj,
+function residual_polar!(F, vm, va, pinj, qload,
                          ybus_re, ybus_im,
                          pv, pq, ref, nbus)
     npv = length(pv)
@@ -65,7 +65,7 @@ function residual_polar!(F, vm, va, pinj, qinj,
     ev = kernel!(F, vm, va,
                  ybus_re.colptr, ybus_re.rowval,
                  ybus_re.nzval, ybus_im.nzval,
-                 pinj, qinj, pv, pq, nbus,
+                 pinj, qload, pv, pq, nbus,
                  ndrange=npv+npq)
     wait(ev)
 end
@@ -225,7 +225,9 @@ This is the CUDA wrapper of the adjoint kernel that computes the adjoint of the 
 function adj_residual_polar!(
     F::CUDA.CuVector{T}, adj_F::CUDA.CuVector{T}, vm, adj_vm, va, adj_va,
     ybus_re, ybus_im, transpose_perm,
-    pinj, adj_pinj, qinj, pv, pq, nbus
+    pinj, adj_pinj, qinj,
+    edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
+    pv, pq, nbus
 ) where {T}
     npv = length(pv)
     npq = length(pq)
@@ -233,13 +235,6 @@ function adj_residual_polar!(
     nnz = length(ybus_re.nzval)
     colptr = ybus_re.colptr
     rowval = ybus_re.rowval
-    edge_vm_from = CUDA.zeros(T, nnz)
-    edge_vm_to   = CUDA.zeros(T, nnz)
-    edge_va_from = CUDA.zeros(T, nnz)
-    edge_va_to   = CUDA.zeros(T, nnz)
-    adj_vm   .= 0.0
-    adj_va   .= 0.0
-    adj_pinj .= 0.0
 
     kernel_edge! = adj_residual_edge_kernel!(KA.CUDADevice())
     kernel_node! = gpu_adj_node_kernel!(KA.CUDADevice())
@@ -282,7 +277,9 @@ This is the CPU wrapper of the adjoint kernel that computes the adjoint of the v
 function adj_residual_polar!(
     F::Vector{T}, adj_F::Vector{T}, vm, adj_vm, va, adj_va,
     ybus_re, ybus_im, transpose_perm,
-    pinj, adj_pinj, qinj, pv, pq, nbus
+    pinj, adj_pinj, qinj,
+    edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
+    pv, pq, nbus
 ) where {T}
     npv = length(pv)
     npq = length(pq)
@@ -290,13 +287,6 @@ function adj_residual_polar!(
     nnz = length(ybus_re.nzval)
     colptr = ybus_re.colptr
     rowval = ybus_re.rowval
-    edge_vm_from = zeros(T, nnz)
-    edge_vm_to   = zeros(T, nnz)
-    edge_va_from = zeros(T, nnz)
-    edge_va_to   = zeros(T, nnz)
-    adj_vm   .= 0.0
-    adj_va   .= 0.0
-    adj_pinj .= 0.0
 
     kernel_edge! = adj_residual_edge_kernel!(KA.CPU())
     ev = kernel_edge!(F, adj_F, vm, adj_vm, va, adj_va,
@@ -387,27 +377,60 @@ KA.@kernel function adj_transfer_kernel!(
     end
 end
 
+function _adj_transfer!(
+    adj_u, adj_x, adj_vmag, adj_vang, adj_pinj, pv, pq, ref,
+)
+    npv = length(pv)
+    npq = length(pq)
+    nref = length(ref)
+
+    # PQ buses
+    @inbounds for i in 1:npq
+        bus = pq[i]
+        adj_x[npv+i] =  adj_vang[bus]
+        adj_x[npv+npq+i] = adj_vmag[bus]
+    end
+    # PV buses
+    @inbounds for i_ in 1:npv
+        bus = pv[i_]
+        adj_u[nref + i_] = adj_vmag[bus]
+        adj_u[nref + npv + i_] += adj_pinj[bus]
+        adj_x[i_] = adj_vang[bus]
+    end
+    # SLACK buses
+    @inbounds for i_ in 1:nref
+        bus = ref[i_]
+        adj_u[i_] = adj_vmag[bus]
+    end
+end
+
 # Transfer values in (x, u) to buffer
 function adjoint_transfer!(
     polar::PolarForm,
     ∂u, ∂x,
-    ∂vm, ∂va, ∂pinj, ∂qinj,
+    ∂vm, ∂va, ∂pinj,
 )
     nbus = get(polar, PS.NumberOfBuses())
     pv = polar.indexing.index_pv
     pq = polar.indexing.index_pq
     ref = polar.indexing.index_ref
-    ev = adj_transfer_kernel!(polar.device)(
+    # TODO
+    ev = _adj_transfer!(
         ∂u, ∂x,
-        ∂vm, ∂va, ∂pinj, ∂qinj,
-        pv, pq, ref;
-        ndrange=nbus,
+        ∂vm, ∂va, ∂pinj,
+        pv, pq, ref
     )
-    wait(ev)
+    # ev = adj_transfer_kernel!(polar.device)(
+    #     ∂u, ∂x,
+    #     ∂vm, ∂va, ∂pinj, ∂qinj,
+    #     pv, pq, ref;
+    #     ndrange=nbus,
+    # )
+    # wait(ev)
 end
 
 KA.@kernel function active_power_kernel!(
-    pg, vmag, vang, pinj, qinj,
+    pg, vmag, vang, pinj,
     pv, ref, pv_to_gen, ref_to_gen,
     ybus_re_nzval, ybus_re_colptr, ybus_re_rowval,
     ybus_im_nzval, pload
@@ -455,7 +478,7 @@ function update!(polar::PolarForm, ::PS.Generators, ::PS.ActivePower, buffer::Po
 
     ev = kernel!(
         buffer.pg,
-        buffer.vmag, buffer.vang, buffer.pinj, buffer.qinj,
+        buffer.vmag, buffer.vang, buffer.pinj,
         pv, ref, pv_to_gen, ref_to_gen,
         ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
         ybus_im.nzval, polar.active_load,
@@ -465,7 +488,7 @@ function update!(polar::PolarForm, ::PS.Generators, ::PS.ActivePower, buffer::Po
 end
 
 KA.@kernel function reactive_power_kernel!(
-    qg, vmag, vang, pinj, qinj,
+    qg, vmag, vang, pinj,
     pv, ref, pv_to_gen, ref_to_gen,
     ybus_re_nzval, ybus_re_colptr, ybus_re_rowval,
     ybus_im_nzval, qload
@@ -510,7 +533,7 @@ function update!(polar::PolarForm, ::PS.Generators, ::PS.ReactivePower, buffer::
     range_ = length(pv) + length(ref)
     ev = kernel!(
         buffer.qg,
-        buffer.vmag, buffer.vang, buffer.pinj, buffer.qinj,
+        buffer.vmag, buffer.vang, buffer.pinj,
         pv, ref, pv_to_gen, ref_to_gen,
         ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
         ybus_im.nzval, polar.reactive_load,
@@ -522,7 +545,7 @@ end
 KA.@kernel function adj_reactive_power_edge_kernel!(
     qg, adj_qg,
     vmag, adj_vmag, vang, adj_vang,
-    pinj, adj_pinj, qinj, adj_qinj,
+    pinj, adj_pinj,
     pv, ref, pv_to_gen, ref_to_gen,
     edge_vmag_bus, edge_vmag_to,
     edge_vang_bus, edge_vang_to,
@@ -590,7 +613,9 @@ end
 function adj_reactive_power!(
     F::CUDA.CuVector{T}, adj_F, vm, adj_vm, va, adj_va,
     ybus_re, ybus_im,
-    pinj, adj_pinj, qinj, adj_qinj, reactive_load,
+    pinj, adj_pinj,
+    edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
+    reactive_load,
     pv, pq, ref, pv_to_gen, ref_to_gen, nbus
 ) where {T}
     npv = length(pv)
@@ -599,18 +624,6 @@ function adj_reactive_power!(
     nnz = length(ybus_re.nzval)
     colptr = ybus_re.colptr
     rowval = ybus_re.rowval
-    edge_vm_from = CUDA.zeros(T, nnz)
-    edge_vm_to   = CUDA.zeros(T, nnz)
-    edge_va_from = CUDA.zeros(T, nnz)
-    edge_va_to   = CUDA.zeros(T, nnz)
-    adj_vm   .= 0.0
-    adj_va   .= 0.0
-    if adj_pinj !== nothing
-        adj_pinj .= 0.0
-    end
-    if adj_qinj !== nothing
-        adj_qinj .= 0.0
-    end
 
     kernel_edge! = adj_reactive_power_edge_kernel!(KA.CUDADevice())
     kernel_node! = gpu_adj_node_kernel!(KA.CUDADevice())
@@ -626,7 +639,6 @@ function adj_reactive_power!(
         vm, adj_vm,
         va, adj_va,
         pinj, adj_pinj,
-        qinj, adj_qinj,
         pv, ref, pv_to_gen, ref_to_gen,
         edge_vm_from, edge_vm_to,
         edge_va_from, edge_va_to,
@@ -652,26 +664,15 @@ end
 function adj_reactive_power!(
     F::Vector{T}, adj_F, vm, adj_vm, va, adj_va,
     ybus_re, ybus_im, transpose_perm,
-    pinj, adj_pinj, qinj, adj_qinj, reactive_load,
+    pinj, adj_pinj,
+    edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
+    reactive_load,
     pv, pq, ref, pv_to_gen, ref_to_gen, nbus
 ) where {T}
     npv = length(pv)
     npq = length(pq)
     nvbus = length(vm)
     nnz = length(ybus_re.nzval)
-
-    edge_vmag_bus = zeros(T, nnz)
-    edge_vmag_to  = zeros(T, nnz)
-    edge_vang_bus = zeros(T, nnz)
-    edge_vang_to  = zeros(T, nnz)
-    adj_vm   .= 0.0
-    adj_va   .= 0.0
-    if adj_pinj !== nothing
-        adj_pinj .= 0.0
-    end
-    if adj_qinj !== nothing
-        adj_qinj .= 0.0
-    end
 
     colptr = ybus_re.colptr
     rowval = ybus_re.rowval
@@ -685,26 +686,25 @@ function adj_reactive_power!(
         vm, adj_vm,
         va, adj_va,
         pinj, adj_pinj,
-        qinj, adj_qinj,
         pv, ref, pv_to_gen, ref_to_gen,
-        edge_vmag_bus, edge_vmag_to,
-        edge_vang_bus, edge_vang_to,
+        edge_vm_from, edge_vm_to,
+        edge_va_from, edge_va_to,
         ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
         ybus_im.nzval, reactive_load,
         ndrange=range_
     )
     wait(ev)
 
-    edge_vmag_to_t = @view edge_vmag_to[transpose_perm]
-    edge_vang_to_t = @view edge_vang_to[transpose_perm]
+    edge_vm_to_t = @view edge_vm_to[transpose_perm]
+    edge_va_to_t = @view edge_va_to[transpose_perm]
 
     cpu_adj_node_kernel!(
         F, adj_F,
         vm, adj_vm,
         va, adj_va,
         ybus_re.colptr, ybus_re.rowval,
-        edge_vmag_bus, edge_vmag_to_t,
-        edge_vang_bus, edge_vang_to_t,
+        edge_vm_from, edge_vm_to_t,
+        edge_va_from, edge_va_to_t,
     )
 end
 
@@ -835,30 +835,15 @@ end
 
 function adj_branch_flow!(
         adj_slines, vm, adj_vm, va, adj_va,
+        adj_vm_from_lines, adj_va_from_lines, adj_vm_to_lines, adj_va_to_lines,
         yff_re, yft_re, ytf_re, ytt_re,
         yff_im, yft_im, ytf_im, ytt_im,
         f, t, nlines, device
     )
-    T = typeof(adj_va)
     nvbus = length(va)
     kernel_edge! = adj_branch_flow_edge_kernel!(device)
     kernel_node! = adj_branch_flow_node_kernel!(device)
-    if device == CUDADevice()
-        T = CUDA.CuVector{eltype(va)}
-    elseif device == CPU()
-        T = Vector{eltype(va)}
-    end
 
-    adj_vm_to_lines   = T(undef, nlines)
-    adj_vm_from_lines = T(undef, nlines)
-    adj_va_to_lines   = T(undef, nlines)
-    adj_va_from_lines = T(undef, nlines)
-    adj_vm_to_lines   .= 0.0
-    adj_vm_from_lines .= 0.0
-    adj_va_to_lines   .= 0.0
-    adj_va_from_lines .= 0.0
-    adj_vm   .= 0.0
-    adj_va   .= 0.0
     ev = kernel_edge!(
             adj_slines, vm, adj_vm, va, adj_va,
             adj_va_to_lines, adj_va_from_lines, adj_vm_to_lines, adj_vm_from_lines,

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -4,9 +4,9 @@ import KernelAbstractions: @index
 
 """
     function residual_kernel!(F, vm, va,
-                                  colptr, rowval,
-                                  ybus_re_nzval, ybus_im_nzval,
-                                  pinj, qload, pv, pq, nbus)
+                              colptr, rowval,
+                              ybus_re_nzval, ybus_im_nzval,
+                              pinj, qload, pv, pq, nbus)
 
 The residual CPU/GPU kernel of the powerflow residual.
 """
@@ -52,9 +52,10 @@ end
 
 The wrapper for the powerflow residual calling the CPU and GPU kernels.
 """
-function residual_polar!(F, vm, va, pinj, qload,
-                         ybus_re, ybus_im,
-                         pv, pq, ref, nbus)
+function residual_polar!(
+    F, vm, va, pinj, qload,
+    ybus_re, ybus_im, pv, pq, ref, nbus
+)
     npv = length(pv)
     npq = length(pq)
     if isa(F, Array)
@@ -163,7 +164,7 @@ This kernel accumulates the adjoint of the voltage magnitude `adj_vm`
 and `adj_va` from the edges of the graph stored as CSC matrices.
 """
 function cpu_adj_node_kernel!(
-    F, adj_F, vm, adj_vm, va, adj_va,
+    adj_vm, adj_va,
     colptr, rowval,
     edge_vm_from, edge_vm_to,
     edge_va_from, edge_va_to
@@ -195,40 +196,43 @@ CUDA does not support efficient CSR -> CSC conversion, hence COO was used.
 KA.@kernel function gpu_adj_node_kernel!(
     adj_vm, adj_va,
     colptr, rowval,
-    edge_vm_from, edge_va_from,
-    edge_vm_a, edge_vm_i, edge_vm_j,
-    edge_va_a, edge_va_i, edge_va_j,
+    edge_vm_from, edge_vm_to,
+    edge_va_from, edge_va_to,
 )
     i = @index(Global, Linear)
     @inbounds for c in colptr[i]:colptr[i+1]-1
         adj_vm[i] += edge_vm_from[c]
+        adj_vm[i] += edge_vm_to[c]
         adj_va[i] += edge_va_from[c]
-    end
-    nnz = length(edge_vm_a)
-    for c in 1:nnz
-        if edge_va_j[c] == i
-            adj_vm[i] += edge_vm_a[c]
-            adj_va[i] += edge_va_a[c]
-        end
+        adj_va[i] += edge_va_to[c]
     end
 end
 
 """
     function adj_residual_polar!(
-        F::CUDA.CuVector{T}, adj_F::CUDA.CuVector{T}, vm, adj_vm, va, adj_va,
+        F, adj_F, vm, adj_vm, va, adj_va,
         ybus_re, ybus_im,
-        pinj, adj_pinj, qinj, pv, pq, nbus
+        pinj, adj_pinj, qinj,
+        edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
+        pv, pq, nbus
     ) where {T}
 
-This is the CUDA wrapper of the adjoint kernel that computes the adjoint of the voltage magnitude `adj_vm` and `adj_va` with respect to the residual `F` and the adjoint `adj_F`.
+This is the wrapper of the adjoint kernel that computes the adjoint of
+the voltage magnitude `adj_vm` and `adj_va` with respect to the residual `F`
+and the adjoint `adj_F`.
 """
 function adj_residual_polar!(
-    F::CUDA.CuVector{T}, adj_F::CUDA.CuVector{T}, vm, adj_vm, va, adj_va,
+    F, adj_F, vm, adj_vm, va, adj_va,
     ybus_re, ybus_im, transpose_perm,
     pinj, adj_pinj, qinj,
     edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
     pv, pq, nbus
 ) where {T}
+    if isa(F, CUDA.CuVector)
+        device = KA.CUDADevice()
+    else
+        device = KA.CPU()
+    end
     npv = length(pv)
     npq = length(pq)
     nvbus = length(vm)
@@ -236,13 +240,7 @@ function adj_residual_polar!(
     colptr = ybus_re.colptr
     rowval = ybus_re.rowval
 
-    kernel_edge! = adj_residual_edge_kernel!(KA.CUDADevice())
-    kernel_node! = gpu_adj_node_kernel!(KA.CUDADevice())
-    spedge_vm_to = CUSPARSE.CuSparseMatrixCSR{T}(colptr, rowval, edge_vm_to,(nvbus,nvbus))
-    spedge_va_to = CUSPARSE.CuSparseMatrixCSR{T}(colptr, rowval, edge_va_to,(nvbus,nvbus))
-    tspedge_vm_to = CUSPARSE.CuSparseMatrixCOO(spedge_vm_to)
-    tspedge_va_to = CUSPARSE.CuSparseMatrixCOO(spedge_va_to)
-
+    kernel_edge! = adj_residual_edge_kernel!(device)
     ev = kernel_edge!(F, adj_F, vm, adj_vm, va, adj_va,
                  ybus_re.colptr, ybus_re.rowval,
                  ybus_re.nzval, ybus_im.nzval,
@@ -252,60 +250,27 @@ function adj_residual_polar!(
                  ndrange=npv+npq)
     wait(ev)
 
-    tspedge_vm_to.nzVal .= spedge_vm_to.nzVal
-    tspedge_va_to.nzVal .= spedge_va_to.nzVal
-
-    ev = kernel_node!(adj_vm, adj_va,
-            ybus_re.colptr, ybus_re.rowval,
-            edge_vm_from, edge_va_from,
-            tspedge_vm_to.nzVal, tspedge_vm_to.rowInd, tspedge_vm_to.colInd,
-            tspedge_va_to.nzVal, tspedge_va_to.rowInd, tspedge_va_to.colInd,
-            ndrange=nvbus)
-    wait(ev)
-end
-
-# TODO: clean
-"""
-    function adj_residual_polar!(
-        F::CUDA.CuVector{T}, adj_F::CUDA.CuVector{T}, vm, adj_vm, va, adj_va,
-        ybus_re, ybus_im,
-        pinj, adj_pinj, qinj, pv, pq, nbus
-    ) where {T}
-
-This is the CPU wrapper of the adjoint kernel that computes the adjoint of the voltage magnitude `adj_vm` and `adj_va` with respect to the residual `F` and the adjoint `adj_F`.
-"""
-function adj_residual_polar!(
-    F::Vector{T}, adj_F::Vector{T}, vm, adj_vm, va, adj_va,
-    ybus_re, ybus_im, transpose_perm,
-    pinj, adj_pinj, qinj,
-    edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
-    pv, pq, nbus
-) where {T}
-    npv = length(pv)
-    npq = length(pq)
-    nvbus = length(vm)
-    nnz = length(ybus_re.nzval)
-    colptr = ybus_re.colptr
-    rowval = ybus_re.rowval
-
-    kernel_edge! = adj_residual_edge_kernel!(KA.CPU())
-    ev = kernel_edge!(F, adj_F, vm, adj_vm, va, adj_va,
-                 ybus_re.colptr, ybus_re.rowval,
-                 ybus_re.nzval, ybus_im.nzval,
-                 edge_vm_from, edge_vm_to,
-                 edge_va_from, edge_va_to,
-                 pinj, adj_pinj, qinj, pv, pq,
-                 ndrange=npv+npq)
-    wait(ev)
-
+    # Apply the permutation corresponding to the transpose of Ybus.
     vm_to_nzval = @view edge_vm_to[transpose_perm]
     va_to_nzval = @view edge_va_to[transpose_perm]
 
-    cpu_adj_node_kernel!(F, adj_F, vm, adj_vm, va, adj_va,
-        ybus_re.colptr, ybus_re.rowval,
-        edge_vm_from, vm_to_nzval,
-        edge_va_from, va_to_nzval
-    )
+    if isa(device, CPU)
+        cpu_adj_node_kernel!(
+            adj_vm, adj_va,
+            ybus_re.colptr, ybus_re.rowval,
+            edge_vm_from, vm_to_nzval,
+            edge_va_from, va_to_nzval
+        )
+    else
+        ev = gpu_adj_node_kernel!(device)(
+            adj_vm, adj_va,
+            ybus_re.colptr, ybus_re.rowval,
+            edge_vm_from, vm_to_nzval,
+            edge_va_from, va_to_nzval,
+            ndrange=nvbus,
+        )
+        wait(ev)
+    end
 end
 
 KA.@kernel function transfer_kernel!(
@@ -350,7 +315,7 @@ function transfer!(polar::PolarForm, buffer::PolarNetworkState, u)
 end
 
 KA.@kernel function adj_transfer_kernel!(
-    adj_u, adj_x, adj_vmag, adj_vang, adj_pinj, adj_qinj, pv, pq, ref,
+    adj_u, adj_x, adj_vmag, adj_vang, adj_pinj, pv, pq, ref,
 )
     i = @index(Global, Linear)
     npv = length(pv)
@@ -377,7 +342,7 @@ KA.@kernel function adj_transfer_kernel!(
     end
 end
 
-function _adj_transfer!(
+function _cpu_adj_transfer!(
     adj_u, adj_x, adj_vmag, adj_vang, adj_pinj, pv, pq, ref,
 )
     npv = length(pv)
@@ -414,19 +379,22 @@ function adjoint_transfer!(
     pv = polar.indexing.index_pv
     pq = polar.indexing.index_pq
     ref = polar.indexing.index_ref
-    # TODO
-    ev = _adj_transfer!(
-        ∂u, ∂x,
-        ∂vm, ∂va, ∂pinj,
-        pv, pq, ref
-    )
-    # ev = adj_transfer_kernel!(polar.device)(
-    #     ∂u, ∂x,
-    #     ∂vm, ∂va, ∂pinj, ∂qinj,
-    #     pv, pq, ref;
-    #     ndrange=nbus,
-    # )
-    # wait(ev)
+    # The adjoint of transfer is performance critical code.
+    # To avoid KernelAbstractions's overhead on the CPU, we
+    # don't use a kernel and use _cpu_adj_transfer instead.
+    if isa(polar.device, CPU)
+        _cpu_adj_transfer!(
+            ∂u, ∂x, ∂vm, ∂va, ∂pinj, pv, pq, ref
+        )
+    else
+        ev = adj_transfer_kernel!(polar.device)(
+            ∂u, ∂x,
+            ∂vm, ∂va, ∂pinj,
+            pv, pq, ref;
+            ndrange=nbus,
+        )
+        wait(ev)
+    end
 end
 
 KA.@kernel function active_power_kernel!(
@@ -487,6 +455,55 @@ function update!(polar::PolarForm, ::PS.Generators, ::PS.ActivePower, buffer::Po
     wait(ev)
 end
 
+KA.@kernel function adj_active_power_kernel!(
+    adj_pg,
+    vmag, adj_vmag, vang, adj_vang, adj_pinj,
+    pv, ref, pv_to_gen, ref_to_gen,
+    ybus_re_nzval, ybus_re_colptr, ybus_re_rowval, ybus_im_nzval,
+)
+    i = @index(Global, Linear)
+    npv = length(pv)
+    nref = length(ref)
+    if i <= npv
+        bus = pv[i]
+        i_gen = pv_to_gen[i]
+        adj_pinj[bus] = adj_pg[i_gen]
+    # Evaluate active power at slack nodes
+    elseif i <= npv + nref
+        i_ = i - npv
+        fr = ref[i_]
+        i_gen = ref_to_gen[i_]
+
+        adj_inj = adj_pg[i_gen]
+        @inbounds for c in ybus_re_colptr[fr]:ybus_re_colptr[fr+1]-1
+            to = ybus_re_rowval[c]
+            aij = vang[fr] - vang[to]
+            # f_re = a * cos + b * sin
+            # f_im = a * sin - b * cos
+            coef_cos = vmag[fr]*vmag[to]*ybus_re_nzval[c]
+            coef_sin = vmag[fr]*vmag[to]*ybus_im_nzval[c]
+            cosθ = cos(aij)
+            sinθ = sin(aij)
+
+            adj_coef_cos = cosθ  * adj_inj
+            adj_cos_val  = coef_cos * adj_inj
+            adj_coef_sin = sinθ  * adj_inj
+            adj_sin_val  = coef_sin * adj_inj
+
+            adj_aij =   cosθ * adj_sin_val
+            adj_aij -=  sinθ * adj_cos_val
+
+            adj_vmag[fr] += vmag[to] * ybus_re_nzval[c] * adj_coef_cos
+            adj_vmag[to] += vmag[fr] * ybus_re_nzval[c] * adj_coef_cos
+            adj_vmag[fr] += vmag[to] * ybus_im_nzval[c] * adj_coef_sin
+            adj_vmag[to] += vmag[fr] * ybus_im_nzval[c] * adj_coef_sin
+
+            adj_vang[fr] += adj_aij
+            adj_vang[to] -= adj_aij
+        end
+    end
+end
+
 KA.@kernel function reactive_power_kernel!(
     qg, vmag, vang, pinj,
     pv, ref, pv_to_gen, ref_to_gen,
@@ -506,7 +523,7 @@ KA.@kernel function reactive_power_kernel!(
         bus = ref[i_]
         i_gen = ref_to_gen[i_]
     end
-    inj = 0
+    inj = 0.0
     @inbounds for c in ybus_re_colptr[bus]:ybus_re_colptr[bus+1]-1
         to = ybus_re_rowval[c]
         aij = vang[bus] - vang[to]
@@ -609,66 +626,19 @@ KA.@kernel function adj_reactive_power_edge_kernel!(
     end
 end
 
-# Refresh active power (needed to evaluate objective)
 function adj_reactive_power!(
-    F::CUDA.CuVector{T}, adj_F, vm, adj_vm, va, adj_va,
-    ybus_re, ybus_im,
-    pinj, adj_pinj,
-    edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
-    reactive_load,
-    pv, pq, ref, pv_to_gen, ref_to_gen, nbus
-) where {T}
-    npv = length(pv)
-    npq = length(pq)
-    nvbus = length(vm)
-    nnz = length(ybus_re.nzval)
-    colptr = ybus_re.colptr
-    rowval = ybus_re.rowval
-
-    kernel_edge! = adj_reactive_power_edge_kernel!(KA.CUDADevice())
-    kernel_node! = gpu_adj_node_kernel!(KA.CUDADevice())
-    spedge_vm_to = CUSPARSE.CuSparseMatrixCSR{T}(colptr, rowval, edge_vm_to,(nvbus,nvbus))
-    spedge_va_to = CUSPARSE.CuSparseMatrixCSR{T}(colptr, rowval, edge_va_to,(nvbus,nvbus))
-    tspedge_vm_to = CUSPARSE.CuSparseMatrixCOO(spedge_vm_to)
-    tspedge_va_to = CUSPARSE.CuSparseMatrixCOO(spedge_va_to)
-
-    range_ = length(pv) + length(ref)
-
-    ev = kernel_edge!(
-        F, adj_F,
-        vm, adj_vm,
-        va, adj_va,
-        pinj, adj_pinj,
-        pv, ref, pv_to_gen, ref_to_gen,
-        edge_vm_from, edge_vm_to,
-        edge_va_from, edge_va_to,
-        ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
-        ybus_im.nzval, reactive_load,
-        ndrange=range_
-    )
-    wait(ev)
-
-    tspedge_vm_to.nzVal .= spedge_vm_to.nzVal
-    tspedge_va_to.nzVal .= spedge_va_to.nzVal
-
-    ev = kernel_node!(adj_vm, adj_va,
-            ybus_re.colptr, ybus_re.rowval,
-            edge_vm_from, edge_va_from,
-            tspedge_vm_to.nzVal, tspedge_vm_to.rowInd, tspedge_vm_to.colInd,
-            tspedge_va_to.nzVal, tspedge_va_to.rowInd, tspedge_va_to.colInd,
-            ndrange=nvbus
-    )
-    wait(ev)
-end
-
-function adj_reactive_power!(
-    F::Vector{T}, adj_F, vm, adj_vm, va, adj_va,
+    F, adj_F, vm, adj_vm, va, adj_va,
     ybus_re, ybus_im, transpose_perm,
     pinj, adj_pinj,
     edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
     reactive_load,
     pv, pq, ref, pv_to_gen, ref_to_gen, nbus
 ) where {T}
+    if isa(F, CUDA.CuVector)
+        device = KA.CUDADevice()
+    else
+        device = KA.CPU()
+    end
     npv = length(pv)
     npq = length(pq)
     nvbus = length(vm)
@@ -677,7 +647,7 @@ function adj_reactive_power!(
     colptr = ybus_re.colptr
     rowval = ybus_re.rowval
 
-    kernel_edge! = adj_reactive_power_edge_kernel!(KA.CPU())
+    kernel_edge! = adj_reactive_power_edge_kernel!(device)
 
     range_ = length(pv) + length(ref)
 
@@ -695,17 +665,26 @@ function adj_reactive_power!(
     )
     wait(ev)
 
-    edge_vm_to_t = @view edge_vm_to[transpose_perm]
-    edge_va_to_t = @view edge_va_to[transpose_perm]
+    vm_to_nzval = @view edge_vm_to[transpose_perm]
+    va_to_nzval = @view edge_va_to[transpose_perm]
+    if isa(device, CPU)
+        cpu_adj_node_kernel!(
+            adj_vm, adj_va,
+            ybus_re.colptr, ybus_re.rowval,
+            edge_vm_from, vm_to_nzval,
+            edge_va_from, va_to_nzval
+        )
+    else
+        ev = gpu_adj_node_kernel!(device)(
+            adj_vm, adj_va,
+            ybus_re.colptr, ybus_re.rowval,
+            edge_vm_from, vm_to_nzval,
+            edge_va_from, va_to_nzval,
+            ndrange=nvbus,
+        )
+        wait(ev)
+    end
 
-    cpu_adj_node_kernel!(
-        F, adj_F,
-        vm, adj_vm,
-        va, adj_va,
-        ybus_re.colptr, ybus_re.rowval,
-        edge_vm_from, edge_vm_to_t,
-        edge_va_from, edge_va_to_t,
-    )
 end
 
 KA.@kernel function branch_flow_kernel!(
@@ -821,7 +800,7 @@ KA.@kernel function adj_branch_flow_node_kernel!(vm, adj_vm, va, adj_va,
         f, t, nlines
 )
     i = @index(Global, Linear)
-    for ℓ in 1:nlines
+    @inbounds for ℓ in 1:nlines
         if f[ℓ] == i
             adj_vm[i] += adj_vm_from_lines[ℓ]
             adj_va[i] += adj_va_from_lines[ℓ]

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -105,7 +105,7 @@ end
 # Cache for adjoint
 # Largely inspired from ChainRulesCore.jl:
 # https://juliadiff.org/ChainRulesCore.jl/stable/design/changing_the_primal.html#The-Journey-to-rrule
-struct PullbackMemory{F, S, I}
+struct TapeMemory{F, S, I}
     func::F
     stack::S
     intermediate::I

--- a/test/Polar/autodiff.jl
+++ b/test/Polar/autodiff.jl
@@ -33,7 +33,7 @@
         ]
             m = ExaPF.size_constraint(polar, cons)
             # Allocation
-            pbm = AutoDiff.PullbackMemory(polar, cons, typeof(u))
+            pbm = AutoDiff.TapeMemory(polar, cons, typeof(u))
             tgt = rand(m)
             c = zeros(m)
 

--- a/test/Polar/gradient.jl
+++ b/test/Polar/gradient.jl
@@ -29,6 +29,7 @@ const KA = KernelAbstractions
         jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
         ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
         ∂obj = ExaPF.AdjointStackObjective(polar)
+        pbm = AutoDiff.PullbackMemory(ExaPF.active_power_constraints, ∂obj, nothing)
 
         # solve power flow
         conv = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-12))
@@ -50,7 +51,7 @@ const KA = KernelAbstractions
             ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
             # We need uk here for the closure
             uk = copy(u)
-            ExaPF.gradient_objective!(polar, ∂obj, cache)
+            ExaPF.gradient_objective!(polar, pbm, cache)
             ∇fₓ = ∂obj.∇fₓ
             ∇fᵤ = ∂obj.∇fᵤ
 

--- a/test/Polar/gradient.jl
+++ b/test/Polar/gradient.jl
@@ -29,7 +29,7 @@ const KA = KernelAbstractions
         jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
         ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
         ∂obj = ExaPF.AdjointStackObjective(polar)
-        pbm = AutoDiff.PullbackMemory(ExaPF.active_power_constraints, ∂obj, nothing)
+        pbm = AutoDiff.TapeMemory(ExaPF.active_power_constraints, ∂obj, nothing)
 
         # solve power flow
         conv = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-12))

--- a/test/Polar/hessian.jl
+++ b/test/Polar/hessian.jl
@@ -53,6 +53,8 @@ const PS = PowerSystem
             jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
             ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
             ∂obj = ExaPF.AdjointStackObjective(polar)
+            pbm = AutoDiff.PullbackMemory(ExaPF.active_power_constraints, ∂obj, nothing)
+
             cpu_jx = AutoDiff.Jacobian(cpu_polar, ExaPF.power_balance, State())
             cpu_ju = AutoDiff.Jacobian(cpu_polar, ExaPF.power_balance, Control())
             cpu_∂obj = ExaPF.AdjointStackObjective(cpu_polar)
@@ -86,7 +88,7 @@ const PS = PowerSystem
             Jₓ = ExaPF.matpower_jacobian(polar, State(), ExaPF.power_balance, V)
             @test isapprox(∇gₓ, Jₓ )
             # Hessian vector product
-            ExaPF.gradient_objective!(polar, ∂obj, cache)
+            ExaPF.gradient_objective!(polar, pbm, cache)
             ∇fₓ = ∂obj.∇fₓ
             ∇fᵤ = ∂obj.∇fᵤ
             λ  = -(Array(∇gₓ')) \ Array(∇fₓ)


### PR DESCRIPTION
This PR removes most of the allocations that occurred in the kernels, when: 
- we compute explicitly a transpose matrix each time we called the adjoints of `reactive_power` or `power_balance`
- we allocate 4 intermediate caches each time we called the adjoints of `reactive_power`, `power_balance`, `line_flow`

We introduce a new `PullbackMemory` object to cache the intermediate caches needed in the computation:
- now, the functions `adjoint!` and `jtprod!` takes as input a `PullbackMemory` object
- the Hessian has been modified and has its own `PullbackMemory`, of `Dual` type

The pullback memory object is greatly inspired from [ChainRulesCore](https://juliadiff.org/ChainRulesCore.jl/stable/design/changing_the_primal.html#The-Journey-to-rrule)
The benchmarks are promising, and we are now almost on par with Matpower's Hessian. For `case300.m`, on the CPU, we get

- Original Matpower's Hessian
```
  Hessprod          194.124 μs (34 allocations: 168.84 KiB)
```
- First implementation of Hessian with AutoDiff: 
```
  Hessprod          369.569 μs (98 allocations: 222.25 KiB)
```
- Removing the allocation in the kernels (this PR)
```
   Hessprod          319.977 μs (51 allocations: 88.39 KiB)
```
- Combining with PR #128 
```
Hessprod          299.846 μs (32 allocations: 67.56 KiB)

```
