### PR TITLE
[MOI] clean Hessian in MathOptInterface wrapper

### DIFF
--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -48,26 +48,25 @@ function ojtprod!(nlp::AbstractNLPEvaluator, jv, u, σ, v)
 end
 
 # Common interface for Hessian
-# Build full Hessian matrix using `n` Hessian-vector product
-function hessian!(nlp::AbstractNLPEvaluator, H, x)
+function hessian!(nlp::AbstractNLPEvaluator, hess, x)
     n = n_variables(nlp)
     v = similar(x)
-    hv = similar(x)
-    for i in 1:n
+    @inbounds for i in 1:n
+        hv = @view hess[:, i]
         fill!(v, 0)
         v[i] = 1.0
         hessprod!(nlp, hv, x, v)
-        H[:, i] .= hv
     end
 end
 
-function hessian_lagrangian_penalty!(nlp::AbstractNLPEvaluator, H, x, y, σ, D,)
+function hessian_lagrangian_penalty!(nlp::AbstractNLPEvaluator, hess, x, y, σ, D,)
     n = n_variables(nlp)
     v = similar(x)
-    for i in 1:n
+    @inbounds for i in 1:n
+        hv = @view hess[:, i]
         fill!(v, 0)
         v[i] = 1.0
-        hessian_lagrangian_penalty_prod!(nlp, view(H, :, i), x, y, σ, v, D)
+        hessian_lagrangian_penalty_prod!(nlp, hv, x, y, σ, v, D)
     end
 end
 

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -332,8 +332,8 @@ end
 function jacobian_structure!(nlp::ReducedSpaceEvaluator, rows, cols)
     m, n = n_constraints(nlp), n_variables(nlp)
     idx = 1
-    for c in 1:m #number of constraints
-        for i in 1:n # number of variables
+    for i in 1:n # number of variables
+        for c in 1:m #number of constraints
             rows[idx] = c ; cols[idx] = i
             idx += 1
         end
@@ -383,9 +383,9 @@ function jprod!(nlp::ReducedSpaceEvaluator, jv, u, v)
 
     ∇gᵤ = nlp.state_jacobian.u.J
     rhs = nlp.buffer.dx
+    z = nlp.buffer.balance
     # init RHS
     mul!(rhs, ∇gᵤ, v)
-    z = similar(rhs)
     # Compute z
     _forward_solve!(nlp, z, rhs)
 

--- a/src/Evaluators/slack_evaluator.jl
+++ b/src/Evaluators/slack_evaluator.jl
@@ -209,15 +209,16 @@ function hessian_lagrangian_penalty_prod!(
 end
 
 function hessian_lagrangian_penalty!(
-    nlp::SlackEvaluator, hess, x, y, σ, w,
+    nlp::SlackEvaluator, H, x, y, σ, w,
 )
+
     n = n_variables(nlp)
     @views begin
         u   = x[1:nlp.nv]
-        Hᵤᵤ = hess[1:nlp.nv, 1:nlp.nv]
-        Hᵤᵥ = hess[1:nlp.nv, 1+nlp.nv:n]
-        Hᵥᵤ = hess[1+nlp.nv:n, 1:nlp.nv]
-        Hᵥᵥ = hess[1+nlp.nv:n, 1+nlp.nv:n]
+        Hᵤᵤ = H[1:nlp.nv, 1:nlp.nv]
+        Hᵤᵥ = H[1:nlp.nv, 1+nlp.nv:n]
+        Hᵥᵤ = H[1+nlp.nv:n, 1:nlp.nv]
+        Hᵥᵥ = H[1+nlp.nv:n, 1+nlp.nv:n]
     end
     # w.r.t. uu
     # ∇²L + ρ Jᵤ' * Jᵤ

--- a/test/Evaluators/MOI_wrapper.jl
+++ b/test/Evaluators/MOI_wrapper.jl
@@ -23,16 +23,33 @@ const MOI = MathOptInterface
 
     datafile = joinpath(INSTANCES_DIR, "case57.m")
     nlp = ExaPF.ReducedSpaceEvaluator(datafile)
-    optimizer = Ipopt.Optimizer()
-    MOI.set(optimizer, MOI.RawParameter("print_level"), 0)
-    MOI.set(optimizer, MOI.RawParameter("limited_memory_max_history"), 50)
-    MOI.set(optimizer, MOI.RawParameter("hessian_approximation"), "limited-memory")
-    MOI.set(optimizer, MOI.RawParameter("tol"), 1e-4)
 
-    solution = ExaPF.optimize!(optimizer, nlp)
-    MOI.empty!(optimizer)
-    @test solution.status ∈ [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
-    @test solution.minimum ≈ 3.7589338e+04
-    @test solution.minimizer ≈ CASE57_SOLUTION rtol=1e-5
+    @testset "ReducedSpaceEvaluator with L-BFGS" begin
+        optimizer = Ipopt.Optimizer()
+        MOI.set(optimizer, MOI.RawParameter("print_level"), 0)
+        MOI.set(optimizer, MOI.RawParameter("limited_memory_max_history"), 50)
+        MOI.set(optimizer, MOI.RawParameter("hessian_approximation"), "limited-memory")
+        MOI.set(optimizer, MOI.RawParameter("tol"), 1e-4)
+
+        solution = ExaPF.optimize!(optimizer, nlp)
+        MOI.empty!(optimizer)
+        @test solution.status ∈ [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
+        @test solution.minimum ≈ 3.7589338e+04
+        @test solution.minimizer ≈ CASE57_SOLUTION rtol=1e-5
+    end
+
+    # Test resolution with AugLagEvaluator and Ipopt, as used inside ProxAL
+    @testset "AugLagEvaluator with Hessian" begin
+        optimizer = Ipopt.Optimizer()
+        MOI.set(optimizer, MOI.RawParameter("print_level"), 0)
+        MOI.set(optimizer, MOI.RawParameter("tol"), 1e-4)
+        MOI.set(optimizer, MOI.RawParameter("max_iter"), 30)
+        aug = ExaPF.AugLagEvaluator(nlp, ExaPF.initial(nlp))
+
+        solution = ExaPF.optimize!(optimizer, aug)
+        MOI.empty!(optimizer)
+        @test solution.status ∈ [MOI.OPTIMAL, MOI.LOCALLY_SOLVED]
+        @test solution.minimum ≈ 25138.76310420395
+    end
 end
 


### PR DESCRIPTION
* Avoid creating a new matrix each time a Hessian or a Jacobian callback is being called