### PR TITLE
Fix index name typo

### DIFF
--- a/src/PowerSystem/power_network.jl
+++ b/src/PowerSystem/power_network.jl
@@ -147,7 +147,7 @@ end
 
 function bounds(pf::PowerNetwork, ::Generator, ::ActivePower)
     GEN_BUS, PG, QG, QMAX, QMIN, VG, MBASE, GEN_STATUS, PMAX, PMIN, PC1, PC2, QC1MIN,
-    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAG, MU_PMIN, MU_QMAX,
+    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAX, MU_PMIN, MU_QMAX,
     MU_QMIN = IndexSet.idx_gen()
 
     gens = pf.data["gen"]
@@ -160,7 +160,7 @@ end
 
 function bounds(pf::PowerNetwork, ::Generator, ::ReactivePower)
     GEN_BUS, PG, QG, QMAX, QMIN, VG, MBASE, GEN_STATUS, PMAX, PMIN, PC1, PC2, QC1MIN,
-    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAG, MU_PMIN, MU_QMAX,
+    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAX, MU_PMIN, MU_QMAX,
     MU_QMIN = IndexSet.idx_gen()
 
     gens = pf.data["gen"]
@@ -182,7 +182,7 @@ function get_costs_coefficients(pf::PowerNetwork)
     BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, VA, BASE_KV, ZONE, VMAX, VMIN,
     LAM_P, LAM_Q, MU_VMAX, MU_VMIN = IndexSet.idx_bus()
     GEN_BUS, PG, QG, QMAX, QMIN, VG, MBASE, GEN_STATUS, PMAX, PMIN, PC1, PC2, QC1MIN,
-    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAG, MU_PMIN, MU_QMAX,
+    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAX, MU_PMIN, MU_QMAX,
     MU_QMIN = IndexSet.idx_gen()
     MODEL, STARTUP, SHUTDOWN, NCOST, COST = IndexSet.idx_cost()
 

--- a/src/PowerSystem/topology.jl
+++ b/src/PowerSystem/topology.jl
@@ -89,7 +89,7 @@ function bustypeindex(bus, gen, bus_to_indexes)
     LAM_P, LAM_Q, MU_VMAX, MU_VMIN = IndexSet.idx_bus()
 
     GEN_BUS, PG, QG, QMAX, QMIN, VG, MBASE, GEN_STATUS, PMAX, PMIN, PC1, PC2, QC1MIN,
-    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAG, MU_PMIN, MU_QMAX,
+    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAX, MU_PMIN, MU_QMAX,
     MU_QMIN = IndexSet.idx_gen()
 
 
@@ -145,7 +145,7 @@ function assembleSbus(gen, bus, baseMVA, bus_to_indexes)
     LAM_P, LAM_Q, MU_VMAX, MU_VMIN = IndexSet.idx_bus()
 
     GEN_BUS, PG, QG, QMAX, QMIN, VG, MBASE, GEN_STATUS, PMAX, PMIN, PC1, PC2, QC1MIN,
-    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAG, MU_PMIN, MU_QMAX,
+    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAX, MU_PMIN, MU_QMAX,
     MU_QMIN = IndexSet.idx_gen()
 
     for i in 1:ngen

--- a/src/indexes.jl
+++ b/src/indexes.jl
@@ -84,7 +84,7 @@ function idx_gen()
     MU_QMIN     = 25   # Kuhn-Tucker multiplier on lower Qg limit (u/MVAr)
 
     return GEN_BUS, PG, QG, QMAX, QMIN, VG, MBASE, GEN_STATUS, PMAX, PMIN, PC1, PC2, QC1MIN,
-    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAG, MU_PMIN, MU_QMAX,
+    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAX, MU_PMIN, MU_QMAX,
     MU_QMIN
 end
 

--- a/src/parsers/parse_mat.jl
+++ b/src/parsers/parse_mat.jl
@@ -67,7 +67,7 @@ function mat_to_exapf(data_mat)
 
     # generators
     GEN_BUS, PG, QG, QMAX, QMIN, VG, MBASE, GEN_STATUS, PMAX, PMIN, PC1, PC2, QC1MIN,
