### PR TITLE
evaluator: fix MOI wrapper for ProxALEvaluator

### DIFF
--- a/src/Evaluators/MOI_wrapper.jl
+++ b/src/Evaluators/MOI_wrapper.jl
@@ -69,9 +69,7 @@ end
 function MOI.eval_constraint_jacobian(ev::MOIEvaluator, jac, x)
     _update!(ev, x)
     fill!(jac, 0)
-    m, n = n_constraints(ev.nlp), n_variables(ev.nlp)
-    J = reshape(jac, m, n) # reshape dense Jacobian
-    jacobian!(ev.nlp, J, x)
+    jacobian!(ev.nlp, jac, x)
 end
 
 function MOI.eval_hessian_lagrangian(ev::MOIEvaluator, hess, x, σ, μ)

--- a/src/Evaluators/proxal_evaluators.jl
+++ b/src/Evaluators/proxal_evaluators.jl
@@ -269,8 +269,11 @@ function jacobian_structure!(nlp::ProxALEvaluator, rows, cols)
 end
 
 function jacobian!(nlp::ProxALEvaluator, jac, w)
+    m = n_constraints(nlp)
+    nnj = length(jac)
     u = @view w[1:nlp.nu]
-    Jᵤ = @view jac[:, 1:nlp.nu]
+    J = reshape(jac, m, div(nnj, m))
+    Jᵤ = @view J[:, 1:nlp.nu]
     jacobian!(nlp.inner, Jᵤ, u)
 end
 

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -350,7 +350,10 @@ function _update_full_jacobian_constraints!(nlp)
 end
 
 # Works only on the CPU!
-function jacobian!(nlp::ReducedSpaceEvaluator, jac, u)
+function jacobian!(nlp::ReducedSpaceEvaluator, J, u)
+    m, n = n_constraints(nlp), n_variables(nlp)
+    jac = reshape(J, m, n)
+
     _update_full_jacobian_constraints!(nlp)
 
     ∇cons = nlp.constraint_jacobians

--- a/test/quickstart.jl
+++ b/test/quickstart.jl
@@ -91,7 +91,7 @@ const LS = ExaPF.LinearSolvers
         ExaPF.init_buffer!(polar_gpu, physical_state_gpu)
 
         linear_solver = ExaPF.KrylovBICGSTAB(precond)
-        pf_algo = NewtonRaphson(; verbose=1, tol=1e-7)
+        pf_algo = NewtonRaphson(; verbose=0, tol=1e-7)
         convergence = ExaPF.powerflow(
             polar_gpu, jx_gpu, physical_state_gpu, pf_algo;
             linear_solver=linear_solver


### PR DESCRIPTION
Allow to run ProxAL with the latest ExaPF