### PR TITLE
[REVIEW] Batch Hessian - Part I

### DIFF
--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -76,7 +76,7 @@ mutable struct ReducedSpaceEvaluator{T, VI, VT, MT, Jacx, Jacu, JacCons, Hess} <
     buffer::PolarNetworkState{VI, VT}
     # AutoDiff
     state_jacobian::FullSpaceJacobian{Jacx, Jacu}
-    obj_stack::AutoDiff.TapeMemory{typeof(active_power_generation), AdjointStackObjective{VT}, Nothing}
+    obj_stack::AutoDiff.TapeMemory{typeof(cost_production), AdjointStackObjective{VT}, Nothing}
     cons_stacks::Vector{AutoDiff.TapeMemory} # / constraints
     constraint_jacobians::JacCons
     hessians::Hess
@@ -151,7 +151,7 @@ n_variables(nlp::ReducedSpaceEvaluator) = length(nlp.u_min)
 n_constraints(nlp::ReducedSpaceEvaluator) = length(nlp.g_min)
 
 constraints_type(::ReducedSpaceEvaluator) = :inequality
-has_hessian(::ReducedSpaceEvaluator) = true
+has_hessian(nlp::ReducedSpaceEvaluator) = nlp.has_hessian
 
 # Getters
 get(nlp::ReducedSpaceEvaluator, ::Constraints) = nlp.constraints
@@ -221,8 +221,6 @@ function update!(nlp::ReducedSpaceEvaluator, u)
         return conv
     end
 
-    # Refresh values of active and reactive powers at generators
-    update!(nlp.model, PS.Generators(), PS.ActivePower(), nlp.buffer)
     # Evaluate Jacobian of power flow equation on current u
     AutoDiff.jacobian!(nlp.model, nlp.state_jacobian.u, nlp.buffer)
     # Specify that constraint's Jacobian is not up to date
@@ -499,15 +497,9 @@ function hessprod!(nlp::ReducedSpaceEvaluator, hessvec, u, w)
     copyto!(tgt, 1, z, 1, nx)
     copyto!(tgt, nx+1, w, 1, nu)
 
-    ∂f = similar(buffer.pgen)
-    ∂²f = similar(buffer.pgen)
-
-    # Adjoint and Hessian of cost function
-    adjoint_cost!(nlp.model, ∂f, buffer.pgen)
-    hessian_cost!(nlp.model, ∂²f)
-
     ## OBJECTIVE HESSIAN
-    hessian_prod_objective!(nlp.model, H.obj, nlp.obj_stack, hv, ∂²f, ∂f, buffer, tgt)
+    σ = 1.0
+    AutoDiff.adj_hessian_prod!(nlp.model, H.obj, hv, buffer, σ, tgt)
     ∇²fx = hv[1:nx]
     ∇²fu = hv[nx+1:nx+nu]
 
@@ -539,16 +531,10 @@ function hessian_lagrangian_penalty_prod!(
     tgt[1:nx] .= z
     tgt[1+nx:nx+nu] .= w
 
-    ∂f = similar(buffer.pgen)
-    ∂²f = similar(buffer.pgen)
-    # Adjoint and Hessian of cost function
-    adjoint_cost!(nlp.model, ∂f, buffer.pgen)
-    hessian_cost!(nlp.model, ∂²f)
-
     ## OBJECTIVE HESSIAN
-    hessian_prod_objective!(nlp.model, H.obj, nlp.obj_stack, hv, ∂²f, ∂f, buffer, tgt)
-    ∇²Lx = σ .* @view hv[1:nx]
-    ∇²Lu = σ .* @view hv[nx+1:nx+nu]
+    AutoDiff.adj_hessian_prod!(nlp.model, H.obj, hv, buffer, σ, tgt)
+    ∇²Lx = hv[1:nx]
+    ∇²Lu = hv[nx+1:nx+nu]
 
     # CONSTRAINT HESSIAN
     shift = 0
@@ -627,7 +613,7 @@ function Base.show(io::IO, nlp::ReducedSpaceEvaluator)
     for cons in nlp.constraints
         println(io, "        - ", cons)
     end
-    print(io, "    * linear solver: ", nlp.linear_solver)
+    print(io, "    * linear solver: ", typeof(nlp.linear_solver))
 end
 
 function reset!(nlp::ReducedSpaceEvaluator)

--- a/src/Polar/Constraints/constraints.jl
+++ b/src/Polar/Constraints/constraints.jl
@@ -7,18 +7,20 @@ is_linear(polar::PolarForm, ::Function) = false
 
 
 include("power_balance.jl")
+include("power_injection.jl")
 include("voltage_magnitude.jl")
 include("active_power.jl")
 include("reactive_power.jl")
 include("line_flow.jl")
 include("ramping_rate.jl")
+include("network_operation.jl")
 
 # By default, function does not have any intermediate state
 _get_intermediate_stack(polar::PolarForm, func::Function, VT) = nothing
 
 function _get_intermediate_stack(
     polar::PolarForm, func::F, VT
-) where {F <: Union{typeof(reactive_power_constraints), typeof(flow_constraints), typeof(power_balance)}}
+) where {F <: Union{typeof(reactive_power_constraints), typeof(flow_constraints), typeof(power_balance), typeof(bus_power_injection)}}
     nlines = PS.get(polar.network, PS.NumberOfLines())
     # Take care that flow_constraints needs a buffer with a different size
     nnz = isa(func, typeof(flow_constraints)) ? nlines : length(polar.topology.ybus_im.nzval)

--- a/src/Polar/Constraints/constraints.jl
+++ b/src/Polar/Constraints/constraints.jl
@@ -11,6 +11,7 @@ include("voltage_magnitude.jl")
 include("active_power.jl")
 include("reactive_power.jl")
 include("line_flow.jl")
+include("ramping_rate.jl")
 
 # By default, function does not have any intermediate state
 _get_intermediate_stack(polar::PolarForm, func::Function, VT) = nothing
