### PR TITLE
polar: move active and reactive loads in cache

### DIFF
--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -176,11 +176,9 @@ function setvalues!(nlp::ReducedSpaceEvaluator, attr::PS.AbstractNetworkValues, 
     setvalues!(nlp.model, attr, values)
 end
 function setvalues!(nlp::ReducedSpaceEvaluator, attr::PS.ActiveLoad, values)
-    setvalues!(nlp.model, attr, values)
     setvalues!(nlp.buffer, attr, values)
 end
 function setvalues!(nlp::ReducedSpaceEvaluator, attr::PS.ReactiveLoad, values)
-    setvalues!(nlp.model, attr, values)
     setvalues!(nlp.buffer, attr, values)
 end
 

--- a/src/Polar/Constraints/active_power.jl
+++ b/src/Polar/Constraints/active_power.jl
@@ -10,7 +10,7 @@ function active_power_constraints(polar::PolarForm, cons, buffer)
 end
 
 # Function for AutoDiff
-function active_power_constraints(polar::PolarForm, cons, vmag, vang, pinj, qinj)
+function active_power_constraints(polar::PolarForm, cons, vmag, vang, pinj, qinj, pd, qd)
     kernel! = active_power_kernel!(polar.device)
     ref = polar.indexing.index_ref
     ref_to_gen = polar.indexing.index_ref_to_gen
@@ -31,7 +31,7 @@ function active_power_constraints(polar::PolarForm, cons, vmag, vang, pinj, qinj
             sin_val = sin(aij)
             inj += coef_cos * cos_val + coef_sin * sin_val
         end
-        cons[i_] = inj + polar.active_load[bus]
+        cons[i_] = inj + pd[bus]
     end
 end
 
@@ -75,6 +75,7 @@ function adjoint!(
     vm, ∂vm,
     va, ∂va,
     pinj, ∂pinj,
+    pload, qload,
 ) where {F<:typeof(active_power_constraints), S, I}
     nbus = PS.get(polar.network, PS.NumberOfBuses())
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())

--- a/src/Polar/Constraints/constraints.jl
+++ b/src/Polar/Constraints/constraints.jl
@@ -55,6 +55,7 @@ function adjoint!(
         buffer.vmag, stack.∂vm,
         buffer.vang, stack.∂va,
         buffer.pinj, stack.∂pinj,
+        buffer.pd, buffer.qd,
     )
 end
 
@@ -75,6 +76,7 @@ function jacobian_transpose_product!(
         buffer.vmag, stack.∂vm,
         buffer.vang, stack.∂va,
         buffer.pinj, stack.∂pinj,
+        buffer.pd, buffer.qd,
     )
     adjoint_transfer!(
         polar,

--- a/src/Polar/Constraints/line_flow.jl
+++ b/src/Polar/Constraints/line_flow.jl
@@ -20,7 +20,7 @@ function flow_constraints(polar::PolarForm, cons, buffer::PolarNetworkState)
 end
 
 # Specialized function for AD with ForwardDiff
-function flow_constraints(polar::PolarForm, cons, vm, va, pbus, qbus)
+function flow_constraints(polar::PolarForm, cons, vm, va, pbus, qbus, pd, qd)
     _flow_constraints(polar, cons, vm, va)
 end
 
@@ -62,6 +62,7 @@ function adjoint!(
     vm, ∂vm,
     va, ∂va,
     pinj, ∂pinj,
+    pload, qload,
 ) where {F<:typeof(flow_constraints), S, I}
     nlines = PS.get(polar.network, PS.NumberOfLines())
     nbus = PS.get(polar.network, PS.NumberOfBuses())

--- a/src/Polar/Constraints/reactive_power.jl
+++ b/src/Polar/Constraints/reactive_power.jl
@@ -31,7 +31,7 @@ function reactive_power_constraints(polar::PolarForm, cons, buffer)
 end
 
 # Function for AD with ForwardDiff
-function reactive_power_constraints(polar::PolarForm, cons, vm, va, pbus, qbus)
+function reactive_power_constraints(polar::PolarForm, cons, vm, va, pbus, qbus, pd, qd)
     nbus = length(vm)
     pv = polar.indexing.index_pv
     pq = polar.indexing.index_pq
@@ -40,7 +40,7 @@ function reactive_power_constraints(polar::PolarForm, cons, vm, va, pbus, qbus)
     ref_to_gen = polar.indexing.index_ref_to_gen
     ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
     _reactive_power_constraints(
-        cons, vm, va, pbus, qbus, polar.reactive_load,
+        cons, vm, va, pbus, qbus, qd,
         ybus_re, ybus_im, pv, pq, ref, pv_to_gen, ref_to_gen, nbus, polar.device
     )
 end
@@ -62,6 +62,7 @@ function adjoint!(
     vm, ∂vm,
     va, ∂va,
     pinj, ∂pinj,
+    pload, qload,
 ) where {F<:typeof(reactive_power_constraints), S, I}
     nbus = get(polar, PS.NumberOfBuses())
     ref = polar.indexing.index_ref
@@ -86,7 +87,7 @@ function adjoint!(
         pbm.intermediate.∂edge_vm_to,
         pbm.intermediate.∂edge_va_fr,
         pbm.intermediate.∂edge_va_to,
-        polar.reactive_load,
+        qload,
         pv, pq, ref, pv_to_gen, ref_to_gen, nbus,
         polar.device
     )

--- a/src/Polar/Constraints/voltage_magnitude.jl
+++ b/src/Polar/Constraints/voltage_magnitude.jl
@@ -3,7 +3,7 @@ is_constraint(::typeof(voltage_magnitude_constraints)) = true
 is_linear(polar::PolarForm, ::typeof(voltage_magnitude_constraints)) = true
 
 # We add constraint only on vmag_pq
-function voltage_magnitude_constraints(polar::PolarForm, cons, vm, va, pinj, qinj)
+function voltage_magnitude_constraints(polar::PolarForm, cons, vm, va, pinj, qinj, pd, qd)
     index_pq = polar.indexing.index_pq
     cons .= @view vm[index_pq]
     return
@@ -33,6 +33,7 @@ function adjoint!(
     vm, ∂vm,
     va, ∂va,
     pinj, ∂pinj,
+    pload, qload,
 ) where {F<:typeof(voltage_magnitude_constraints), S, I}
     index_pq = polar.indexing.index_pq
     ∂vm[index_pq] .= ∂cons

--- a/src/Polar/caches.jl
+++ b/src/Polar/caches.jl
@@ -19,10 +19,12 @@ the network, in polar formulation. Attributes are:
 
 - `vmag` (length: nbus): voltage magnitude at each bus
 - `vang` (length: nbus): voltage angle at each bus
-- `pinj` (length: nbus): power injection RHS. Equal to `Cg * Pg - Pd`
-- `qinj` (length: nbus): power injection RHS. Equal to `Cg * Qg - Qd`
+- `pinj` (length: nbus): power generation RHS. Equal to `Cg * Pg`
+- `qinj` (length: nbus): power generation RHS. Equal to `Cg * Qg`
 - `pg`   (length: ngen): active power of generators
 - `qg`   (length: ngen): reactive power of generators
+- `pd`   (length: nbus): active loads
+- `qd`   (length: nbus): reactive loads
 - `dx`   (length: nstates): cache the difference between two consecutive states (used in power flow resolution)
 - `balance` (length: nstates): cache for current power imbalance (used in power flow resolution)
 - `bus_gen` (length: ngen): generator-bus incidence matrix `Cg`
@@ -35,6 +37,8 @@ struct PolarNetworkState{VI,VT} <: AbstractNetworkBuffer
     qinj::VT
     pg::VT
     qg::VT
+    pd::VT
+    qd::VT
     balance::VT
     dx::VT
     bus_gen::VI   # Generator-Bus incidence matrix
@@ -49,43 +53,31 @@ function PolarNetworkState{VT}(nbus::Int, ngen::Int, nstates::Int, bus_gen::VI) 
     # Generators variables
     pg = xzeros(VT, ngen)
     qg = xzeros(VT, ngen)
+    pd = xzeros(VT, nbus)
+    qd = xzeros(VT, nbus)
     # Buffers
     balance = xzeros(VT, nstates)
     dx = xzeros(VT, nstates)
-    return PolarNetworkState{VI,VT}(vmag, vang, pbus, qbus, pg, qg, balance, dx, bus_gen)
+    return PolarNetworkState{VI,VT}(vmag, vang, pbus, qbus, pg, qg, pd, qd, balance, dx, bus_gen)
 end
 
 setvalues!(buf::PolarNetworkState, ::PS.VoltageMagnitude, values) = copyto!(buf.vmag, values)
 setvalues!(buf::PolarNetworkState, ::PS.VoltageAngle, values) = copyto!(buf.vang, values)
 function setvalues!(buf::PolarNetworkState, ::PS.ActivePower, values)
     pgenbus = view(buf.pinj, buf.bus_gen)
-    # Remove previous values
-    pgenbus .-= buf.pg
-    # Add new values
+    pgenbus .= values
     copyto!(buf.pg, values)
-    pgenbus .+= buf.pg
 end
 function setvalues!(buf::PolarNetworkState, ::PS.ReactivePower, values)
     qgenbus = view(buf.qinj, buf.bus_gen)
-    # Remove previous values
-    qgenbus .-= buf.qg
-    # Add new values
+    qgenbus .= values
     copyto!(buf.qg, values)
-    qgenbus .+= buf.qg
 end
 function setvalues!(buf::PolarNetworkState, ::PS.ActiveLoad, values)
-    fill!(buf.pinj, 0)
-    # Pbus = Cg * Pg - Pd
-    buf.pinj .-= values
-    pgenbus = view(buf.pinj, buf.bus_gen)
-    pgenbus .+= buf.pg
+    copyto!(buf.pd, values)
 end
 function setvalues!(buf::PolarNetworkState, ::PS.ReactiveLoad, values)
-    fill!(buf.qinj, 0)
-    # Qbus = Cg * Qg - Qd
-    buf.qinj .-= values
-    qgenbus = view(buf.qinj, buf.bus_gen)
-    qgenbus .+= buf.qg
+    copyto!(buf.qd, values)
 end
 
 function Base.iszero(buf::PolarNetworkState)
@@ -95,6 +87,8 @@ function Base.iszero(buf::PolarNetworkState)
         iszero(buf.vang) &&
         iszero(buf.pg) &&
         iszero(buf.qg) &&
+        iszero(buf.pd) &&
+        iszero(buf.qd) &&
         iszero(buf.balance) &&
         iszero(buf.dx)
 end

--- a/src/Polar/derivatives.jl
+++ b/src/Polar/derivatives.jl
@@ -108,6 +108,8 @@ function AutoDiff.jacobian!(polar::PolarForm, jac::AutoDiff.Jacobian, buffer)
             view(jac.t1sx, nbus+1:2*nbus),
             buffer.pinj,
             buffer.qinj,
+            buffer.pd,
+            buffer.qd,
         )
     elseif isa(type, Control)
         jac.func(
@@ -117,6 +119,8 @@ function AutoDiff.jacobian!(polar::PolarForm, jac::AutoDiff.Jacobian, buffer)
             buffer.vang,
             view(jac.t1sx, nbus+1:2*nbus),
             buffer.qinj,
+            buffer.pd,
+            buffer.qd,
         )
     end
 
@@ -241,6 +245,7 @@ function AutoDiff.adj_hessian_prod!(
         view(t1sx, 1:nbus), view(adj_t1sx, 1:nbus),                   # vmag
         view(t1sx, nbus+1:2*nbus), view(adj_t1sx, nbus+1:2*nbus),     # vang
         view(t1sx, 2*nbus+1:3*nbus), view(adj_t1sx, 2*nbus+1:3*nbus), # pinj
+        buffer.pd, buffer.qd,
     )
 
     AutoDiff.getpartials_kernel!(hv, adj_t1sx, H.map, polar.device)

--- a/src/Polar/objective.jl
+++ b/src/Polar/objective.jl
@@ -9,6 +9,7 @@ function adjoint!(
     vm, ∂vm,
     va, ∂va,
     pinj, ∂pinj,
+    pload, qload,
 ) where {F<:typeof(active_power_generation), S, I}
     nbus = PS.get(polar.network, PS.NumberOfBuses())
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())
@@ -97,7 +98,8 @@ function put(
         buffer.pg, adj_pg,
         buffer.vmag, adj_vmag,
         buffer.vang, adj_vang,
-        buffer.pinj, adj_pinj
+        buffer.pinj, adj_pinj,
+        buffer.pd, buffer.qd,
     )
 
     # Adjoint w.r.t. x and u

