### PR TITLE
Minor documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # ExaPF
 
-| **Documentation**                       | **Build Status**                                              |
-|:---------------------------------------:|:-------------------------------------------------------------:|
-| [![][docs-latest-img]][docs-latest-url] | ![Run tests](https://github.com/exanauts/ExaPF.jl/workflows/Run%20tests/badge.svg?branch=master) |
+[![][docs-latest-img]][docs-latest-url] ![CI](https://github.com/exanauts/ExaPF.jl/workflows/Run%20tests/badge.svg?branch=master) 
 
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: https://exanauts.github.io/ExaPF.jl/

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,9 @@
 # ExaPF
 
-[ExaPF.jl](https://github.com/exanauts/ExaPF.jl) is a
+[`ExaPF.jl`](https://github.com/exanauts/ExaPF.jl) is a
 package to solve the power flow problem on upcoming exascale architectures. 
 On these architectures the computational performance can only be achieved through graphics processing units (GPUs) as these systems lack substantial computational performance through classical CPUs.
-`ExaPF.jl` aims to
+[`ExaPF.jl`](https://github.com/exanauts/ExaPF.jl) aims to
 provide the sensitivity information required for a reduced space optimization
 method, and enabling the computation of the optimal power flow problem (OPF)
 fully on GPUs. Reduced space methods enforce the constraints, represented here by
@@ -16,7 +16,7 @@ computational loop entirely on the GPU with no transfer from host to device.
 
 We leverage the packages [`CUDA.jl`](https://github.com/JuliaGPU/CUDA.jl) and [`KernelAbstractions.jl`](https://github.com/JuliaGPU/KernelAbstractions.jl) to make ExaPF portable across GPU architectures.
 [autodiff](man/autodiff.md) and [linear solver](man/linearsolver.md) illustrate
-the design overview of `ExaPF.jl` targeted for GPUs.
+the design overview of [`ExaPF.jl`](https://github.com/exanauts/ExaPF.jl) targeted for GPUs.
 
 The user API is separated into three layers:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,7 +2,7 @@
 
 [ExaPF.jl](https://github.com/exanauts/ExaPF.jl) is a
 package to solve the power flow problem on upcoming exascale architectures. 
-On these architectures the computational performance can only be achieved through graphics processing units (GPUs) as they lack substantial computational performance through classical CPUs.
+On these architectures the computational performance can only be achieved through graphics processing units (GPUs) as these systems lack substantial computational performance through classical CPUs.
 `ExaPF.jl` aims to
 provide the sensitivity information required for a reduced space optimization
 method, and enabling the computation of the optimal power flow problem (OPF)

--- a/docs/src/man/evaluators.md
+++ b/docs/src/man/evaluators.md
@@ -1,13 +1,13 @@
 # Evaluators
 
 In `ExaPF.jl`, the evaluators are the final layer of the structure.
-They take as input a given `AbstractFormulation` and implement the
+They take as input a given [`ExaPF.AbstractFormulation`](@ref) and implement the
 callbacks for the optimization solvers.
 
 ## Overview of the AbstractNLPEvaluator
 
-An `AbstractNLPEvaluator` implements an optimization problem
-associated with an underlying `AbstractFormulation`:
+An [`ExaPF.AbstractNLPEvaluator`](@ref) implements an optimization problem
+associated with an underlying [`ExaPF.AbstractFormulation`](@ref):
 ```math
 \begin{aligned}
 \min_{u \in \mathbb{R}^n} \;             & f(u)     \\
@@ -24,9 +24,9 @@ $h: \mathbb{R}^n \to \mathbb{R}^{m_I}$ non-linear inequality constraints.
 Most non-linear optimization algorithms rely on *callbacks* to pass
 information about the structure of the problem to the optimizer.
 In `ExaPF`, the implementation of the evaluators allows to have a proper splitting
-between the model (formulated in the `AbstractFormulation` layer)
+between the model (formulated in the [`ExaPF.AbstractFormulation`](@ref) layer)
 and the optimization algorithms. By design, the implementation
-of an `AbstractEvaluator` shares a similar spirit with the implementations
+of an [`ExaPF.AbstractNLPEvaluator`](@ref) shares a similar spirit with the implementations
 introduced in other packages, as
 
 - MathOptInterface.jl's [AbstractNLPEvaluator](https://jump.dev/MathOptInterface.jl/stable/apireference/#MathOptInterface.AbstractNLPEvaluator)
@@ -37,8 +37,8 @@ the callbacks (e.g. the polar representation of the problem, with voltage
 magnitudes and angles). This cache allows to reduce the number of memory allocations to
 its minimum.
 Once a new variable $u$ passed to the evaluator
-a function `update!` is being called to update the cache,
-according to the model specified in the underlying `AbstractFormulation`.
+a function `ExaPF.update!` is being called to update the cache,
+according to the model specified in the underlying [`ExaPF.AbstractFormulation`](@ref).
 Denoting by `nlp` an instance of AbstractNLPEvaluator, the cache is
 updated via
 ```julia-repl
@@ -64,13 +64,13 @@ julia> ExaPF.constraint!(nlp, cons, u)
 ## A journey to the reduced space with the ReducedSpaceEvaluator
 
 When we aim at optimizing the problem directly in the powerflow
-manifold, the `ReducedSpaceEvaluator` is our workhorse.
+manifold, the [`ExaPF.ReducedSpaceEvaluator`](@ref) is our workhorse.
 We recall that the powerflow manifold is defined implicitly by the
 powerflow equations:
 ```math
     g(x(u), u) = 0.
 ```
-By design, the `ReducedSpaceEvaluator` works in the reduced
+By design, the [`ExaPF.ReducedSpaceEvaluator`](@ref) works in the reduced
 space $(x(u), u)$. Hence, the reduced optimization problem writes out
 ```math
 \begin{aligned}
@@ -88,7 +88,7 @@ This formulation comes with two advantages:
 ### Playing with the ReducedSpaceEvaluator
 
 #### Constructor
-To create a `ReducedSpaceEvaluator`, we just need a polar formulation
+To create a [`ExaPF.ReducedSpaceEvaluator`](@ref), we just need a polar formulation
 `polar::PolarForm`:
 ```julia-repl
 julia> nlp = ExaPF.ReducedSpaceEvaluator(polar)
@@ -116,8 +116,8 @@ Let's describe the output of the last command.
 * `device: KernelAbstractions.CPU()`: the evaluator is instantiated on the CPU ;
 * `#vars: 5`: it has 5 optimization variables ;
 * `#cons: 10`: and 10 inequality constraints ;
-* `constraints:` by default, `nlp` comes with three inequality constraints: `voltage_magnitude_constraints` (specifying the bounds $x_L \leq x(u) \leq x_U$ on the state $x$), `active_power_constraints` and `reactive_power_constraints` (bounding the active and reactive power of the generators) ;
-* `linear solver: ExaPF.LinearSolvers.DirectSolver()`: to solve the linear systems, the evaluator uses a direct linear algebra solver.
+* `constraints`: by default, `nlp` comes with three inequality constraints: `voltage_magnitude_constraints` (specifying the bounds $x_L \leq x(u) \leq x_U$ on the state $x$), `active_power_constraints` and `reactive_power_constraints` (bounding the active and reactive power of the generators) ;
+* `linear solver`: [`ExaPF.LinearSolvers.DirectSolver`](@ref): to solve the linear systems, the evaluator uses a direct linear algebra solver.
 
 Of course, these settings are only specified by default. The user is free
 to choose the parameters she wants. For instance,
@@ -140,7 +140,7 @@ to choose the parameters she wants. For instance,
 To juggle between the mathematical description (characterized
 by a state $x$ and a control $u$) and the physical description (characterized
 by the voltage and power injection at each bus), the evaluator `nlp`
-stores internally a cache `nlp.buffer`, with type `AbstractNetworkBuffer`.
+stores internally a cache `nlp.buffer`, with type `ExaPF.AbstractNetworkBuffer`.
 ```julia-repl
 julia> buffer = get(nlp, ExaPF.PhysicalState())
 ```
@@ -218,7 +218,7 @@ all the different callbacks, independently of one other.
 ## Passing the problem to an optimization solver with MathOptInterface
 
 `ExaPF.jl` provides a utility to pass the non-linear structure
-specified by a `AbstractNLPEvaluator` to a `MathOptInterface` (MOI)
+specified by a [`ExaPF.AbstractNLPEvaluator`](@ref) to a `MathOptInterface` (MOI)
 optimization problem. That allows to solve the corresponding
 optimal power flow problem using any non-linear optimization solver compatible
 with MOI.

--- a/docs/src/man/linearsolver.md
+++ b/docs/src/man/linearsolver.md
@@ -19,11 +19,12 @@ dx .= jacobian(x)\f(x)
 
 Our package supports the following linear solvers:
 
-* [`CUSOLVER`](https://docs.nvidia.com/cuda/cusolver/index.html) with `csrlsvqr` (GPU),
+* [`cuSOLVER`](https://docs.nvidia.com/cuda/cusolver/index.html) with `csrlsvqr` (GPU),
 * [`Krylov.jl`](https://github.com/JuliaSmoothOptimizers/Krylov.jl) with `dqgmres` and `bicgstab` (CPU/GPU),
 * [`IterativeSolvers.jl`](https://github.com/JuliaMath/IterativeSolvers.jl) with `bicgstab` (CPU),
 * UMFPACK through the default Julia `\` operator (CPU),
-* and a generic BiCGSTAB implementation [^Vorst1992] \(CPU/GPU\).
+* generic BiCGSTAB implementation [^Vorst1992] \(CPU/GPU\),
+* or any linear solver wrapped in `LinearAlgebra`.
 
 
 ## Preconditioning
@@ -34,11 +35,11 @@ systems. That's why this package comes with a block Jacobi preconditioner
 that is tailored towards GPUs and is proven to work well with power flow
 problems.
 
-The Jacobian is partitioned into a dense block diagonal structure, where each block is inverted to build our preconditioner `P`. For the partition we use `Metis.jl`.
+The Jacobian is partitioned into a dense block diagonal structure using `Metis.jl`, where each block is inverted to build our preconditioner `P`.
 
 ![Dense block Jacobi preconditioner \label{fig:preconditioner}](../figures/gpublocks.png)
 
-Compared to incomplete Cholesky and incomplete LU this preconditioner is easily portable to the GPU if the number of blocks is high enough. `ExaPF.jl` uses the batch BLAS calls from `CUBLAS` to invert the single blocks.
+Compared to incomplete Cholesky and incomplete LU this preconditioner is easily portable to the GPU if the number of blocks is high enough. `ExaPF.jl` uses the batch BLAS calls from `cuBLAS` to invert the single blocks.
 
 ```julia
 CUDA.@sync pivot, info = CUDA.CUBLAS.getrf_batched!(blocks, true)

--- a/docs/src/man/powersystem.md
+++ b/docs/src/man/powersystem.md
@@ -41,19 +41,19 @@ where each bus $i$ has variables $p_i, q_i, v_i, \theta_i$ and the topology
 of the network is defined by a non-negative value of the admittance between
 two buses $i$ and $j$, $y_{ij} = g_{ij} + ib_{ij}$.
 
-## The PowerNetwork object
+## The PowerNetwork Object
 
-Currently we can create a PowerNetwork object by parsing a MATPOWER datafile.
+Currently we can create a PowerNetwork object by parsing a MATPOWER data file.
 
 ```julia-repl
 julia> ps = PowerSystem.PowerNetwork("data/case9.m")
 ```
-Apart of MATPOWER datafile, PSSE datafile are also supported:
+Apart of MATPOWER data file, PSSE data file are also supported:
 ```julia-repl
 julia> ps = PowerSystem.PowerNetwork("data/case14.raw")
 ```
 
-If we print the object, we will obtain bus information and initial voltage and power that we read from the datafile.
+If we print the object, we will obtain bus information, initial voltage, and power that we read from the data file.
 
 ```julia-repl
 julia> println(ps)
@@ -74,7 +74,7 @@ Power Network characteristics:
     9     1      1.000  0.00    -1.250  -0.500
 ```
 
-then, using multiple dispatch, we have defined a set of abstract datatypes and getter functions which allow us to retrieve information from the PowerNetwork object
+then, using multiple dispatch, we have defined a set of abstract data types and getter functions which allow us to retrieve information from the PowerNetwork object
 
 ```julia-repl
 julia> PowerSystem.get(ps, PowerSystem.NumberOfPQBuses())

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -3,7 +3,7 @@
 This page introduces the first steps to set up `ExaPF.jl`.
 We show how to load a power network instance and how to solve
 the power flow equations both on the CPU and on the GPU.
-The full script is implemented in [this file](https://github.com/exanauts/ExaPF.jl/tree/master/test/quickstart.jl)
+The full script is implemented in [test/quickstart.jl](https://github.com/exanauts/ExaPF.jl/tree/master/test/quickstart.jl)
 
 We start by importing CUDA and KernelAbstractions:
 ```julia
@@ -54,7 +54,7 @@ In what follows, we detail step by step the detailed procedure to solve
 the powerflow equations.
 
 ### How to load a MATPOWER instance as a PowerNetwork object?
-We start by importing a MATPOWER instance to a `PowerNetwork` object:
+We start by importing a MATPOWER instance to a [`ExaPF.PowerSystem.PowerNetwork`](@ref) object:
 ```julia
 pf = PS.PowerNetwork(pglib_instance)
 ```
@@ -66,12 +66,12 @@ nbus = PS.get(pf, PS.NumberOfBuses())
 pv_indexes = PS.get(pf, PS.PVIndexes())
 ```
 
-However, a `PowerNetwork` object stores only the **physical** attributes
+However, a [`ExaPF.PowerSystem.PowerNetwork`](@ref) object stores only the **physical** attributes
 of the network, independently of the mathematical formulations
 we could use to model the network. To choose a particular formulation,
-we need to pass the object `pf` to an `AbstractFormulation` layer.
+we need to pass the object `pf` to an [`ExaPF.AbstractFormulation`](@ref) layer.
 Currently, the only layer implemented is the polar formulation,
-with the `PolarForm` structure. In the future, other formulations
+with the [`ExaPF.PolarForm`](@ref) structure. In the future, other formulations
 (e.g. `RectangularForm`) may be implemented as well.
 
 
@@ -105,9 +105,9 @@ as a model:
 polar = ExaPF.PolarForm(pf, CPU())
 
 ```
-Note that the constructor `PolarForm` takes as input a `PowerNetwork` object
+Note that the constructor [`ExaPF.PolarForm`](@ref) takes as input a [`ExaPF.PowerSystem.PowerNetwork`](@ref) object
 and a `KernelAbstractions.jl` device (here set to `CPU()` by default). We
-will explain in the next section how to load a `PolarForm` object on
+will explain in the next section how to load a [`ExaPF.PolarForm`](@ref) object on
 the GPU with the help of a `CUDADevice()`.
 
 The Newton-Raphson solves the equation $g(x, u) = 0$ in an iterative fashion.
@@ -180,7 +180,7 @@ avoid any unnecessary memory allocations.
 
 Now, how could we deport the resolution on the GPU?
 The procedure looks exactly the same. It suffices to initiate
-a new `PolarForm` object, but on the GPU:
+a new [`ExaPF.PolarForm`](@ref) object, but on the GPU:
 ```julia
 polar_gpu = ExaPF.PolarForm(pf, CUDADevice())
 


### PR DESCRIPTION
@frapac There are some missing docstrings for functions/objects that are in the documentation. Those are:
* `update!`
* `AbstractNetworkBuffer`

and in the quickstart there's a reference to `AbstractPhysicalCache` which I am not sure still exists.