### PR TITLE
Update to KA 0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ CUDA = "^2.0"
 FiniteDiff = "2.7"
 ForwardDiff = "0.10"
 IterativeSolvers = "0.8"
-KernelAbstractions = "0.5"
+KernelAbstractions = "0.6"
 Krylov = "~0.6.0"
 LightGraphs = "1.3"
 MathOptInterface = "0.9"
@@ -35,6 +35,7 @@ julia = "^1.5"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CUDAKernels = "72cfdca4-0801-4ab0-bf6a-d52aa10adc57"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -43,4 +44,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
 scripts = ["Ipopt", "NLsolve", "UnicodePlots", "BenchmarkTools"]
-test = ["Test", "Random", "Ipopt", "BenchmarkTools"]
+test = ["CUDAKernels", "Test", "Random", "Ipopt", "BenchmarkTools"]

--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -44,8 +44,7 @@ abstract type AbstractIterativeLinearSolver <: AbstractLinearSolver end
 """
     list_solvers(::KernelAbstractions.Device)
 
-List linear solvers available on current device. Currently,
-only `CPU()` and `CUDADevice()` are supported.
+List linear solvers available on current device.
 
 """
 function list_solvers end
@@ -137,8 +136,8 @@ function ldiv!(::DirectSolver{Nothing},
 end
 get_transpose(::DirectSolver, M::CUSPARSE.CuSparseMatrixCSR) = CUSPARSE.CuSparseMatrixCSC(M)
 
-function update!(solver::AbstractIterativeLinearSolver, J)
-    update(J, solver.precond)
+function update_preconditioner!(solver::AbstractIterativeLinearSolver, J, device)
+    update(solver.precond, J, device)
 end
 
 """
@@ -270,10 +269,9 @@ List all linear solvers available solving the power flow on the CPU.
 list_solvers(::KA.CPU) = [RefBICGSTAB, RefGMRES, DQGMRES, BICGSTAB, EigenBICGSTAB, DirectSolver, KrylovBICGSTAB]
 
 """
-    list_solvers(::KA.CUDADevice)
+    list_solvers(::KA.GPU)
 
 List all linear solvers available solving the power flow on an NVIDIA GPU.
 """
-list_solvers(::KA.CUDADevice) = [BICGSTAB, DQGMRES, EigenBICGSTAB, DirectSolver, KrylovBICGSTAB]
-
+list_solvers(::KA.GPU) = [BICGSTAB, DQGMRES, EigenBICGSTAB, DirectSolver, KrylovBICGSTAB]
 end

--- a/src/LinearSolvers/preconditioners.jl
+++ b/src/LinearSolvers/preconditioners.jl
@@ -42,22 +42,22 @@ struct BlockJacobiPreconditioner{AT,GAT,VI,GVI,MT,GMT,MI,GMI,SMT} <: AbstractPre
     P::SMT
     id::Union{GMT,MT}
     function BlockJacobiPreconditioner(J, npart, device=CPU()) where {}
-        if device == CPU()
+        if isa(device, CPU)
             AT  = Array{Float64,3}
             GAT = Nothing
             VI  = Vector{Int64}
             GVI = Nothing
-            MT = Matrix{Float64}
+            MT  = Matrix{Float64}
             GMT = Nothing
             MI  = Matrix{Int64}
-            GMI  = Nothing
+            GMI = Nothing
             SMT = SparseMatrixCSC{Float64,Int64}
-        elseif device == CUDADevice()
+        elseif isa(device, GPU)
             AT  = Array{Float64,3}
             GAT = CuArray{Float64,3}
             VI  = Vector{Int64}
             GVI = CuVector{Int64}
-            MT = Matrix{Float64}
+            MT  = Matrix{Float64}
             GMT = CuMatrix{Float64}
             MI  = Matrix{Int64}
             GMI = CuMatrix{Int64}
@@ -121,7 +121,7 @@ struct BlockJacobiPreconditioner{AT,GAT,VI,GVI,MT,GMT,MI,GMI,SMT} <: AbstractPre
             end
         end
         P = sparse(row, col, nzval)
-        if isa(device, CUDADevice)
+        if isa(device, GPU)
             id = GMT(I, blocksize, blocksize)
             cubpartitions = GMI(bpartitions)
             culpartitions = GVI(lpartitions)
@@ -207,12 +207,12 @@ Update the values of the preconditioner matrix from the dense Jacobi blocks
     end
 end
 
-function _update_gpu(j_rowptr, j_colval, j_nzval, p)
+function _update_gpu(p, j_rowptr, j_colval, j_nzval, device)
     nblocks = p.nblocks
-    fillblock_gpu_kernel! = fillblock_gpu!(CUDADevice())
-    fillP_gpu_kernel! = fillP_gpu!(CUDADevice())
+    fillblock_gpu_kernel! = fillblock_gpu!(device)
+    fillP_gpu_kernel! = fillP_gpu!(device)
     # Fill Block Jacobi" begin
-    ev = fillblock_gpu_kernel!(p.cublocks, size(p.id,1), p.cupartitions, p.cumap, j_rowptr, j_colval, j_nzval, p.cupart, p.culpartitions, p.id, ndrange=nblocks, dependencies=Event(CUDADevice()))
+    ev = fillblock_gpu_kernel!(p.cublocks, size(p.id,1), p.cupartitions, p.cumap, j_rowptr, j_colval, j_nzval, p.cupart, p.culpartitions, p.id, ndrange=nblocks, dependencies=Event(device))
     wait(ev)
     # Invert blocks begin
     blocklist = Array{CuArray{Float64,2}}(undef, nblocks)
@@ -226,7 +226,7 @@ function _update_gpu(j_rowptr, j_colval, j_nzval, p)
     end
     p.P.nzVal .= 0.0
     # Move blocks to P" begin
-    ev = fillP_gpu_kernel!(p.cublocks, p.cupartitions, p.cumap, p.P.rowPtr, p.P.colVal, p.P.nzVal, p.cupart, p.culpartitions, ndrange=nblocks, dependencies=Event(CUDADevice()))
+    ev = fillP_gpu_kernel!(p.cublocks, p.cupartitions, p.cumap, p.P.rowPtr, p.P.colVal, p.P.nzVal, p.cupart, p.culpartitions, ndrange=nblocks, dependencies=Event(device))
     wait(ev)
     return p.P
 end
@@ -241,12 +241,12 @@ Update the preconditioner `p` from the sparse Jacobian `J` in CSR format for the
 3) Extract the preconditioner matrix `p.P` from the dense blocks `cuJs`
 
 """
-function update(J::CUSPARSE.CuSparseMatrixCSR, p)
-    _update_gpu(J.rowPtr, J.colVal, J.nzVal, p)
+function update(p, J::CUSPARSE.CuSparseMatrixCSR, device)
+    _update_gpu(p, J.rowPtr, J.colVal, J.nzVal, device)
 end
-function update(J::Transpose{T, CUSPARSE.CuSparseMatrixCSR{T}}, p) where T
+function update(p, J::Transpose{T, CUSPARSE.CuSparseMatrixCSR{T}}, device) where T
     Jt = CUSPARSE.CuSparseMatrixCSC(J.parent)
-    _update_gpu(Jt.colPtr, Jt.rowVal, Jt.nzVal, p)
+    _update_gpu(p, Jt.colPtr, Jt.rowVal, Jt.nzVal, device)
 end
 
 @kernel function update_cpu_kernel!(colptr, rowval, nzval, p, lpartitions)
@@ -288,16 +288,16 @@ Update the preconditioner `p` from the sparse Jacobian `J` in CSC format for the
 Note that this implements the same algorithm as for the GPU and becomes very slow on CPU with growing number of blocks.
 
 """
-function update(J::SparseMatrixCSC, p)
-    kernel! = update_cpu_kernel!(CPU())
+function update(p, J::SparseMatrixCSC, device)
+    kernel! = update_cpu_kernel!(device)
     p.P.nzval .= 0.0
-    ev = kernel!(J.colptr, J.rowval, J.nzval, p, p.lpartitions, ndrange=p.nblocks, dependencies=Event(CPU()))
+    ev = kernel!(J.colptr, J.rowval, J.nzval, p, p.lpartitions, ndrange=p.nblocks, dependencies=Event(device))
     wait(ev)
     return p.P
 end
-function update(J::Transpose{T, SparseMatrixCSC{T, I}}, p) where {T, I}
+function update(p, J::Transpose{T, SparseMatrixCSC{T, I}}) where {T, I}
     ix, jx, zx = findnz(J.parent)
-    update(sparse(jx, ix, zx), p)
+    update(p, sparse(jx, ix, zx))
 end
 
 is_valid(precond::BlockJacobiPreconditioner) = _check_nan(precond.P)

--- a/src/Polar/Constraints/power_balance.jl
+++ b/src/Polar/Constraints/power_balance.jl
@@ -1,17 +1,11 @@
 is_constraint(::typeof(power_balance)) = true
 
 function _power_balance!(
-    F, v_m, v_a, pinj, qinj, ybus_re, ybus_im, pv, pq, ref, nbus,
+    F, v_m, v_a, pinj, qinj, ybus_re, ybus_im, pv, pq, ref, nbus, device
 )
     npv = length(pv)
     npq = length(pq)
-    if isa(F, Array)
-        device = KA.CPU()
-        kernel! = residual_kernel!(device)
-    else
-        device = KA.CUDADevice()
-        kernel! = residual_kernel!(device)
-    end
+    kernel! = residual_kernel!(device)
     ev = kernel!(
         F, v_m, v_a,
         ybus_re.colptr, ybus_re.rowval,
@@ -34,7 +28,7 @@ function power_balance(polar::PolarForm, cons, vm, va, pbus, qbus)
     _power_balance!(
         cons, vm, va, pbus, qbus,
         ybus_re, ybus_im,
-        pv, pq, ref, nbus
+        pv, pq, ref, nbus, polar.device
     )
 end
 
@@ -86,6 +80,7 @@ function adjoint!(
         pbm.intermediate.∂edge_va_fr,
         pbm.intermediate.∂edge_va_to,
         pv, pq, nbus,
+        polar.device
     )
 end
 

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -46,37 +46,6 @@ KA.@kernel function residual_kernel!(
 end
 
 """
-    function residual_polar!(F, vm, va, pinj, qload,
-                         ybus_re, ybus_im,
-                         pv, pq, ref, nbus)
-
-The wrapper for the powerflow residual calling the CPU and GPU kernels.
-"""
-function residual_polar!(
-    F, vm, va, pinj, qload,
-    ybus_re, ybus_im, pv, pq, ref, nbus
-)
-    npv = length(pv)
-    npq = length(pq)
-    if isa(F, Array)
-        device = KA.CPU()
-        kernel! = residual_kernel!(device)
-    else
-        device = KA.CUDADevice()
-        kernel! = residual_kernel!(device)
-    end
-    ev = kernel!(
-        F, vm, va,
-        ybus_re.colptr, ybus_re.rowval,
-        ybus_re.nzval, ybus_im.nzval,
-        pinj, qload, pv, pq, nbus,
-        ndrange=npv+npq,
-        dependencies=Event(device)
-    )
-    wait(ev)
-end
-
-"""
     function adj_residual_edge_kernel!(
         F, adj_F, vm, adj_vm, va, adj_va,
         colptr, rowval,
@@ -232,13 +201,8 @@ function adj_residual_polar!(
     ybus_re, ybus_im, transpose_perm,
     pinj, adj_pinj, qinj,
     edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
-    pv, pq, nbus
-) where {T}
-    if isa(F, CUDA.CuVector)
-        device = KA.CUDADevice()
-    else
-        device = KA.CPU()
-    end
+    pv, pq, nbus, device
+)
     npv = length(pv)
     npq = length(pq)
     nvbus = length(vm)
@@ -642,13 +606,8 @@ function adj_reactive_power!(
     pinj, adj_pinj,
     edge_vm_from, edge_vm_to, edge_va_from, edge_va_to,
     reactive_load,
-    pv, pq, ref, pv_to_gen, ref_to_gen, nbus
-) where {T}
-    if isa(F, CUDA.CuVector)
-        device = KA.CUDADevice()
-    else
-        device = KA.CPU()
-    end
+    pv, pq, ref, pv_to_gen, ref_to_gen, nbus, device
+)
     npv = length(pv)
     npq = length(pq)
     nvbus = length(vm)