--- a/src/Polar/polar.jl
+++ b/src/Polar/polar.jl
@@ -25,9 +25,6 @@ struct PolarForm{T, IT, VT, MT} <: AbstractFormulation where {T, IT, VT, MT}
     u_max::VT
     # costs
     costs_coefficients::MT
-    # Constant loads
-    active_load::VT
-    reactive_load::VT
     # Indexing of the PV, PQ and slack buses
     indexing::IndexingCache{IT}
     # struct
@@ -68,9 +65,6 @@ function PolarForm(pf::PS.PowerNetwork, device::KA.Device)
     topology = NetworkTopology{IT, VT}(pf)
     # Get coefficients penalizing the generation of the generators
     coefs = convert(AT{Float64, 2}, PS.get_costs_coefficients(pf))
-    # Move load to the target device
-    pload = convert(VT, PS.get(pf, PS.ActiveLoad()))
-    qload = convert(VT, PS.get(pf, PS.ReactiveLoad()))
 
     # Move the indexing to the target device
     idx_gen = PS.get(pf, PS.GeneratorIndexes())
@@ -142,7 +136,7 @@ function PolarForm(pf::PS.PowerNetwork, device::KA.Device)
     return PolarForm{Float64, IT, VT, AT{Float64,  2}}(
         pf, device,
         x_min, x_max, u_min, u_max,
-        coefs, pload, qload,
+        coefs,
         indexing,
         topology,
         statemap, controlmap,
@@ -171,16 +165,6 @@ function get(polar::PolarForm, attr::PS.AbstractNetworkAttribute)
     return get(polar.network, attr)
 end
 
-# Setters
-function setvalues!(polar::PolarForm, ::PS.ActiveLoad, values)
-    @assert length(polar.active_load) == length(values)
-    copyto!(polar.active_load, values)
-end
-function setvalues!(polar::PolarForm, ::PS.ReactiveLoad, values)
-    @assert length(polar.reactive_load) == length(values)
-    copyto!(polar.reactive_load, values)
-end
-
 ## Bounds
 function bounds(polar::PolarForm{T, IT, VT, MT}, ::State) where {T, IT, VT, MT}
     return polar.x_min, polar.x_max
@@ -193,10 +177,9 @@ end
 # Initial position
 function initial(polar::PolarForm{T, IT, VT, MT}, X::Union{State,Control}) where {T, IT, VT, MT}
     # Load data from PowerNetwork
-    pbus = real.(polar.network.sbus) |> VT
-    qbus = imag.(polar.network.sbus) |> VT
     vmag = abs.(polar.network.vbus) |> VT
     vang = angle.(polar.network.vbus) |> VT
+    pg = get(polar.network, PS.ActivePower())
 
     npv = get(polar, PS.NumberOfPVBuses())
     npq = get(polar, PS.NumberOfPQBuses())
@@ -214,10 +197,8 @@ function initial(polar::PolarForm{T, IT, VT, MT}, X::Union{State,Control}) where
         dimension = get(polar, NumberOfControl())
         u = xzeros(VT, dimension)
         u[1:nref] = vmag[polar.network.ref]
-        # u is equal to active power of generator (Pᵍ)
-        # As P = Pᵍ - Pˡ , we get
         u[nref + 1:nref + npv] = vmag[polar.network.pv]
-        u[nref + npv + 1:nref + 2*npv] = pbus[polar.network.pv] + polar.active_load[polar.network.pv]
+        u[nref + npv + 1:nref + 2*npv] = pg[polar.indexing.index_pv_to_gen]
         return u
     end
 end
@@ -268,10 +249,10 @@ end
 
 function init_buffer!(form::PolarForm{T, IT, VT, MT}, buffer::PolarNetworkState) where {T, IT, VT, MT}
     # FIXME: add proper getters in PowerSystem
-    pbus = real.(form.network.sbus)
-    qbus = imag.(form.network.sbus)
     vmag = abs.(form.network.vbus)
     vang = angle.(form.network.vbus)
+    pd = PS.get(form.network, PS.ActiveLoad())
+    qd = PS.get(form.network, PS.ReactiveLoad())
 
     pg = get(form.network, PS.ActivePower())
     qg = get(form.network, PS.ReactivePower())
@@ -280,8 +261,14 @@ function init_buffer!(form::PolarForm{T, IT, VT, MT}, buffer::PolarNetworkState)
     copyto!(buffer.vang, vang)
     copyto!(buffer.pg, pg)
     copyto!(buffer.qg, qg)
-    copyto!(buffer.pinj, pbus)
-    copyto!(buffer.qinj, qbus)
+    copyto!(buffer.pd, pd)
+    copyto!(buffer.qd, qd)
+
+    fill!(buffer.pinj, 0.0)
+    fill!(buffer.qinj, 0.0)
+    copyto!(view(buffer.pinj, form.indexing.index_generators), pg)
+    copyto!(view(buffer.qinj, form.indexing.index_generators), qg)
+    return
 end
 
 function direct_linear_solver(polar::PolarForm)

--- a/src/Polar/powerflow.jl
+++ b/src/Polar/powerflow.jl
@@ -18,7 +18,7 @@ function powerflow(
     linear_solver=DirectSolver(),
 ) where {T, IT, VT, MT}
     # Retrieve parameter and initial voltage guess
-    Vm, Va, pbus, qbus = buffer.vmag, buffer.vang, buffer.pinj, buffer.qinj
+    Vm, Va = buffer.vmag, buffer.vang
 
     nbus = PS.get(polar.network, PS.NumberOfBuses())
     ngen = PS.get(polar.network, PS.NumberOfGenerators())

--- a/test/Polar/api.jl
+++ b/test/Polar/api.jl
@@ -26,9 +26,8 @@ function test_polar_network_cache(polar, device, M)
     ExaPF.setvalues!(cache, PS.ReactiveLoad(), values)
     @test cache.vmag == values
     @test cache.vang == values
-    # Power generations are still equal to 0, so we get equality
-    @test cache.pinj == -values  # Pinj = 0 - Pd
-    @test cache.qinj == -values  # Qinj = 0 - Qd
+    @test cache.pd == values
+    @test cache.qd == values
 
     ## Generators
     vgens = similar(u0, ngen)
@@ -38,8 +37,8 @@ function test_polar_network_cache(polar, device, M)
     genbus = polar.indexing.index_generators
     @test cache.pg == vgens
     @test cache.qg == vgens
-    @test cache.pinj[genbus] == vgens - values[genbus]  # Pinj = Cg*Pg - Pd
-    @test cache.qinj[genbus] == vgens - values[genbus]  # Qinj = Cg*Qg - Pd
+    @test cache.pinj[genbus] == vgens # Pinj = Cg*Pg
+    @test cache.qinj[genbus] == vgens # Qinj = Cg*Qg
     @test !iszero(cache)
 
     return nothing

--- a/test/Polar/autodiff.jl
+++ b/test/Polar/autodiff.jl
@@ -46,7 +46,7 @@ function test_constraints_jacobian(polar, device, MT)
             cache.vang[pq] .= x[npv+1:npv+npq]
             cache.vmag[pq] .= x[npv+npq+1:end]
             c = zeros(m) |> MT
-            cons(polar, c, cache.vmag, cache.vang, cache.pinj, cache.qinj)
+            cons(polar, c, cache.vmag, cache.vang, cache.pinj, cache.qinj, cache.pd, cache.qd)
             return c
         end
         x = [cache.vang[pv]; cache.vang[pq]; cache.vmag[pq]]
@@ -75,7 +75,7 @@ function test_constraints_jacobian(polar, device, MT)
                 cache.vmag[pv] .= u[nref+1:npv+nref]
                 cache.pinj[pv] .= u[nref+npv+1:end]
                 c = zeros(m) |> MT
-                cons(polar, c, cache.vmag, cache.vang, cache.pinj, cache.qinj)
+                cons(polar, c, cache.vmag, cache.vang, cache.pinj, cache.qinj, cache.pd, cache.qd)
                 return c
             end
             u = [cache.vmag[ref]; cache.vmag[pv]; cache.pinj[pv]]
@@ -123,7 +123,7 @@ function test_constraints_adjoint(polar, device, MT)
         function test_fd(vvm)
             cache.vmag .= vvm[1:nbus]
             cache.vang .= vvm[1+nbus:2*nbus]
-            cons(polar, c, cache.vmag, cache.vang, cache.pinj, cache.qinj)
+            cons(polar, c, cache.vmag, cache.vang, cache.pinj, cache.qinj, cache.pd, cache.qd)
             return dot(c, tgt)
         end
         vv = [cache.vmag; cache.vang]

--- a/test/Polar/gradient.jl
+++ b/test/Polar/gradient.jl
@@ -80,7 +80,7 @@ function test_line_flow_gradient(polar, device, MT)
         # Needed for ForwardDiff to have a cache with the right active type VT
         adcache = ExaPF.PolarNetworkState{VI, VT}(
             cache.vmag, cache.vang, cache.pinj, cache.qinj,
-            cache.pg, cache.qg, cache.balance, cache.dx, bus_gen,
+            cache.pg, cache.qg, cache.pd, cache.qd, cache.balance, cache.dx, bus_gen,
         )
         adcache.vmag .= x[1:nbus]
         adcache.vang .= x[1+nbus:2*nbus]


### PR DESCRIPTION
Before this PR, the loads were defined two times: 
- explicitly as attributes of the `PolarForm` object (`polar.active_load` and `polar.reactive_load`)
- implicitly in the power injection stored inside the buffer (`buffer.pinj` and `buffer.qinj`), as `pinj` was defined as `Pinj = Pgen - Pload`

This leads to several side effects (one of them leading to convergence issues in ProxAL, where we are updating the loads all the time). To avoid this, this PR updates ExaPF to define the loads only *once*, directly in the cache. Now, `PolarForm` stores only information about the topology of the graph, and that's all. 

This will ease the definition of multi-generators per node, too. Suppose we have the genererators-buses incidence matrix `Cg`. With this PR, `pinj` and `qinj` are defined as 
```
pinj = Cg * pg
qinj = Cg * qg
```
Once this PR merged, support to multi-generators will be easy to implement.