-    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAG, MU_PMIN, MU_QMAX,
+    QC2MIN, QC2MAX, RAMP_AGC, RAMP_10, RAMP_30, RAMP_Q, APF, MU_PMAX, MU_PMIN, MU_QMAX,
     MU_QMIN = IndexSet.idx_gen()
 
     ngen = length(data_mat["gen"])


### PR DESCRIPTION
This fix allows the test suite to run.  Without it I got the following
errors.

```
(ExaPF) pkg> test
     Testing ExaPF
      Status `/tmp/jl_JY3jX5/Project.toml`
  [6e4b80f9] BenchmarkTools v0.5.0
  [052768ef] CUDA v2.6.2
  [0cf0e50c] ExaPF v0.4.0 `~/research/code/ExaPF.jl`
  [6a86dc24] FiniteDiff v2.8.0
  [f6369f11] ForwardDiff v0.10.17
  [b6b21f68] Ipopt v0.6.5
  [42fd0dbc] IterativeSolvers v0.8.5
  [63c18a36] KernelAbstractions v0.4.6
  [ba0b0d4f] Krylov v0.5.5
  [093fc24a] LightGraphs v1.3.5
  [b8f27783] MathOptInterface v0.9.20
  [2679e427] Metis v1.0.0
  [47a9eef4] SparseDiffTools v1.13.0
  [a759f4b9] TimerOutputs v0.5.8
  [37e2e46d] LinearAlgebra `@stdlib/LinearAlgebra`
  [de0858da] Printf `@stdlib/Printf`
  [9a3f8284] Random `@stdlib/Random`
  [2f01184e] SparseArrays `@stdlib/SparseArrays`
  [8dfed614] Test `@stdlib/Test`
      Status `/tmp/jl_JY3jX5/Manifest.toml`
  [621f4979] AbstractFFTs v1.0.1
  [79e6a3ab] Adapt v3.2.0
  [ec485272] ArnoldiMethod v0.1.0
  [4fba245c] ArrayInterface v3.1.6
  [ab4f0b2a] BFloat16s v0.1.0
  [6e4b80f9] BenchmarkTools v0.5.0
  [b99e7846] BinaryProvider v0.5.10
  [fa961155] CEnum v0.4.1
  [052768ef] CUDA v2.6.2
  [7057c7e9] Cassette v0.3.5
  [d360d2e6] ChainRulesCore v0.9.33
  [523fee87] CodecBzip2 v0.7.2
  [944b1d66] CodecZlib v0.7.0
  [bbf7d656] CommonSubexpressions v0.3.0
  [34da2185] Compat v3.25.0
  [864edb3b] DataStructures v0.18.9
  [163ba53b] DiffResults v1.0.3
  [b552c78f] DiffRules v1.0.2
  [0cf0e50c] ExaPF v0.4.0 `~/research/code/ExaPF.jl`
  [e2ba6199] ExprTools v0.1.3
  [9aa1b823] FastClosures v0.3.2
  [6a86dc24] FiniteDiff v2.8.0
  [f6369f11] ForwardDiff v0.10.17
  [0c68f7d7] GPUArrays v6.2.0
  [61eb1bfa] GPUCompiler v0.10.0
  [cd3eb016] HTTP v0.9.5
  [615f187c] IfElse v0.1.0
  [d25df0c9] Inflate v0.1.2
  [83e8ac13] IniFile v0.5.0
  [b6b21f68] Ipopt v0.6.5
  [42fd0dbc] IterativeSolvers v0.8.5
  [692b3bcd] JLLWrappers v1.2.0
  [682c06a0] JSON v0.21.1
  [7d188eb4] JSONSchema v0.3.3
  [63c18a36] KernelAbstractions v0.4.6
  [ba0b0d4f] Krylov v0.5.5
  [929cbde3] LLVM v3.6.0
  [093fc24a] LightGraphs v1.3.5
  [5c8ed15e] LinearOperators v1.1.0
  [1914dd2f] MacroTools v0.5.6
  [b8f27783] MathOptInterface v0.9.20
  [fdba3010] MathProgBase v0.7.8
  [739be429] MbedTLS v1.0.3
  [c03570c3] Memoize v0.4.4
  [2679e427] Metis v1.0.0
  [d8a4904e] MutableArithmetics v0.2.14
  [872c559c] NNlib v0.7.17
  [77ba4419] NaNMath v0.3.5
  [bac558e1] OrderedCollections v1.4.0
  [69de0a69] Parsers v1.1.0
  [3cdcf5f2] RecipesBase v1.1.1
  [189a3867] Reexport v1.0.0
  [ae029012] Requires v1.1.3
  [6c6a2e73] Scratch v1.0.3
  [699a6c99] SimpleTraits v0.9.3
  [47a9eef4] SparseDiffTools v1.13.0
  [276daf66] SpecialFunctions v1.3.0
  [aedffcd0] Static v0.2.4
  [90137ffa] StaticArrays v1.0.1
  [a759f4b9] TimerOutputs v0.5.8
  [3bb67fe8] TranscodingStreams v0.9.5
  [5c2747f8] URIs v1.2.0
  [19fa3120] VertexSafeGraphs v0.1.2
  [a5390f91] ZipFile v0.9.3
  [ae81ac8f] ASL_jll v0.1.1+4
  [6e34b625] Bzip2_jll v1.0.6+5
  [9cc047cb] Ipopt_jll v3.13.4+0
  [d00139f3] METIS_jll v5.1.0+5
  [d7ed1dd3] MUMPS_seq_jll v5.2.1+4
  [656ef2d0] OpenBLAS32_jll v0.3.12+1
  [efe28fd5] OpenSpecFun_jll v0.5.3+4
  [0dad84c5] ArgTools `@stdlib/ArgTools`
  [56f22d72] Artifacts `@stdlib/Artifacts`
  [2a0f44e3] Base64 `@stdlib/Base64`
  [ade2ca70] Dates `@stdlib/Dates`
  [8bb1440f] DelimitedFiles `@stdlib/DelimitedFiles`
  [8ba89e20] Distributed `@stdlib/Distributed`
  [f43a241f] Downloads `@stdlib/Downloads`
  [b77e0a4c] InteractiveUtils `@stdlib/InteractiveUtils`
  [4af54fe1] LazyArtifacts `@stdlib/LazyArtifacts`
  [b27032c2] LibCURL `@stdlib/LibCURL`
  [76f85450] LibGit2 `@stdlib/LibGit2`
  [8f399da3] Libdl `@stdlib/Libdl`
  [37e2e46d] LinearAlgebra `@stdlib/LinearAlgebra`
  [56ddb016] Logging `@stdlib/Logging`
  [d6f4376e] Markdown `@stdlib/Markdown`
  [a63ad114] Mmap `@stdlib/Mmap`
  [ca575930] NetworkOptions `@stdlib/NetworkOptions`
  [44cfe95a] Pkg `@stdlib/Pkg`
  [de0858da] Printf `@stdlib/Printf`
  [3fa0cd96] REPL `@stdlib/REPL`
  [9a3f8284] Random `@stdlib/Random`
  [ea8e919c] SHA `@stdlib/SHA`
  [9e88b42a] Serialization `@stdlib/Serialization`
  [1a1011a3] SharedArrays `@stdlib/SharedArrays`
  [6462fe0b] Sockets `@stdlib/Sockets`
  [2f01184e] SparseArrays `@stdlib/SparseArrays`
  [10745b16] Statistics `@stdlib/Statistics`
  [fa267f1f] TOML `@stdlib/TOML`
  [a4e569a6] Tar `@stdlib/Tar`
  [8dfed614] Test `@stdlib/Test`
  [cf7118a7] UUIDs `@stdlib/UUIDs`
  [4ec0a83e] Unicode `@stdlib/Unicode`
  [e66e0078] CompilerSupportLibraries_jll `@stdlib/CompilerSupportLibraries_jll`
  [deac9b47] LibCURL_jll `@stdlib/LibCURL_jll`
  [29816b5a] LibSSH2_jll `@stdlib/LibSSH2_jll`
  [c8ffd9c3] MbedTLS_jll `@stdlib/MbedTLS_jll`
  [14a3606d] MozillaCACerts_jll `@stdlib/MozillaCACerts_jll`
  [83775a58] Zlib_jll `@stdlib/Zlib_jll`
  [8e850ede] nghttp2_jll `@stdlib/nghttp2_jll`
  [3f19e933] p7zip_jll `@stdlib/p7zip_jll`
     Testing Running tests...
Powerflow residuals and Jacobian: Error During Test at /home/lucas/research/code/ExaPF.jl/test/powersystem.jl:11
  Got exception outside of a @test
  UndefVarError: MU_PMAG not defined
  Stacktrace:
    [1] idx_gen
      @ ~/research/code/ExaPF.jl/src/indexes.jl:86 [inlined]
    [2] assembleSbus(gen::Matrix{Float64}, bus::Matrix{Float64}, baseMVA::Float64, bus_to_indexes::Dict{Int64, Int64})
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/topology.jl:147
    [3] macro expansion
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:64 [inlined]
    [4] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [5] top-level scope
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:12
    [6] include(fname::String)
      @ Base.MainInclude ./client.jl:444
    [7] macro expansion
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18 [inlined]
    [8] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [9] top-level scope
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18
   [10] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [11] top-level scope
      @ none:6
   [12] eval
      @ ./boot.jl:360 [inlined]
   [13] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [14] _start()
      @ Base ./client.jl:485
Reading PSSE format
Parsers case14.raw: Error During Test at /home/lucas/research/code/ExaPF.jl/test/powersystem.jl:123
  Got exception outside of a @test
  UndefVarError: MU_PMAG not defined
  Stacktrace:
    [1] idx_gen
      @ ~/research/code/ExaPF.jl/src/indexes.jl:86 [inlined]
    [2] bustypeindex(bus::Matrix{Float64}, gen::Matrix{Float64}, bus_to_indexes::Dict{Int64, Int64})
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/topology.jl:91
    [3] ExaPF.PowerSystem.PowerNetwork(datafile::String, data_format::Int64)
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/power_network.jl:68
    [4] macro expansion
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:126 [inlined]
    [5] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1226 [inlined]
    [6] macro expansion
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:123 [inlined]
    [7] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [8] top-level scope
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:119
    [9] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [10] macro expansion
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18 [inlined]
   [11] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [12] top-level scope
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18
   [13] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [14] top-level scope
      @ none:6
   [15] eval
      @ ./boot.jl:360 [inlined]
   [16] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [17] _start()
      @ Base ./client.jl:485
Parsers case9.m: Error During Test at /home/lucas/research/code/ExaPF.jl/test/powersystem.jl:123
  Got exception outside of a @test
  UndefVarError: MU_PMAG not defined
  Stacktrace:
    [1] idx_gen
      @ ~/research/code/ExaPF.jl/src/indexes.jl:86 [inlined]
    [2] mat_to_exapf(data_mat::Dict{String, Any})
      @ ExaPF.ParseMAT ~/research/code/ExaPF.jl/src/parsers/parse_mat.jl:69
    [3] ExaPF.PowerSystem.PowerNetwork(datafile::String, data_format::Int64)
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/power_network.jl:43
    [4] macro expansion
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:126 [inlined]
    [5] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1226 [inlined]
    [6] macro expansion
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:123 [inlined]
    [7] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [8] top-level scope
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:119
    [9] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [10] macro expansion
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18 [inlined]
   [11] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [12] top-level scope
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18
   [13] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [14] top-level scope
      @ none:6
   [15] eval
      @ ./boot.jl:360 [inlined]
   [16] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [17] _start()
      @ Base ./client.jl:485
PowerNetwork object: Error During Test at /home/lucas/research/code/ExaPF.jl/test/powersystem.jl:118
  Got exception outside of a @test
  UndefVarError: MU_PMAG not defined
  Stacktrace:
    [1] idx_gen
      @ ~/research/code/ExaPF.jl/src/indexes.jl:86 [inlined]
    [2] mat_to_exapf(data_mat::Dict{String, Any})
      @ ExaPF.ParseMAT ~/research/code/ExaPF.jl/src/parsers/parse_mat.jl:69
    [3] ExaPF.PowerSystem.PowerNetwork(datafile::String, data_format::Int64)
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/power_network.jl:43
    [4] macro expansion
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:132 [inlined]
    [5] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [6] top-level scope
      @ ~/research/code/ExaPF.jl/test/powersystem.jl:119
    [7] include(fname::String)
      @ Base.MainInclude ./client.jl:444
    [8] macro expansion
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18 [inlined]
    [9] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [10] top-level scope
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18
   [11] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [12] top-level scope
      @ none:6
   [13] eval
      @ ./boot.jl:360 [inlined]
   [14] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [15] _start()
      @ Base ./client.jl:485
Power flow 9 bus case: Error During Test at /home/lucas/research/code/ExaPF.jl/test/matpower.jl:8
  Got exception outside of a @test
  UndefVarError: MU_PMAG not defined
  Stacktrace:
    [1] idx_gen
      @ ~/research/code/ExaPF.jl/src/indexes.jl:86 [inlined]
    [2] mat_to_exapf(data_mat::Dict{String, Any})
      @ ExaPF.ParseMAT ~/research/code/ExaPF.jl/src/parsers/parse_mat.jl:69
    [3] ExaPF.PowerSystem.PowerNetwork(datafile::String, data_format::Int64)
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/power_network.jl:43
    [4] macro expansion
      @ ~/research/code/ExaPF.jl/test/matpower.jl:10 [inlined]
    [5] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [6] top-level scope
      @ ~/research/code/ExaPF.jl/test/matpower.jl:9
    [7] include(fname::String)
      @ Base.MainInclude ./client.jl:444
    [8] macro expansion
      @ ~/research/code/ExaPF.jl/test/runtests.jl:20 [inlined]
    [9] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [10] top-level scope
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18
   [11] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [12] top-level scope
      @ none:6
   [13] eval
      @ ./boot.jl:360 [inlined]
   [14] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [15] _start()
      @ Base ./client.jl:485
Power flow 14 bus case: Error During Test at /home/lucas/research/code/ExaPF.jl/test/matpower.jl:45
  Got exception outside of a @test
  UndefVarError: MU_PMAG not defined
  Stacktrace:
    [1] idx_gen
      @ ~/research/code/ExaPF.jl/src/indexes.jl:86 [inlined]
    [2] mat_to_exapf(data_mat::Dict{String, Any})
      @ ExaPF.ParseMAT ~/research/code/ExaPF.jl/src/parsers/parse_mat.jl:69
    [3] ExaPF.PowerSystem.PowerNetwork(datafile::String, data_format::Int64)
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/power_network.jl:43
    [4] macro expansion
      @ ~/research/code/ExaPF.jl/test/matpower.jl:47 [inlined]
    [5] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [6] top-level scope
      @ ~/research/code/ExaPF.jl/test/matpower.jl:46
    [7] include(fname::String)
      @ Base.MainInclude ./client.jl:444
    [8] macro expansion
      @ ~/research/code/ExaPF.jl/test/runtests.jl:20 [inlined]
    [9] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [10] top-level scope
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18
   [11] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [12] top-level scope
      @ none:6
   [13] eval
      @ ./boot.jl:360 [inlined]
   [14] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [15] _start()
      @ Base ./client.jl:485
Power flow 30 bus case: Error During Test at /home/lucas/research/code/ExaPF.jl/test/matpower.jl:68
  Got exception outside of a @test
  UndefVarError: MU_PMAG not defined
  Stacktrace:
    [1] idx_gen
      @ ~/research/code/ExaPF.jl/src/indexes.jl:86 [inlined]
    [2] mat_to_exapf(data_mat::Dict{String, Any})
      @ ExaPF.ParseMAT ~/research/code/ExaPF.jl/src/parsers/parse_mat.jl:69
    [3] ExaPF.PowerSystem.PowerNetwork(datafile::String, data_format::Int64)
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/power_network.jl:43
    [4] macro expansion
      @ ~/research/code/ExaPF.jl/test/matpower.jl:70 [inlined]
    [5] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [6] top-level scope
      @ ~/research/code/ExaPF.jl/test/matpower.jl:69
    [7] include(fname::String)
      @ Base.MainInclude ./client.jl:444
    [8] macro expansion
      @ ~/research/code/ExaPF.jl/test/runtests.jl:20 [inlined]
    [9] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [10] top-level scope
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18
   [11] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [12] top-level scope
      @ none:6
   [13] eval
      @ ./boot.jl:360 [inlined]
   [14] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [15] _start()
      @ Base ./client.jl:485
Power flow 300 bus case: Error During Test at /home/lucas/research/code/ExaPF.jl/test/matpower.jl:92
  Got exception outside of a @test
  UndefVarError: MU_PMAG not defined
  Stacktrace:
    [1] idx_gen
      @ ~/research/code/ExaPF.jl/src/indexes.jl:86 [inlined]
    [2] mat_to_exapf(data_mat::Dict{String, Any})
      @ ExaPF.ParseMAT ~/research/code/ExaPF.jl/src/parsers/parse_mat.jl:69
    [3] ExaPF.PowerSystem.PowerNetwork(datafile::String, data_format::Int64)
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/power_network.jl:43
    [4] macro expansion
      @ ~/research/code/ExaPF.jl/test/matpower.jl:94 [inlined]
    [5] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [6] top-level scope
      @ ~/research/code/ExaPF.jl/test/matpower.jl:93
    [7] include(fname::String)
      @ Base.MainInclude ./client.jl:444
    [8] macro expansion
      @ ~/research/code/ExaPF.jl/test/runtests.jl:20 [inlined]
    [9] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [10] top-level scope
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18
   [11] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [12] top-level scope
      @ none:6
   [13] eval
      @ ./boot.jl:360 [inlined]
   [14] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [15] _start()
      @ Base ./client.jl:485
Polar formulation: Error During Test at /home/lucas/research/code/ExaPF.jl/test/polar_form.jl:17
  Got exception outside of a @test
  UndefVarError: MU_PMAG not defined
  Stacktrace:
    [1] idx_gen
      @ ~/research/code/ExaPF.jl/src/indexes.jl:86 [inlined]
    [2] mat_to_exapf(data_mat::Dict{String, Any})
      @ ExaPF.ParseMAT ~/research/code/ExaPF.jl/src/parsers/parse_mat.jl:69
    [3] ExaPF.PowerSystem.PowerNetwork(datafile::String, data_format::Int64)
      @ ExaPF.PowerSystem ~/research/code/ExaPF.jl/src/PowerSystem/power_network.jl:43
    [4] macro expansion
      @ ~/research/code/ExaPF.jl/test/polar_form.jl:20 [inlined]
    [5] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
    [6] top-level scope
      @ ~/research/code/ExaPF.jl/test/polar_form.jl:18
    [7] include(fname::String)
      @ Base.MainInclude ./client.jl:444
    [8] macro expansion
      @ ~/research/code/ExaPF.jl/test/runtests.jl:22 [inlined]
    [9] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [10] top-level scope
      @ ~/research/code/ExaPF.jl/test/runtests.jl:18
   [11] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [12] top-level scope
      @ none:6
   [13] eval
      @ ./boot.jl:360 [inlined]
   [14] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [15] _start()
      @ Base ./client.jl:485
Test Summary:                      | Pass  Error  Total
Problem formulations               |    1      9     10
  Powerflow residuals and Jacobian |    1      1      2
  PowerNetwork object              |           3      3
    Parsers case14.raw             |           1      1
    Parsers case9.m                |           1      1
  Power flow 9 bus case            |           1      1
  Power flow 14 bus case           |           1      1
  Power flow 30 bus case           |           1      1
  Power flow 300 bus case          |           1      1
  Polar formulation                |           1      1
ERROR: LoadError: Some tests did not pass: 1 passed, 0 failed, 9 errored, 0 broken.
in expression starting at /home/lucas/research/code/ExaPF.jl/test/runtests.jl:16
ERROR: Package ExaPF errored during testing
```