### PR TITLE
Fix powerflow with nonzero slack's voltage angle

### DIFF
--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -345,7 +345,6 @@ KA.@kernel function transfer_kernel!(
         i_ref = i - npv
         bus = ref[i_ref]
         vmag[bus] = u[i_ref]
-        vang[bus] = 0.0  # reference angle set to 0 by default
     end
 end
 


### PR DESCRIPTION
Before pushing this change, I have investigated why we get a difference of behavior between the CPU and the GPU when resolving the powerflow. 

It appears that the difference was caused by both
- conflicts on the GPU when someone else is running heavy computation (explaining difference in convergence pattern when starting from the same initial point)
- non-regeneration of KA kernels on the GPU when using Revise (explaining why we get a different starting point between the CPU and the GPU when the slack's voltage angle was nonzero)

With this PR, the stacktrace of the powerflow solver for `case30K` is: 
- On the CPU+UMFPACK:
```
 Iteration 0. Residual norm: 21.6402.
Iteration 1. Residual norm: 1.27923.
Iteration 2. Residual norm: 0.0150574.
Iteration 3. Residual norm: 5.09504e-05.
Iteration 4. Residual norm: 6.17504e-10.
Iteration 5. Residual norm: 3.55443e-11.
```
- On the GPU+CUSOLVER:
```
Iteration 0. Residual norm: 21.6402.
Iteration 1. Residual norm: 1.27923.
Iteration 2. Residual norm: 0.0150574.
Iteration 3. Residual norm: 5.09504e-05.
Iteration 4. Residual norm: 6.1734e-10.
Iteration 5. Residual norm: 3.4709e-11.

```