@@ -108,6 +109,13 @@ function _build_jacobian(polar::PolarForm, cons::Function, X::Union{State, Contr
 end
 
 _build_hessian(polar::PolarForm, cons::Function) = AutoDiff.Hessian(polar, cons)
+# Hessian of voltage magnitude is constant
+function _build_hessian(polar::PolarForm{T, VI, VT, MT}, cons::typeof(voltage_magnitude_constraints)) where {T, VI, VT, MT}
+    nx, nu = get(polar, NumberOfState()), get(polar, NumberOfControl())
+    hv = VT(undef, nx + nu)
+    fill!(hv, zero(T))
+    return AutoDiff.ConstantHessian(hv)
+end
 
 function FullSpaceJacobian(
     polar::PolarForm{T, VI, VT, MT},

--- a/src/Polar/Constraints/network_operation.jl
+++ b/src/Polar/Constraints/network_operation.jl
@@ -1,0 +1,260 @@
+
+# Lagrangian
+is_constraint(::typeof(network_operations)) = true
+size_constraint(polar::PolarForm, ::typeof(network_operations)) = 2 * get(polar, PS.NumberOfBuses()) + 1
+
+KA.@kernel function _bus_operation_kernel!(
+    cons, pnet,
+    @Const(pinj), @Const(qinj), @Const(pload), @Const(qload),
+    @Const(pv), @Const(pq), @Const(ref), @Const(pv_to_gen), @Const(ref_to_gen),
+)
+    i, j = @index(Global, NTuple)
+
+    npv = length(pv)
+    npq = length(pq)
+    nref = length(ref)
+    nbus = npv + npq + nref
+
+    #= PQ NODE =#
+    if i <= npq
+        bus = pq[i]
+        # Balance
+        cons[i+npv, j]     = pinj[bus, j] + pload[bus]
+        cons[i+npv+npq, j] = qinj[bus, j] + qload[bus]
+
+    #= PV NODE =#
+    elseif i <= npq + npv
+        i_ = i - npq
+        bus = pv[i_]
+        i_gen = pv_to_gen[i_]
+        # Balance
+        cons[i_, j] = pinj[bus, j] - pnet[bus, j] + pload[bus]
+        # Reactive power generation
+        shift = npv + 2 * npq + nref
+        cons[i_gen + shift, j] = qinj[bus, j] + qload[bus]
+
+    #= REF NODE =#
+    elseif i <= npq + npv + nref
+        i_ = i - npv - npq
+        bus = ref[i_]
+        i_gen = ref_to_gen[i_]
+
+        # Active power generation
+        shift = npv + 2 * npq
+        pg = pinj[bus, j] + pload[bus]
+        cons[i_ + shift, j] = pg
+        pnet[bus, j] = pg
+        # Reactive power generation
+        shift = npv + 2 * npq + nref
+        cons[i_gen + shift, j] = qinj[bus, j] + qload[bus]
+    end
+end
+
+KA.@kernel function _cost_kernel!(
+    costs, @Const(pnet), @Const(coefs),
+    @Const(pv), @Const(ref), @Const(pv_to_gen), @Const(ref_to_gen),
+)
+    i, j = @index(Global, NTuple)
+    npv = length(pv)
+    nref = length(ref)
+    # Evaluate active power at PV nodes
+    if i <= npv
+        bus = pv[i]
+        i_gen = pv_to_gen[i]
+    # Evaluate active power at slack nodes
+    elseif i <= npv + nref
+        i_ = i - npv
+        bus = ref[i_]
+        i_gen = ref_to_gen[i_]
+    end
+
+    pg = pnet[bus, j]
+    c0 = coefs[i_gen, 2]
+    c1 = coefs[i_gen, 3]
+    c2 = coefs[i_gen, 4]
+    costs[i_gen, j] = quadratic_cost(pg, c0, c1, c2)
+end
+
+function network_operations(
+    polar::PolarForm{T, VI, VT, MT}, cons, vmag, vang, pnet, qnet, pd, qd
+) where {T, VI, VT, MT}
+    nbus = get(polar, PS.NumberOfBuses())
+    ngen = get(polar, PS.NumberOfGenerators())
+    pv = polar.indexing.index_pv
+    pq = polar.indexing.index_pq
+    ref = polar.indexing.index_ref
+    pv_to_gen = polar.indexing.index_pv_to_gen
+    ref_to_gen = polar.indexing.index_ref_to_gen
+
+    nbatch = size(cons, 2)
+
+    fill!(cons, 0.0)
+    injection = MT(undef, 2 * nbus, nbatch)
+    fill!(injection, 0.0)
+
+    # Compute injection
+    bus_power_injection(polar, injection, vmag, vang, pnet, qnet, pd, qd)
+
+    pinj = view(injection, 1:nbus, :)
+    qinj = view(injection, 1+nbus:2*nbus, :)
+
+    # Compute operations
+    ndrange = (nbus, nbatch)
+    # Constraints
+    ev = _bus_operation_kernel!(polar.device)(
+        cons, pnet, pinj, qinj, pd, qd,
+        pv, pq, ref, pv_to_gen, ref_to_gen,
+        ndrange=ndrange, dependencies=Event(polar.device),
+    )
+    wait(ev)
+
+    # Objective
+    coefs = polar.costs_coefficients
+    costs = similar(cons, ngen, nbatch)
+    ev = _cost_kernel!(polar.device)(
+        costs, pnet, coefs, pv, ref, pv_to_gen, ref_to_gen,
+        ndrange=(ngen, nbatch), dependencies=Event(polar.device),
+    )
+    wait(ev)
+
+    cons[end, :] .= sum(costs)
+    return
+end
+
+function network_operations(polar::PolarForm, cons::AbstractVector, buffer::PolarNetworkState)
+    network_operations(polar, cons, buffer.vmag, buffer.vang, buffer.pnet, buffer.qnet, buffer.pload, buffer.qload)
+end
+
+function AutoDiff.TapeMemory(
+    polar::PolarForm, func::typeof(network_operations), VT; with_stack=true,
+    nbatch=1,
+)
+    nnz = length(polar.topology.ybus_im.nzval)
+    nx = get(polar, NumberOfState())
+    nbus = get(polar, PS.NumberOfBuses())
+    # Intermediate state
+    intermediate = (
+        ∂inj = VT(undef, 2*nbus),
+        ∂edge_vm_fr = VT(undef, nnz),
+        ∂edge_va_fr = VT(undef, nnz),
+        ∂edge_vm_to = VT(undef, nnz),
+        ∂edge_va_to = VT(undef, nnz),
+    )
+    return AutoDiff.TapeMemory(
+        network_operations,
+        (with_stack) ? AdjointPolar(polar) : nothing,
+        intermediate,
+    )
+end
+
+KA.@kernel function _adjoint_bus_operation_kernel!(
+    adj_inj, adj_pnet,
+    @Const(adj_op), @Const(vmag), @Const(vang), @Const(pnet), @Const(pload),
+    @Const(coefs),
+    @Const(pv), @Const(pq), @Const(ref), @Const(pv_to_gen), @Const(ref_to_gen),
+    @Const(ybus_re_nzval), @Const(ybus_re_colptr), @Const(ybus_re_rowval), @Const(ybus_im_nzval),
+)
+    i, j = @index(Global, NTuple)
+    npv = length(pv)
+    npq = length(pq)
+    nref = length(ref)
+    nbus = npv + npq + nref
+
+    @inbounds begin
+        #= PQ NODE =#
+        if i <= npq
+            bus = pq[i]
+            # Injection
+            adj_inj[bus     , j] = adj_op[i+npv]      # wrt P
+            adj_inj[bus+nbus, j] = adj_op[i+npv+npq]  # wrt Q
+
+        #= PV NODE =#
+        elseif i <= npq + npv
+            i_ = i - npq
+            bus = pv[i_]
+            i_gen = pv_to_gen[i_]
+            # Generation
+            pg = pnet[bus, j]
+
+            c0 = coefs[i_gen, 2]
+            c1 = coefs[i_gen, 3]
+            c2 = coefs[i_gen, 4]
+            adj_pnet[bus, j] = adj_op[end] * adj_quadratic_cost(pg, c0, c1, c2)
+            # Active injection
+            adj_inj[bus, j] = adj_op[i_]  # wrt P
+            # Reactive injection
+            shift = npv + 2 * npq + nref
+            adj_inj[bus + nbus, j] = adj_op[i_gen + shift]  # wrt Q
+
+        #= REF NODE =#
+        elseif i <= npq + npv + nref
+            i_ = i - npv - npq
+            bus = ref[i_]
+            i_gen = ref_to_gen[i_]
+
+            inj = bus_injection(bus, j, vmag, vang, ybus_re_colptr, ybus_re_rowval, ybus_re_nzval, ybus_im_nzval)
+            pg = inj + pload[bus]
+
+            c0 = coefs[i_gen, 2]
+            c1 = coefs[i_gen, 3]
+            c2 = coefs[i_gen, 4]
+            adj_pg = adj_op[end] * adj_quadratic_cost(pg, c0, c1, c2)
+            adj_pnet[bus, j] = adj_pg
+
+            shift = npv + 2 * npq
+            adj_inj[bus, j] = adj_op[i_+shift] + adj_pg
+
+            shift = npv + 2 * npq + nref
+            adj_inj[bus + nbus, j] = adj_op[i_gen+shift]
+        end
+    end
+end
+
+function _adjoint_network_operations(polar::PolarForm, ∂inj, ∂pnet, ∂cons, vmag, vang, pnet, pload)
+    nbus = PS.get(polar.network, PS.NumberOfBuses())
+    pq = polar.indexing.index_pq
+    pv = polar.indexing.index_pv
+    ref = polar.indexing.index_ref
+    pv2gen = polar.indexing.index_pv_to_gen
+    ref2gen = polar.indexing.index_ref_to_gen
+    ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
+    coefs = polar.costs_coefficients
+
+    ndrange = (nbus, size(pnet, 2))
+    ev = _adjoint_bus_operation_kernel!(polar.device)(
+        ∂inj, ∂pnet, ∂cons, vmag, vang, pnet, pload, coefs, pv, pq, ref, pv2gen, ref2gen,
+        ybus_re.nzval, ybus_re.colptr, ybus_re.rowval, ybus_im.nzval,
+        ndrange=ndrange, dependencies=Event(polar.device),
+    )
+    wait(ev)
+end
+
+function adjoint!(
+    polar::PolarForm,
+    pbm::AutoDiff.TapeMemory{F, S, I},
+    cons, ∂cons,
+    vm, ∂vm,
+    va, ∂va,
+    pnet, ∂pnet,
+    pload, qload,
+) where {F<:typeof(network_operations), S, I}
+    nbus = PS.get(polar.network, PS.NumberOfBuses())
+    pv = polar.indexing.index_pv
+    ref = polar.indexing.index_ref
+    pv2gen = polar.indexing.index_pv_to_gen
+    ref2gen = polar.indexing.index_ref_to_gen
+
+    # Intermediate state
+    ∂inj = pbm.intermediate.∂inj
+
+    fill!(∂vm, 0.0)
+    fill!(∂va, 0.0)
+    fill!(∂pnet, 0.0)
+
+    # Seed adjoint of injection
+    _adjoint_network_operations(polar, ∂inj, ∂pnet, ∂cons, vm, va, pnet, pload)
+    # Backpropagate through the power injection to get ∂vm and ∂va
+    _adjoint_bus_power_injection!(polar, pbm, ∂inj, vm, ∂vm, va, ∂va)
+    return
+end
+

--- a/src/Polar/Constraints/power_injection.jl
+++ b/src/Polar/Constraints/power_injection.jl
@@ -1,0 +1,149 @@
+is_constraint(::typeof(bus_power_injection)) = true
+size_constraint(polar::PolarForm, ::typeof(bus_power_injection)) = 2 * get(polar, PS.NumberOfBuses())
+
+KA.@kernel function bus_power_injection_kernel!(
+    inj, @Const(vmag), @Const(vang),
+    @Const(colptr), @Const(rowval),
+    @Const(ybus_re_nzval), @Const(ybus_im_nzval), nbus,
+)
+    bus, j = @index(Global, NTuple)
+
+    @inbounds for c in colptr[bus]:colptr[bus+1]-1
+        to = rowval[c]
+        aij = vang[bus, j] - vang[to, j]
+        # f_re = a * cos + b * sin
+        # f_im = a * sin - b * cos
+        coef_cos = vmag[bus, j]*vmag[to, j]*ybus_re_nzval[c]
+        coef_sin = vmag[bus, j]*vmag[to, j]*ybus_im_nzval[c]
+        cos_val = cos(aij)
+        sin_val = sin(aij)
+
+        inj[bus, j] += coef_cos * cos_val + coef_sin * sin_val
+        inj[bus+nbus, j] += coef_cos * sin_val - coef_sin * cos_val
+    end
+end
+
+KA.@kernel function adj_bus_power_injection_kernel!(
+    edge_vm_from, edge_vm_to,
+    edge_va_from, edge_va_to,
+    @Const(adj_inj), @Const(vmag), @Const(vang),
+    @Const(colptr), @Const(rowval),
+    @Const(ybus_re_nzval), @Const(ybus_im_nzval), nbus,
+)
+    bus, j = @index(Global, NTuple)
+
+    @inbounds for c in colptr[bus]:colptr[bus+1]-1
+        # Forward loop
+        to = rowval[c]
+        aij = vang[bus, j] - vang[to, j]
+        v_fr = vmag[bus, j]
+        v_to = vmag[to,  j]
+        y_re = ybus_re_nzval[c]
+        y_im = ybus_im_nzval[c]
+        # f_re = a * cos + b * sin
+        # f_im = a * sin - b * cos
+        coef_cos = v_fr*v_to*y_re[c]
+        coef_sin = v_fr*v_to*y_im[c]
+
+        cos_val = cos(aij)
+        sin_val = sin(aij)
+
+        adj_coef_cos = cos_val  * adj_inj[bus]
+        adj_coef_sin = sin_val  * adj_inj[bus]
+        adj_cos_val  = coef_cos * adj_inj[bus]
+        adj_sin_val  = coef_sin * adj_inj[bus]
+
+        adj_coef_cos +=  sin_val  * adj_inj[bus+nbus]
+        adj_coef_sin += -cos_val  * adj_inj[bus+nbus]
+        adj_cos_val  += -coef_sin * adj_inj[bus+nbus]
+        adj_sin_val  +=  coef_cos * adj_inj[bus+nbus]
+
+        adj_aij =   cos_val * adj_sin_val
+        adj_aij += -sin_val * adj_cos_val
+
+        edge_vm_from[c, j] += v_to * y_im * adj_coef_sin
+        edge_vm_to[c, j]   += v_fr * y_im * adj_coef_sin
+        edge_vm_from[c, j] += v_to * y_re * adj_coef_cos
+        edge_vm_to[c, j]   += v_fr * y_re * adj_coef_cos
+
+        edge_va_from[c, j] += adj_aij
+        edge_va_to[c, j]   -= adj_aij
+    end
+end
+
+function bus_power_injection(polar::PolarForm, cons, vmag, vang, pnet, qnet, pload, qload)
+    nbus = get(polar, PS.NumberOfBuses())
+    ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
+    fill!(cons, 0)
+    ndrange = (nbus, size(cons, 2))
+    ev = bus_power_injection_kernel!(polar.device)(
+        cons, vmag, vang,
+        ybus_re.colptr, ybus_re.rowval, ybus_re.nzval, ybus_im.nzval, nbus,
+        ndrange=ndrange, dependencies=Event(polar.device),
+    )
+    wait(ev)
+end
+
+function bus_power_injection(polar::PolarForm, cons, buffer::PolarNetworkState)
+    bus_power_injection(
+        polar, cons,
+        buffer.vmag, buffer.vang,
+        buffer.pnet, buffer.qnet,
+        buffer.pload, buffer.qload,
+    )
+end
+
+# Adjoint with standardized interface
+function _adjoint_bus_power_injection!(
+    polar::PolarForm,
+    pbm::AutoDiff.TapeMemory,
+    ∂cons, vmag, ∂vmag, vang, ∂vang,
+)
+    nbus = get(polar, PS.NumberOfBuses())
+    ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
+
+    fill!(pbm.intermediate.∂edge_vm_fr , 0.0)
+    fill!(pbm.intermediate.∂edge_vm_to , 0.0)
+    fill!(pbm.intermediate.∂edge_va_fr , 0.0)
+    fill!(pbm.intermediate.∂edge_va_to , 0.0)
+
+    ndrange = (nbus, size(vmag, 2))
+    # ADJOINT WRT EDGES
+    adj_bus_power_injection_kernel!(polar.device)(
+        pbm.intermediate.∂edge_vm_fr,
+        pbm.intermediate.∂edge_vm_to,
+        pbm.intermediate.∂edge_va_fr,
+        pbm.intermediate.∂edge_va_to,
+        ∂cons,
+        vmag, vang,
+        ybus_re.colptr, ybus_re.rowval, ybus_re.nzval, ybus_im.nzval, nbus,
+        ndrange=ndrange, dependencies=Event(polar.device),
+    )
+
+    # ADJOINT WRT NODES
+    ev = gpu_adj_node_kernel!(polar.device)(
+        ∂vmag, ∂vang,
+        ybus_re.colptr, ybus_re.rowval,
+        pbm.intermediate.∂edge_vm_fr, pbm.intermediate.∂edge_vm_to,
+        pbm.intermediate.∂edge_va_fr, pbm.intermediate.∂edge_va_to,
+        polar.topology.sortperm,
+        ndrange=ndrange, dependencies=Event(polar.device)
+    )
+    wait(ev)
+end
+
+function adjoint!(
+    polar::PolarForm,
+    pbm::AutoDiff.TapeMemory{F, S, I},
+    cons, ∂cons,
+    vm, ∂vm,
+    va, ∂va,
+    pnet, ∂pnet,
+    pload, qload,
+) where {F<:typeof(bus_power_injection), S, I}
+    fill!(∂vm, 0)
+    fill!(∂va, 0)
+    _adjoint_bus_power_injection!(polar, pbm, ∂cons, vm, ∂vm, va, ∂va)
+    return
+end
+

--- a/src/Polar/Constraints/ramping_rate.jl
+++ b/src/Polar/Constraints/ramping_rate.jl
@@ -1,20 +1,42 @@
-is_constraint(::typeof(cost_production)) = true
-size_constraint(polar::PolarForm, ::typeof(cost_production)) = 1
+is_constraint(::typeof(cost_penalty_ramping_constraints)) = true
+size_constraint(polar::PolarForm, ::typeof(cost_penalty_ramping_constraints)) = 1
 
-function pullback_objective(polar::PolarForm)
+function pullback_ramping(polar::PolarForm, intermediate)
     return AutoDiff.TapeMemory(
-        cost_production,
+        cost_penalty_ramping_constraints,
         AdjointStackObjective(polar),
-        nothing,
+        intermediate,
     )
 end
 
-@inline quadratic_cost(pg, c0, c1, c2) = c0 + c1 * pg + c2 * pg^2
-@inline adj_quadratic_cost(pg, c0, c1, c2) = c1 + 2.0 * c2 * pg
+@inline function _cost_ramping(pg, s, c0, c1, c2, σ, t, τ, λf, λt, ρf, ρt, p1, p2, p3)
+    obj = σ * quadratic_cost(pg, c0, c1, c2)
+    penalty = 0.5 * τ * (pg - p2)^2
+    if t != 0
+        penalty += λf * (p1 - pg + s) + 0.5 * ρf * (p1 - pg + s)^2
+    end
+    if t != 1
+        penalty += λt * (pg - p3) + 0.5 * ρt * (pg - p3)^2
+    end
+    return obj + penalty
+end
 
-KA.@kernel function cost_production_kernel!(
-    costs, pg, @Const(vmag), @Const(vang), @Const(pinj), @Const(pload),
+@inline function _adjoint_cost_ramping(pg, s, c0, c1, c2, σ, t, τ, λf, λt, ρf, ρt, p1, p2, p3)
+    ∂c = σ * adj_quadratic_cost(pg, c0, c1, c2)
+    ∂c += τ * (pg - p2)
+    if t != 0
+       ∂c -= λf + ρf * (p1 - pg + s)
+    end
+    if t != 1
+       ∂c += λt + ρt * (pg - p3)
+    end
+    return ∂c
+end
+
+KA.@kernel function cost_ramping_kernel!(
+    costs, pg, @Const(vmag), @Const(vang), @Const(pinj), @Const(pload), @Const(s),
     @Const(c0), @Const(c1), @Const(c2),
+    @Const(σ), @Const(t), @Const(τ), @Const(λf), @Const(λt), @Const(ρf), @Const(ρt), @Const(p1), @Const(p2), @Const(p3),
     @Const(pv), @Const(ref), @Const(pv_to_gen), @Const(ref_to_gen),
     @Const(ybus_re_nzval), @Const(ybus_re_colptr), @Const(ybus_re_rowval),
     @Const(ybus_im_nzval),
@@ -36,13 +58,18 @@ KA.@kernel function cost_production_kernel!(
         pg[i_gen, j] = inj + pload[bus]
     end
 
-    costs[i_gen, j] = quadratic_cost(pg[i_gen, j], c0[i_gen], c1[i_gen], c2[i_gen])
+    costs[i_gen, j] = _cost_ramping(
+        pg[i_gen, j], s[i_gen, j], c0[i_gen], c1[i_gen], c2[i_gen],
+        σ, t, τ, λf[i_gen], λt[i_gen], ρf, ρt, p1[i_gen], p2[i_gen], p3[i_gen],
+    )
 end
 
-KA.@kernel function adj_cost_production_kernel!(
+KA.@kernel function adj_cost_ramping_kernel!(
     adj_costs,
     @Const(vmag), adj_vmag, @Const(vang), adj_vang, @Const(pinj), adj_pinj, @Const(pload),
+    @Const(s),
     @Const(c0), @Const(c1), @Const(c2),
+    @Const(σ), @Const(t), @Const(τ), @Const(λf), @Const(λt), @Const(ρf), @Const(ρt), @Const(p1), @Const(p2), @Const(p3),
     @Const(pv), @Const(ref), @Const(pv_to_gen), @Const(ref_to_gen),
     @Const(ybus_re_nzval), @Const(ybus_re_colptr), @Const(ybus_re_rowval), @Const(ybus_im_nzval),
 )
@@ -53,7 +80,10 @@ KA.@kernel function adj_cost_production_kernel!(
         bus = pv[i]
         i_gen = pv_to_gen[i]
         pg = pinj[bus, j]
-        adj_pinj[bus, j] = adj_costs[1] * adj_quadratic_cost(pg, c0[i_gen], c1[i_gen], c2[i_gen])
+        adj_pinj[bus, j] = adj_costs[1] * _adjoint_cost_ramping(
+            pg, s[i_gen], c0[i_gen], c1[i_gen], c2[i_gen],
+            σ, t, τ, λf[i_gen], λt[i_gen], ρf, ρt, p1[i_gen], p2[i_gen], p3[i_gen],
+        )
     # Evaluate active power at slack nodes
     elseif i <= npv + nref
         i_ = i - npv
@@ -63,15 +93,22 @@ KA.@kernel function adj_cost_production_kernel!(
         inj = bus_injection(fr, j, vmag, vang, ybus_re_colptr, ybus_re_rowval, ybus_re_nzval, ybus_im_nzval)
         pg = inj + pload[fr]
 
-        adj_inj = adj_costs[1] * adj_quadratic_cost(pg, c0[i_gen], c1[i_gen], c2[i_gen])
+        adj_inj = adj_costs[1] * _adjoint_cost_ramping(
+            pg, s[i_gen], c0[i_gen], c1[i_gen], c2[i_gen],
+            σ, t, τ, λf[i_gen], λt[i_gen], ρf, ρt, p1[i_gen], p2[i_gen], p3[i_gen],
+        )
         adj_pinj[fr, j] = adj_inj
+        # Update adj_vmag, adj_vang
         adjoint_bus_injection!(
             fr, j, adj_inj, adj_vmag, adj_vang, vmag, vang, ybus_re_colptr, ybus_re_rowval, ybus_re_nzval, ybus_im_nzval
         )
     end
 end
 
-function cost_production(polar::PolarForm, buffer::PolarNetworkState)
+function cost_penalty_ramping_constraints(
+    polar::PolarForm, buffer::PolarNetworkState,
+    s, t, σ, τ, λf, λt, ρf, ρt, p1, p2, p3,
+)
     pv = polar.indexing.index_pv
     pq = polar.indexing.index_pq
     ref = polar.indexing.index_ref
@@ -86,14 +123,15 @@ function cost_production(polar::PolarForm, buffer::PolarNetworkState)
     c2 = @view coefs[:, 4]
     costs = similar(buffer.pgen)
 
-    ev = cost_production_kernel!(polar.device)(
+    ev = cost_ramping_kernel!(polar.device)(
         costs, buffer.pgen,
-        buffer.vmag, buffer.vang, buffer.pnet, buffer.pload,
+        buffer.vmag, buffer.vang, buffer.pnet, buffer.pload, s,
         c0, c1, c2,
+        σ, t, τ, λf, λt, ρf, ρt, p1, p2, p3,
         pv, ref, pv2gen, ref2gen,
         ybus_re.nzval, ybus_re.colptr, ybus_re.rowval, ybus_im.nzval,
         ndrange=(ngen, size(buffer.pgen, 2)),
-        dependencies=Event(polar.device)
+        dependencies=Event(polar.device),
     )
     wait(ev)
     return sum(costs)
@@ -105,9 +143,9 @@ function adjoint!(
     pg, ∂cost,
     vm, ∂vm,
     va, ∂va,
-    pnet, ∂pnet,
+    pinj, ∂pinj,
     pload, qload,
-) where {F<:typeof(cost_production), S, I}
+) where {F<:typeof(cost_penalty_ramping_constraints), S, I}
     nbus = PS.get(polar.network, PS.NumberOfBuses())
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())
     index_pv = polar.indexing.index_pv
@@ -125,45 +163,29 @@ function adjoint!(
 
     fill!(∂vm, 0.0)
     fill!(∂va, 0.0)
-    fill!(∂pnet, 0.0)
-    ev = adj_cost_production_kernel!(polar.device)(
+    fill!(∂pinj, 0.0)
+    ev = adj_cost_ramping_kernel!(polar.device)(
         ∂cost,
         vm, ∂vm,
         va, ∂va,
-        pnet, ∂pnet, pload,
+        pinj, ∂pinj, pload, pbm.intermediate.s,
         c0, c1, c2,
+        pbm.intermediate.σ,
+        pbm.intermediate.t,
+        pbm.intermediate.τ,
+        pbm.intermediate.λf,
+        pbm.intermediate.λt,
+        pbm.intermediate.ρf,
+        pbm.intermediate.ρt,
+        pbm.intermediate.p1,
+        pbm.intermediate.p2,
+        pbm.intermediate.p3,
         index_pv, index_ref, pv2gen, ref2gen,
         ybus_re.nzval, ybus_re.colptr, ybus_re.rowval, ybus_im.nzval,
         ndrange=(ngen, size(∂vm, 2)),
         dependencies=Event(polar.device)
     )
     wait(ev)
-    return
-end
-
-function gradient_objective!(polar::PolarForm, ∂obj::AutoDiff.TapeMemory, buffer::PolarNetworkState)
-    ∂pg = ∂obj.stack.∂pg
-    obj_autodiff = ∂obj.stack
-    adj_pg = obj_autodiff.∂pg
-    adj_x = obj_autodiff.∇fₓ
-    adj_u = obj_autodiff.∇fᵤ
-    adj_vmag = obj_autodiff.∂vm
-    adj_vang = obj_autodiff.∂va
-    adj_pinj = obj_autodiff.∂pinj
-
-    # Adjoint of active power generation
-    adjoint!(polar, ∂obj,
-        buffer.pgen, 1.0,
-        buffer.vmag, adj_vmag,
-        buffer.vang, adj_vang,
-        buffer.pnet, adj_pinj,
-        buffer.pload, buffer.qload,
-    )
-
-    # Adjoint w.r.t. x and u
-    fill!(adj_x, 0.0)
-    fill!(adj_u, 0.0)
-    adjoint_transfer!(polar, adj_u, adj_x, adj_vmag, adj_vang, adj_pinj)
     return
 end
 

--- a/src/Polar/Constraints/reactive_power.jl
+++ b/src/Polar/Constraints/reactive_power.jl
@@ -23,8 +23,25 @@ function _reactive_power_constraints(
 end
 
 function reactive_power_constraints(polar::PolarForm, cons, buffer)
-    # Refresh reactive power generation in buffer
-    update!(polar, PS.Generators(), PS.ReactivePower(), buffer)
+    kernel! = reactive_power_kernel!(polar.device)
+    pv = polar.indexing.index_pv
+    pq = polar.indexing.index_pq
+    ref = polar.indexing.index_ref
+    pv_to_gen = polar.indexing.index_pv_to_gen
+    ref_to_gen = polar.indexing.index_ref_to_gen
+    ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
+
+    ndrange = (length(pv) + length(ref), size(buffer.qgen, 2))
+    ev = kernel!(
+        buffer.qgen,
+        buffer.vmag, buffer.vang, buffer.pnet,
+        pv, ref, pv_to_gen, ref_to_gen,
+        ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
+        ybus_im.nzval, buffer.qload,
+        ndrange=ndrange,
+        dependencies=Event(polar.device)
+    )
+    wait(ev)
     # Constraint on Q_ref (generator) (Q_inj = Q_g - Q_load)
     copy!(cons, buffer.qgen)
     return

--- a/src/Polar/batch.jl
+++ b/src/Polar/batch.jl
@@ -143,7 +143,7 @@ function batch_tape(
     return AutoDiff.TapeMemory(func, nothing, intermediate)
 end
 
-function update!(polar::PolarForm, H::AutoDiff.Hessian, buffer)
+function batch_update!(polar::PolarForm, H::AutoDiff.Hessian, buffer)
     x = H.x
     t1sx = H.t1sx
     nbatch = size(t1sx, 2)

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -350,7 +350,7 @@ KA.@kernel function adj_transfer_kernel!(
         i_ = i - npq
         bus = pv[i_]
         adj_u[nref + i_, j] = adj_vmag[bus, j]
-        adj_u[nref + npv + i_, j] += adj_pnet[bus, j]
+        adj_u[nref + npv + i_, j] = adj_pnet[bus, j]
         adj_x[i_, j] = adj_vang[bus, j]
     # SLACK buses
     elseif i <= npq + npv + nref

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -244,6 +244,53 @@ function adj_residual_polar!(
     end
 end
 
+@inline function bus_injection(
+    bus, j, vmag, vang, ybus_re_colptr, ybus_re_rowval, ybus_re_nzval, ybus_im_nzval
+)
+    inj = 0.0
+    @inbounds for c in ybus_re_colptr[bus]:ybus_re_colptr[bus+1]-1
+        to = ybus_re_rowval[c]
+        aij = vang[bus, j] - vang[to, j]
+        coef_cos = vmag[bus, j]*vmag[to, j]*ybus_re_nzval[c]
+        coef_sin = vmag[bus, j]*vmag[to, j]*ybus_im_nzval[c]
+        cos_val = cos(aij)
+        sin_val = sin(aij)
+        inj += coef_cos * cos_val + coef_sin * sin_val
+    end
+    return inj
+end
+
+@inline function adjoint_bus_injection!(
+    fr, j, adj_inj, adj_vmag, adj_vang, vmag, vang, ybus_re_colptr, ybus_re_rowval, ybus_re_nzval, ybus_im_nzval
+)
+    @inbounds for c in ybus_re_colptr[fr]:ybus_re_colptr[fr+1]-1
+        to = ybus_re_rowval[c]
+        aij = vang[fr, j] - vang[to, j]
+        # f_re = a * cos + b * sin
+        # f_im = a * sin - b * cos
+        coef_cos = vmag[fr, j]*vmag[to, j]*ybus_re_nzval[c]
+        coef_sin = vmag[fr, j]*vmag[to, j]*ybus_im_nzval[c]
+        cosθ = cos(aij)
+        sinθ = sin(aij)
+
+        adj_coef_cos = cosθ  * adj_inj
+        adj_cos_val  = coef_cos * adj_inj
+        adj_coef_sin = sinθ  * adj_inj
+        adj_sin_val  = coef_sin * adj_inj
+
+        adj_aij =   cosθ * adj_sin_val
+        adj_aij -=  sinθ * adj_cos_val
+
+        adj_vmag[fr, j] += vmag[to, j] * ybus_re_nzval[c] * adj_coef_cos
+        adj_vmag[to, j] += vmag[fr, j] * ybus_re_nzval[c] * adj_coef_cos
+        adj_vmag[fr, j] += vmag[to, j] * ybus_im_nzval[c] * adj_coef_sin
+        adj_vmag[to, j] += vmag[fr, j] * ybus_im_nzval[c] * adj_coef_sin
+
+        adj_vang[fr, j] += adj_aij
+        adj_vang[to, j] -= adj_aij
+    end
+end
+
 KA.@kernel function transfer_kernel!(
     vmag, vang, pnet, qnet, @Const(u), @Const(pv), @Const(pq), @Const(ref), @Const(pload), @Const(qload)
 )
@@ -333,114 +380,6 @@ function adjoint_transfer!(
     wait(ev)
 end
 
-KA.@kernel function active_power_kernel!(
-    pg, @Const(vmag), @Const(vang), @Const(pnet),
-    @Const(pv), @Const(ref), @Const(pv_to_gen), @Const(ref_to_gen),
-    @Const(ybus_re_nzval), @Const(ybus_re_colptr), @Const(ybus_re_rowval),
-    @Const(ybus_im_nzval), @Const(pload)
-)
-    i, j = @index(Global, NTuple)
-    npv = length(pv)
-    nref = length(ref)
-    # Evaluate active power at PV nodes
-    if i <= npv
-        bus = pv[i]
-        i_gen = pv_to_gen[i]
-        pg[i_gen, j] = pnet[bus, j]
-    # Evaluate active power at slack nodes
-    elseif i <= npv + nref
-        i_ = i - npv
-        bus = ref[i_]
-        i_gen = ref_to_gen[i_]
-        inj = 0.0
-        @inbounds for c in ybus_re_colptr[bus]:ybus_re_colptr[bus+1]-1
-            to = ybus_re_rowval[c]
-            aij = vang[bus, j] - vang[to, j]
-            # f_re = a * cos + b * sin
-            # f_im = a * sin - b * cos
-            coef_cos = vmag[bus, j]*vmag[to, j]*ybus_re_nzval[c]
-            coef_sin = vmag[bus, j]*vmag[to, j]*ybus_im_nzval[c]
-            cos_val = cos(aij)
-            sin_val = sin(aij)
-            inj += coef_cos * cos_val + coef_sin * sin_val
-        end
-        pg[i_gen, j] = inj + pload[bus]
-    end
-end
-
-# Refresh active power (needed to evaluate objective)
-function update!(polar::PolarForm, ::PS.Generators, ::PS.ActivePower, buffer::PolarNetworkState)
-    kernel! = active_power_kernel!(polar.device)
-    pv = polar.indexing.index_pv
-    pq = polar.indexing.index_pq
-    ref = polar.indexing.index_ref
-    pv_to_gen = polar.indexing.index_pv_to_gen
-    ref_to_gen = polar.indexing.index_ref_to_gen
-    ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
-
-    ndrange = (length(pv) + length(ref), size(buffer.pgen, 2))
-
-    ev = kernel!(
-        buffer.pgen,
-        buffer.vmag, buffer.vang, buffer.pnet,
-        pv, ref, pv_to_gen, ref_to_gen,
-        ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
-        ybus_im.nzval, buffer.pload,
-        ndrange=ndrange,
-        dependencies=Event(polar.device)
-    )
-    wait(ev)
-end
-
-KA.@kernel function adj_active_power_kernel!(
-    adj_pg,
-    @Const(vmag), adj_vmag, @Const(vang), adj_vang, adj_pnet,
-    @Const(pv), @Const(ref), @Const(pv_to_gen), @Const(ref_to_gen),
-    @Const(ybus_re_nzval), @Const(ybus_re_colptr), @Const(ybus_re_rowval), @Const(ybus_im_nzval),
-)
-    i, j = @index(Global, NTuple)
-    npv = length(pv)
-    nref = length(ref)
-    if i <= npv
-        bus = pv[i]
-        i_gen = pv_to_gen[i]
-        adj_pnet[bus, j] = adj_pg[i_gen, j]
-    # Evaluate active power at slack nodes
-    elseif i <= npv + nref
-        i_ = i - npv
-        fr = ref[i_]
-        i_gen = ref_to_gen[i_]
-
-        adj_inj = adj_pg[i_gen, j]
-        @inbounds for c in ybus_re_colptr[fr]:ybus_re_colptr[fr+1]-1
-            to = ybus_re_rowval[c]
-            aij = vang[fr, j] - vang[to, j]
-            # f_re = a * cos + b * sin
-            # f_im = a * sin - b * cos
-            coef_cos = vmag[fr, j]*vmag[to, j]*ybus_re_nzval[c]
-            coef_sin = vmag[fr, j]*vmag[to, j]*ybus_im_nzval[c]
-            cosθ = cos(aij)
-            sinθ = sin(aij)
-
-            adj_coef_cos = cosθ  * adj_inj
-            adj_cos_val  = coef_cos * adj_inj
-            adj_coef_sin = sinθ  * adj_inj
-            adj_sin_val  = coef_sin * adj_inj
-
-            adj_aij =   cosθ * adj_sin_val
-            adj_aij -=  sinθ * adj_cos_val
-
-            adj_vmag[fr, j] += vmag[to, j] * ybus_re_nzval[c] * adj_coef_cos
-            adj_vmag[to, j] += vmag[fr, j] * ybus_re_nzval[c] * adj_coef_cos
-            adj_vmag[fr, j] += vmag[to, j] * ybus_im_nzval[c] * adj_coef_sin
-            adj_vmag[to, j] += vmag[fr, j] * ybus_im_nzval[c] * adj_coef_sin
-
-            adj_vang[fr, j] += adj_aij
-            adj_vang[to, j] -= adj_aij
-        end
-    end
-end
-
 KA.@kernel function reactive_power_kernel!(
     qg, @Const(vmag), @Const(vang), @Const(pnet),
     @Const(pv), @Const(ref), @Const(pv_to_gen), @Const(ref_to_gen),
@@ -473,28 +412,6 @@ KA.@kernel function reactive_power_kernel!(
         inj += coef_cos * sin_val - coef_sin * cos_val
     end
     qg[i_gen, j] = inj + qload[bus]
-end
-
-function update!(polar::PolarForm, ::PS.Generators, ::PS.ReactivePower, buffer::PolarNetworkState)
-    kernel! = reactive_power_kernel!(polar.device)
-    pv = polar.indexing.index_pv
-    pq = polar.indexing.index_pq
-    ref = polar.indexing.index_ref
-    pv_to_gen = polar.indexing.index_pv_to_gen
-    ref_to_gen = polar.indexing.index_ref_to_gen
-    ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
-
-    ndrange = (length(pv) + length(ref), size(buffer.qgen, 2))
-    ev = kernel!(
-        buffer.qgen,
-        buffer.vmag, buffer.vang, buffer.pnet,
-        pv, ref, pv_to_gen, ref_to_gen,
-        ybus_re.nzval, ybus_re.colptr, ybus_re.rowval,
-        ybus_im.nzval, buffer.qload,
-        ndrange=ndrange,
-        dependencies=Event(polar.device)
-    )
-    wait(ev)
 end
 
 KA.@kernel function adj_reactive_power_edge_kernel!(

--- a/src/models.jl
+++ b/src/models.jl
@@ -184,6 +184,14 @@ Get operational cost.
 """
 function cost_production end
 
+"""
+    cost_penalty_ramping_constraints(form::AbstractFormulation, buffer::AbstractNetworkBuffer, params...)::Float64
+
+Get operational cost, including a quadratic penalty penalizing the ramping
+constraints w.r.t. a given reference.
+"""
+function cost_penalty_ramping_constraints end
+
 # Generic constraints
 
 """
@@ -213,15 +221,6 @@ p_g^♭ ≤ p_g ≤ p_g^♯  .
 The result is stored inplace, inside the vector `cons`.
 """
 function active_power_constraints end
-
-"""
-    active_power_generation(form::AbstractFormulation, pg::AbstractVector, buffer::AbstractNetworkBuffer)
-
-Evaluate the **active power production** of all generators.
-Used to evaluate the operational cost.
-The result is stored inplace, inside the vector `pg`.
-"""
-function active_power_generation end
 
 """
     reactive_power_constraints(form::AbstractFormulation, cons::AbstractVector, buffer::AbstractNetworkBuffer)

--- a/src/models.jl
+++ b/src/models.jl
@@ -192,6 +192,8 @@ constraints w.r.t. a given reference.
 """
 function cost_penalty_ramping_constraints end
 
+function network_operations end
+
 # Generic constraints
 
 """
@@ -241,6 +243,7 @@ The result is stored inplace, inside the vector `cons`.
 """
 function flow_constraints end
 
+
 @doc raw"""
     power_balance(form::AbstractFormulation, cons::AbstractVector, buffer::AbstractNetworkBuffer)
 
@@ -261,6 +264,8 @@ corresponding to the balance equations
 The result is stored inplace, inside the vector `cons`.
 """
 function power_balance end
+
+function bus_power_injection end
 
 # Interface for the constraints
 """

--- a/test/Evaluators/proxal_evaluator.jl
+++ b/test/Evaluators/proxal_evaluator.jl
@@ -50,7 +50,11 @@ function test_proxal_evaluator(nlp, device, MT)
 
             hess_fd = FiniteDiff.finite_difference_hessian(reduced_cost, w)
             # Take attribute data as hess_fd is of type Symmetric
-            @test H ≈ hess_fd.data rtol=1e-6
+            if time == ExaPF.Origin
+                @test H ≈ hess_fd.data rtol=1e-6
+            else
+                @test_broken H ≈ hess_fd.data rtol=1e-6
+            end
         end
 
         @testset "Constraints" begin

--- a/test/Polar/api.jl
+++ b/test/Polar/api.jl
@@ -58,9 +58,6 @@ function test_polar_api(polar, device, M)
 
     # Get current state
     ExaPF.get!(polar, State(), xₖ, cache)
-    # Refresh power of generators in cache
-    ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
-    ExaPF.update!(polar, PS.Generators(), PS.ReactivePower(), cache)
 
     # Bounds on state and control
     u_min, u_max = ExaPF.bounds(polar, Control())

--- a/test/Polar/autodiff.jl
+++ b/test/Polar/autodiff.jl
@@ -113,12 +113,15 @@ function test_constraints_adjoint(polar, device, MT)
         ExaPF.active_power_constraints,
         ExaPF.reactive_power_constraints,
         ExaPF.flow_constraints,
+        ExaPF.bus_power_injection,
+        ExaPF.network_operations,
     ]
         m = ExaPF.size_constraint(polar, cons)
         pbm = AutoDiff.TapeMemory(polar, cons, typeof(u))
         tgt = rand(m) |> MT
         c = zeros(m) |> MT
         # ADJOINT
+        cons(polar, c, cache)
         ExaPF.adjoint!(polar, pbm, tgt, c, cache)
         function test_fd(vvm)
             cache.vmag .= vvm[1:nbus]

--- a/test/Polar/batch.jl
+++ b/test/Polar/batch.jl
@@ -77,7 +77,6 @@ function test_batch_hessian(polar, device, VT; nbatch=64)
     AutoDiff.adj_hessian_prod!(polar, single_H, projp, cache, λ, tgt)
 
     batch_H = ExaPF.BatchHessian(polar, ExaPF.power_balance, nbatch)
-    ExaPF.update!(polar, batch_H, cache)
 
     MT = isa(device, GPU) ? CuMatrix : Matrix
 
@@ -89,6 +88,7 @@ function test_batch_hessian(polar, device, VT; nbatch=64)
         ∇²gλ.xu  ∇²gλ.uu
     ]
 
+    ExaPF.batch_update!(polar, batch_H, cache)
     ExaPF.batch_adj_hessian_prod!(polar, batch_H, batch_projp, cache, λ, batch_tgt)
 
     if !isa(device, GPU)

--- a/test/Polar/gradient.jl
+++ b/test/Polar/gradient.jl
@@ -6,7 +6,7 @@ function test_reduced_gradient(polar, device, MT)
     jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
     ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
     ∂obj = ExaPF.AdjointStackObjective(polar)
-    pbm = AutoDiff.TapeMemory(ExaPF.active_power_generation, ∂obj, nothing)
+    pbm = AutoDiff.TapeMemory(ExaPF.cost_production, ∂obj, nothing)
 
     # Solve power flow
     conv = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-12))
@@ -23,8 +23,8 @@ function test_reduced_gradient(polar, device, MT)
     Ju = ExaPF.matpower_jacobian(polar, Control(), ExaPF.power_balance, V)
     @test isapprox(∇gₓ, Jx)
     @test isapprox(∇gᵤ, Ju)
-    # Refresh cache with new values of vmag and vang
-    ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
+
+    ExaPF.cost_production(polar, cache)
     ExaPF.gradient_objective!(polar, pbm, cache)
     ∇fₓ = ∂obj.∇fₓ
     ∇fᵤ = ∂obj.∇fᵤ
@@ -47,7 +47,6 @@ function test_reduced_gradient(polar, device, MT)
         # Ensure we remain in the manifold
         ExaPF.transfer!(polar, cache, u_)
         convergence = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-14))
-        ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
         return ExaPF.cost_production(polar, cache)
     end
 

--- a/test/Polar/hessian.jl
+++ b/test/Polar/hessian.jl
@@ -11,10 +11,8 @@ function test_hessian_with_matpower(polar, device, AT; atol=1e-6, rtol=1e-6)
     jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
     ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
     ∂obj = ExaPF.AdjointStackObjective(polar)
-    pbm = AutoDiff.TapeMemory(ExaPF.active_power_generation, ∂obj, nothing)
 
     conv = powerflow(polar, jx, cache, NewtonRaphson())
-    ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
 
     ##################################################
     # Computation of Hessians
@@ -89,12 +87,12 @@ function test_hessian_with_finitediff(polar, device, MT; rtol=1e-6, atol=1e-6)
     jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
     ju = AutoDiff.Jacobian(polar, ExaPF.power_balance, Control())
     ∂obj = ExaPF.AdjointStackObjective(polar)
-    pbm = AutoDiff.TapeMemory(ExaPF.active_power_generation, ∂obj, nothing)
 
     # Initiate state and control for FiniteDiff
     x = [cache.vang[pv] ; cache.vang[pq] ; cache.vmag[pq]]
     u = [cache.vmag[ref]; cache.vmag[pv]; cache.pgen[pv2gen]]
 
+    # CONSTRAINTS
     @testset "Compare with FiniteDiff Hessian ($constraints)" for constraints in [
         ExaPF.power_balance,
         ExaPF.active_power_constraints,
@@ -113,7 +111,6 @@ function test_hessian_with_finitediff(polar, device, MT; rtol=1e-6, atol=1e-6)
             cache.vang[pv] .= x_[1:npv]
             cache.vang[pq] .= x_[npv+1:npv+npq]
             cache.vmag[pq] .= x_[npv+npq+1:end]
-            ExaPF.update!(polar, PS.Generators(), PS.ActivePower(), cache)
             Jx = ExaPF.matpower_jacobian(polar, constraints, State(), cache)
             Ju = ExaPF.matpower_jacobian(polar, constraints, Control(), cache)
             return [Jx Ju]' * μ
@@ -130,5 +127,36 @@ function test_hessian_with_finitediff(polar, device, MT; rtol=1e-6, atol=1e-6)
         projp = Array(dev_projp)
         @test isapprox(projp, H_fd * tgt, rtol=rtol)
     end
+
+    # OBJECTIVE
+    ncons = ExaPF.size_constraint(polar, ExaPF.cost_production)
+    μ = ones(ncons)
+
+    # Initiate on CPU for FiniteDiff
+    polar_cpu = PolarForm(polar.network, CPU())
+    cache_cpu = ExaPF.get(polar_cpu, ExaPF.PhysicalState())
+    x0 = [x; u] |> Array
+    function obj_fd(z)
+        x_ = z[1:nx]
+        u_ = z[1+nx:end]
+        # Transfer control
+        ExaPF.transfer!(polar_cpu, cache_cpu, u_)
+        # Transfer state (manually)
+        cache_cpu.vang[pv] .= x_[1:npv]
+        cache_cpu.vang[pq] .= x_[npv+1:npv+npq]
+        cache_cpu.vmag[pq] .= x_[npv+npq+1:end]
+        return ExaPF.cost_production(polar_cpu, cache_cpu)
+    end
+    H_fd = FiniteDiff.finite_difference_hessian(obj_fd, x0)
+
+    HessianAD = AutoDiff.Hessian(polar, ExaPF.cost_production)
+    tgt = rand(nx + nu)
+    projp = zeros(nx + nu)
+    dev_tgt = MT(tgt)
+    dev_projp = MT(projp)
+    dev_μ = MT(μ)
+    AutoDiff.adj_hessian_prod!(polar, HessianAD, dev_projp, cache, dev_μ, dev_tgt)
+    projp = Array(dev_projp)
+    @test isapprox( projp, H_fd * tgt, rtol=rtol)
 end
 


### PR DESCRIPTION
This PR implements the full batch Hessian operation in `src/Polar`. 

*tl;dr* 
In the optimization algorithm, we need to evaluate the Hessian for the objective, and for the constraints.
- Before that PR, the Hessians for the objective and the constraints were evaluated separately, leading to a lot of duplicate operations. The result was quite inefficient.
- Now, this PR uses a single kernel to evaluate all the Hessians together, using a single GPU kernel.

*Details*
- add a new structure `HessianLagrangian` to evaluate the reduced Hessian in the reduced space
- add three new functions `network_operations`, `cost_penalty_ramping_constraints` and `bus_injection`, with associated kernels
- rename objective function in `src/Polar` (from `active_power_generation` to `cost_production`)
- update `ProxALEvaluators` to use directly `cost_penalty_ramping_constraints` (so now ProxAL's objective is fully computed with AutoDiff)