--- a/src/Polar/polar.jl
+++ b/src/Polar/polar.jl
@@ -51,7 +51,7 @@ function PolarForm(pf::PS.PowerNetwork, device::KA.Device)
         VT = Vector{Float64}
         M = SparseMatrixCSC
         AT = Array
-    elseif isa(device, KA.CUDADevice)
+    elseif isa(device, KA.GPU)
         IT = CUDA.CuVector{Int64}
         VT = CUDA.CuVector{Float64}
         M = CUSPARSE.CuSparseMatrixCSR

--- a/src/Polar/powerflow.jl
+++ b/src/Polar/powerflow.jl
@@ -80,7 +80,7 @@ function powerflow(
 
         # Find descent direction
         if isa(linear_solver, LinearSolvers.AbstractIterativeLinearSolver)
-            @timeit TIMER "Preconditioner" LinearSolvers.update!(linear_solver, J)
+            @timeit TIMER "Preconditioner" LinearSolvers.update_preconditioner!(linear_solver, J, polar.device)
         end
         @timeit TIMER "Linear Solver" n_iters = LinearSolvers.ldiv!(linear_solver, dx, J, F)
         push!(linsol_iters, n_iters)

--- a/src/architectures.jl
+++ b/src/architectures.jl
@@ -2,7 +2,7 @@
 abstract type AbstractArchitecture end
 
 array_type(::KA.CPU) = Array
-array_type(::KA.CUDADevice) = CUDA.CuArray
+array_type(::KA.GPU) = CUDA.CuArray
 
 # norm
 xnorm(x::AbstractVector) = norm(x, 2)

--- a/test/Evaluators/powerflow.jl
+++ b/test/Evaluators/powerflow.jl
@@ -1,4 +1,5 @@
 using CUDA
+using CUDAKernels
 using ExaPF
 using KernelAbstractions
 using Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,14 @@
 using CUDA
 using CUDA.CUSPARSE
+using CUDAKernels
 using ExaPF
+using FiniteDiff
 using KernelAbstractions
 using LinearAlgebra
 using Random
 using SparseArrays
 using Test
 using TimerOutputs
-using FiniteDiff
 
 import ExaPF: AutoDiff
 Random.seed!(2713)


### PR DESCRIPTION
Update to KernelAbstractions 0.6.

* No dependency on `CUDAKernels.jl`
* Removed any occurence of `CUDADevice`
* ExaPF now distinguishes only between `KA.CPU()` and `KA.GPU()` device. Of course this is only valid if the GPU is always a CUDA device for now. This will be extended when moving to AMD GPUs.