### PR TITLE
Weekly CI on default branch (master)

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   schedule:
-    cron:  '* * * * 1' 
+    cron: '* * * * 1'
 
 jobs:
   test-github-cpuonly:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -7,6 +7,8 @@ on:
       - develop
   pull_request:
     types: [opened, synchronize, reopened]
+  schedule:
+    cron:  '* * * * 1' 
 
 jobs:
   test-github-cpuonly:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   schedule:
-    cron: '* * * * 1'
+    - cron: '* * * * 1'
 
 jobs:
   test-github-cpuonly:


### PR DESCRIPTION
This does a CI run every Monday. According to the Github Actions documentation it should only be triggered on the default branch which is master in our case.