### PR TITLE
Improve performance of reduced Hessian on GPU

### DIFF
--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -78,7 +78,7 @@ mutable struct ReducedSpaceEvaluator{T, VI, VT, MT, Jacx, Jacu, JacCons, Hess} <
     buffer::PolarNetworkState{VI, VT}
     # AutoDiff
     state_jacobian::FullSpaceJacobian{Jacx, Jacu}
-    obj_stack::AutoDiff.TapeMemory{typeof(active_power_constraints), AdjointStackObjective{VT}, Nothing}
+    obj_stack::AutoDiff.TapeMemory{typeof(active_power_generation), AdjointStackObjective{VT}, Nothing}
     cons_stacks::Vector{AutoDiff.TapeMemory} # / constraints
     constraint_jacobians::JacCons
     hessians::Hess

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -512,8 +512,8 @@ function hessprod!(nlp::ReducedSpaceEvaluator, hessvec, u, w)
     _second_order_adjoint_z!(nlp, z, w)
 
     # Init tangent
-    tgt[1:nx] .= z
-    tgt[1+nx:nx+nu] .= w
+    copyto!(tgt, 1, z, 1, nx)
+    copyto!(tgt, nx+1, w, 1, nu)
 
     ∂f = similar(buffer.pg)
     ∂²f = similar(buffer.pg)

--- a/src/Polar/derivatives.jl
+++ b/src/Polar/derivatives.jl
@@ -87,13 +87,13 @@ function AutoDiff.jacobian!(polar::PolarForm, jac::AutoDiff.Jacobian, buffer)
     nbus = get(polar, PS.NumberOfBuses())
     type = jac.var
     if isa(type, State)
-        jac.x[1:nbus] .= buffer.vmag
-        jac.x[nbus+1:2*nbus] .= buffer.vang
+        copyto!(jac.x, 1, buffer.vmag, 1, nbus)
+        copyto!(jac.x, nbus+1, buffer.vang, 1, nbus)
         jac.t1sx .= jac.x
         jac.t1sF .= 0.0
     elseif isa(type, Control)
-        jac.x[1:nbus] .= buffer.vmag
-        jac.x[nbus+1:2*nbus] .= buffer.pinj
+        copyto!(jac.x, 1, buffer.vmag, 1, nbus)
+        copyto!(jac.x, nbus+1, buffer.pinj, 1, nbus)
         jac.t1sx .= jac.x
         jac.t1sF .= 0.0
     end
@@ -220,9 +220,9 @@ function AutoDiff.adj_hessian_prod!(
     t1sF = H.t1sF
     adj_t1sF = H.∂t1sF
     # Move data
-    x[1:nbus] .= buffer.vmag
-    x[nbus+1:2*nbus] .= buffer.vang
-    x[2*nbus+1:3*nbus] .= buffer.pinj
+    copyto!(x, 1, buffer.vmag, 1, nbus)
+    copyto!(x, nbus+1, buffer.vang, 1, nbus)
+    copyto!(x, 2*nbus+1, buffer.pinj, 1, nbus)
     # Init dual variables
     t1sx .= H.x
     adj_t1sx .= 0.0

--- a/src/Polar/derivatives.jl
+++ b/src/Polar/derivatives.jl
@@ -406,7 +406,7 @@ function HessianStorage(polar::PolarForm{T, VI, VT, MT}, constraints::Vector{Fun
     nu = get(polar, NumberOfControl())
 
     Hstate = AutoDiff.Hessian(polar, power_balance)
-    Hobj = AutoDiff.Hessian(polar, active_power_constraints)
+    Hobj = AutoDiff.Hessian(polar, active_power_generation)
     Hcons = AutoDiff.Hessian[]
     for cons in constraints
         push!(Hcons, _build_hessian(polar, cons))

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -253,7 +253,7 @@ function adj_residual_polar!(
                  edge_va_from, edge_va_to,
                  pinj, adj_pinj, qinj, pv, pq,
                  ndrange=npv+npq,
-                 dependencies = Event(device) 
+                 dependencies = Event(device)
                  )
     wait(ev)
 
@@ -275,7 +275,7 @@ function adj_residual_polar!(
             edge_vm_from, vm_to_nzval,
             edge_va_from, va_to_nzval,
             ndrange=nvbus,
-            dependencies = Event(device) 
+            dependencies = Event(device)
         )
         wait(ev)
     end
@@ -317,7 +317,7 @@ function transfer!(polar::PolarForm, buffer::PolarNetworkState, u)
         pv, pq, ref,
         polar.active_load, polar.reactive_load,
         ndrange=(length(pv)+length(ref)),
-        dependencies = Event(polar.device) 
+        dependencies = Event(polar.device)
     )
     wait(ev)
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -207,6 +207,15 @@ The result is stored inplace, inside the vector `cons`.
 function active_power_constraints end
 
 """
+    active_power_generation(form::AbstractFormulation, pg::AbstractVector, buffer::AbstractNetworkBuffer)
+
+Evaluate the **active power production** of all generators.
+Used to evaluate the operational cost.
+The result is stored inplace, inside the vector `pg`.
+"""
+function active_power_generation end
+
+"""
     reactive_power_constraints(form::AbstractFormulation, cons::AbstractVector, buffer::AbstractNetworkBuffer)
 
 Evaluate the constraints on the **reactive power production** at the generators:

--- a/test/Polar/gradient.jl
+++ b/test/Polar/gradient.jl
@@ -29,7 +29,7 @@ const KA = KernelAbstractions
         jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
         ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
         ∂obj = ExaPF.AdjointStackObjective(polar)
-        pbm = AutoDiff.TapeMemory(ExaPF.active_power_constraints, ∂obj, nothing)
+        pbm = AutoDiff.TapeMemory(ExaPF.active_power_generation, ∂obj, nothing)
 
         # solve power flow
         conv = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-12))

--- a/test/Polar/hessian.jl
+++ b/test/Polar/hessian.jl
@@ -53,7 +53,7 @@ const PS = PowerSystem
             jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
             ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
             ∂obj = ExaPF.AdjointStackObjective(polar)
-            pbm = AutoDiff.TapeMemory(ExaPF.active_power_constraints, ∂obj, nothing)
+            pbm = AutoDiff.TapeMemory(ExaPF.active_power_generation, ∂obj, nothing)
 
             cpu_jx = AutoDiff.Jacobian(cpu_polar, ExaPF.power_balance, State())
             cpu_ju = AutoDiff.Jacobian(cpu_polar, ExaPF.power_balance, Control())


### PR DESCRIPTION
- in reverse over forward pass, call proper kernel to compute the Hessian of the objective
- transpose matrix implicitly in the adjoint of the residual kernel (instead of using views) 
- replace `dotview` by `copyto!`, leading to better performance on the GPU