### PR TITLE
Disallow scalar indexing on GPU - part I

### DIFF
--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -77,6 +77,7 @@ function hessian(nlp::AbstractNLPEvaluator, x)
     return H
 end
 
+mynorm(a) = maximum(abs.(a))
 # Counters
 abstract type AbstractCounter end
 
@@ -102,8 +103,8 @@ function _check(val, val_min, val_max)
     violated_sup = findall(val .> val_max)
     n_inf = length(violated_inf)
     n_sup = length(violated_sup)
-    err_inf = norm(val_min[violated_inf] .- val[violated_inf], Inf)
-    err_sup = norm(val[violated_sup] .- val_max[violated_sup] , Inf)
+    err_inf = mynorm(val_min[violated_inf] .- val[violated_inf])
+    err_sup = mynorm(val[violated_sup] .- val_max[violated_sup])
     return (n_inf, err_inf, n_sup, err_sup)
 end
 
@@ -129,6 +130,8 @@ function MaxScaler(g_min, g_max)
     sc = similar(g_min) ; fill!(sc, 1.0)
     return MaxScaler{eltype(g_min), typeof(g_min)}(1.0, sc, g_min, g_max)
 end
+
+
 function MaxScaler(nlp::AbstractNLPEvaluator, u0::AbstractVector;
                    η=100.0, tol=1e-8)
     n = n_variables(nlp)
@@ -136,20 +139,24 @@ function MaxScaler(nlp::AbstractNLPEvaluator, u0::AbstractVector;
     conv = update!(nlp, u0)
     ∇g = similar(u0) ; fill!(∇g, 0)
     gradient!(nlp, ∇g, u0)
-    s_obj = scale_factor(norm(∇g, Inf), tol, η)
+
+    s_obj = scale_factor(mynorm(∇g), tol, η)
 
     VT = typeof(u0)
     ∇c = xzeros(VT, n)
-    s_cons = xzeros(VT, m)
+    h_s_cons = zeros(m)
     v = xzeros(VT, m)
-    for i in eachindex(s_cons)
-        fill!(v, 0.0)
-        v[i] = 1.0
+    h_v = zeros(m)
+    for i in eachindex(h_s_cons)
+        fill!(h_v, 0.0)
+        h_v[i] = 1.0
+        copyto!(v, h_v)
         jtprod!(nlp, ∇c, u0, v)
-        s_cons[i] = scale_factor(norm(∇c, Inf), tol, η)
+        h_s_cons[i] = scale_factor(mynorm(∇c), tol, η)
     end
 
     g♭, g♯ = bounds(nlp, Constraints())
+    s_cons = h_s_cons |> VT
 
     return MaxScaler{typeof(s_obj), typeof(s_cons)}(s_obj, s_cons, s_cons .* g♭, s_cons .* g♯)
 end

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -77,7 +77,6 @@ function hessian(nlp::AbstractNLPEvaluator, x)
     return H
 end
 
-mynorm(a) = maximum(abs.(a))
 # Counters
 abstract type AbstractCounter end
 
@@ -103,8 +102,8 @@ function _check(val, val_min, val_max)
     violated_sup = findall(val .> val_max)
     n_inf = length(violated_inf)
     n_sup = length(violated_sup)
-    err_inf = mynorm(val_min[violated_inf] .- val[violated_inf])
-    err_sup = mynorm(val[violated_sup] .- val_max[violated_sup])
+    err_inf = xnorm_inf(val_min[violated_inf] .- val[violated_inf])
+    err_sup = xnorm_inf(val[violated_sup] .- val_max[violated_sup])
     return (n_inf, err_inf, n_sup, err_sup)
 end
 
@@ -140,7 +139,7 @@ function MaxScaler(nlp::AbstractNLPEvaluator, u0::AbstractVector;
     ∇g = similar(u0) ; fill!(∇g, 0)
     gradient!(nlp, ∇g, u0)
 
-    s_obj = scale_factor(mynorm(∇g), tol, η)
+    s_obj = scale_factor(xnorm_inf(∇g), tol, η)
 
     VT = typeof(u0)
     ∇c = xzeros(VT, n)
@@ -152,7 +151,7 @@ function MaxScaler(nlp::AbstractNLPEvaluator, u0::AbstractVector;
         h_v[i] = 1.0
         copyto!(v, h_v)
         jtprod!(nlp, ∇c, u0, v)
-        h_s_cons[i] = scale_factor(mynorm(∇c), tol, η)
+        h_s_cons[i] = scale_factor(xnorm_inf(∇c), tol, η)
     end
 
     g♭, g♯ = bounds(nlp, Constraints())

--- a/src/Evaluators/reduced_evaluator.jl
+++ b/src/Evaluators/reduced_evaluator.jl
@@ -91,7 +91,7 @@ end
 
 function ReducedSpaceEvaluator(
     model::PolarForm{T, VI, VT, MT};
-    constraints=Function[voltage_magnitude_constraints, reactive_power_constraints],
+    constraints=Function[voltage_magnitude_constraints, active_power_constraints, reactive_power_constraints],
     linear_solver=direct_linear_solver(model),
     powerflow_solver=NewtonRaphson(tol=1e-12),
     want_jacobian=true,

--- a/src/Polar/Constraints/active_power.jl
+++ b/src/Polar/Constraints/active_power.jl
@@ -5,7 +5,7 @@ function active_power_constraints(polar::PolarForm, cons, buffer)
     ref_to_gen = polar.indexing.index_ref_to_gen
     # Constraint on P_ref (generator) (P_inj = P_g - P_load)
     # NB: Active power generation has been updated previously inside buffer
-    copy!(cons, buffer.pgen[ref_to_gen])
+    copyto!(cons, buffer.pgen[ref_to_gen])
     return
 end
 
@@ -13,26 +13,13 @@ end
 function active_power_constraints(polar::PolarForm, cons, vmag, vang, pnet, qnet, pd, qd)
     kernel! = active_power_kernel!(polar.device)
     ref = polar.indexing.index_ref
-    ref_to_gen = polar.indexing.index_ref_to_gen
     ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
-
-    for i_ in 1:length(ref)
-        bus = ref[i_]
-        i_gen = ref_to_gen[i_]
-        inj = 0.0
-        @inbounds for c in ybus_re.colptr[bus]:ybus_re.colptr[bus+1]-1
-            to = ybus_re.rowval[c]
-            aij = vang[bus] - vang[to]
-            # f_re = a * cos + b * sin
-            # f_im = a * sin - b * cos
-            coef_cos = vmag[bus]*vmag[to]*ybus_re.nzval[c]
-            coef_sin = vmag[bus]*vmag[to]*ybus_im.nzval[c]
-            cos_val = cos(aij)
-            sin_val = sin(aij)
-            inj += coef_cos * cos_val + coef_sin * sin_val
-        end
-        cons[i_] = inj + pd[bus]
-    end
+    ndrange = length(ref)
+    ev = active_power_slack!(polar.device)(cons, vmag, vang, ref, pd,
+        ybus_re.nzval, ybus_re.colptr, ybus_re.rowval, ybus_im.nzval,
+        ndrange=ndrange,
+    )
+    wait(ev)
 end
 
 function size_constraint(polar::PolarForm{T, IT, VT, MT}, ::typeof(active_power_constraints)) where {T, IT, VT, MT}
@@ -42,29 +29,10 @@ end
 function bounds(polar::PolarForm{T, IT, VT, MT}, ::typeof(active_power_constraints)) where {T, IT, VT, MT}
     # Get all bounds (lengths of p_min, p_max, q_min, q_max equal to ngen)
     p_min, p_max = PS.bounds(polar.network, PS.Generators(), PS.ActivePower())
-    ref_to_gen = polar.indexing.index_ref_to_gen
+    ref_to_gen = polar.indexing.index_ref_to_gen |> Array
     pq_min = p_min[ref_to_gen]
     pq_max = p_max[ref_to_gen]
     return convert(VT, pq_min), convert(VT, pq_max)
-end
-
-function _put_active_power_injection!(fr, v_m, v_a, adj_v_m, adj_v_a, adj_P, ybus_re, ybus_im)
-    @inbounds for c in ybus_re.colptr[fr]:ybus_re.colptr[fr+1]-1
-        to = ybus_re.rowval[c]
-        aij = v_a[fr] - v_a[to]
-        cosθ = cos(aij)
-        sinθ = sin(aij)
-        cθ = ybus_re.nzval[c]*cosθ
-        sθ = ybus_im.nzval[c]*sinθ
-        adj_v_m[fr] += v_m[to] * (cθ + sθ) * adj_P
-        adj_v_m[to] += v_m[fr] * (cθ + sθ) * adj_P
-
-        adj_aij = -(v_m[fr]*v_m[to]*(ybus_re.nzval[c]*sinθ))
-        adj_aij += v_m[fr]*v_m[to]*(ybus_im.nzval[c]*cosθ)
-        adj_aij *= adj_P
-        adj_v_a[to] += -adj_aij
-        adj_v_a[fr] += adj_aij
-    end
 end
 
 # Adjoint
@@ -79,16 +47,15 @@ function adjoint!(
 ) where {F<:typeof(active_power_constraints), S, I}
     nbus = PS.get(polar.network, PS.NumberOfBuses())
     nref = PS.get(polar.network, PS.NumberOfSlackBuses())
-    index_ref = polar.indexing.index_ref
-    ref_to_gen = polar.indexing.index_ref_to_gen
+    ref = polar.indexing.index_ref
 
     ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
-    # Constraint on P_ref (generator) (P_inj = P_g - P_load)
-    for i in 1:nref
-        ibus = index_ref[i]
-        igen = ref_to_gen[i]
-        _put_active_power_injection!(ibus, vm, va, ∂vm, ∂va, ∂pg[i], ybus_re, ybus_im)
-    end
+    ndrange = nref
+    ev = adj_active_power_slack!(polar.device)(vm, va, ∂vm, ∂va, ∂pg, ref,
+        ybus_re.nzval, ybus_re.colptr, ybus_re.rowval, ybus_im.nzval,
+        ndrange=ndrange,
+    )
+    wait(ev)
     return
 end
 
@@ -117,15 +84,15 @@ function matpower_jacobian(polar::PolarForm, X::Union{State,Control}, ::typeof(a
 end
 
 function matpower_hessian(polar::PolarForm, ::typeof(active_power_constraints), buffer, λ)
-    pv = polar.indexing.index_pv
-    pq = polar.indexing.index_pq
-    ref = polar.indexing.index_ref
+    pv = polar.network.pv
+    pq = polar.network.pq
+    ref = polar.network.ref
     # Check consistency: currently only support a single slack node
     @assert length(λ) == 1
     V = buffer.vmag .* exp.(im .* buffer.vang) |> Array
     hxx, hxu, huu = PS.active_power_hessian(V, polar.network.Ybus, pv, pq, ref)
 
-    λₚ = λ[1]
+    λₚ = sum(λ)  # TODO
     return FullSpaceHessian(
         λₚ .* hxx,
         λₚ .* hxu,

--- a/src/Polar/Constraints/constraints.jl
+++ b/src/Polar/Constraints/constraints.jl
@@ -94,7 +94,7 @@ function jacobian_sparsity(polar::PolarForm, func::Function, xx::AbstractVariabl
 end
 
 function matpower_jacobian(polar::PolarForm, func::Function, X::AbstractVariable, buffer::PolarNetworkState)
-    V = buffer.vmag .* exp.(im .* buffer.vang) |> Array
+    V = voltage_host(buffer)
     return matpower_jacobian(polar, X, func, V)
 end
 

--- a/src/Polar/Constraints/constraints.jl
+++ b/src/Polar/Constraints/constraints.jl
@@ -94,7 +94,7 @@ function jacobian_sparsity(polar::PolarForm, func::Function, xx::AbstractVariabl
 end
 
 function matpower_jacobian(polar::PolarForm, func::Function, X::AbstractVariable, buffer::PolarNetworkState)
-    V = buffer.vmag .* exp.(im .* buffer.vang)
+    V = buffer.vmag .* exp.(im .* buffer.vang) |> Array
     return matpower_jacobian(polar, X, func, V)
 end
 

--- a/src/Polar/Constraints/line_flow.jl
+++ b/src/Polar/Constraints/line_flow.jl
@@ -91,9 +91,10 @@ function matpower_jacobian(polar::PolarForm, X::Union{State,Control}, ::typeof(f
     nbus = get(polar, PS.NumberOfBuses())
     nlines = get(polar, PS.NumberOfLines())
     pf = polar.network
-    ref = pf.ref ; nref = length(ref)
-    pv  = pf.pv  ; npv  = length(pv)
-    pq  = pf.pq  ; npq  = length(pq)
+    ref, pv, pq = index_buses_host(polar)
+    nref = length(ref)
+    npv  = length(pv)
+    npq  = length(pq)
     lines = pf.lines
 
     dSl_dVm, dSl_dVa = PS.matpower_lineflow_power_jacobian(V, lines)

--- a/src/Polar/Constraints/power_balance.jl
+++ b/src/Polar/Constraints/power_balance.jl
@@ -20,9 +20,7 @@ end
 
 function power_balance(polar::PolarForm, cons, vmag, vang, pnet, qnet, pload, qload)
     nbus = get(polar, PS.NumberOfBuses())
-    ref = polar.indexing.index_ref
-    pv = polar.indexing.index_pv
-    pq = polar.indexing.index_pq
+    ref, pv, pq = index_buses_device(polar)
     ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
 
     fill!(cons, 0.0)
@@ -64,9 +62,7 @@ function adjoint!(
     pload, qload,
 ) where {F<:typeof(power_balance), S, I}
     nbus = get(polar, PS.NumberOfBuses())
-    ref = polar.indexing.index_ref
-    pv = polar.indexing.index_pv
-    pq = polar.indexing.index_pq
+    ref, pv, pq = index_buses_device(polar)
     ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
 
     fill!(pbm.intermediate.∂edge_vm_fr , 0.0)
@@ -92,9 +88,10 @@ end
 function matpower_jacobian(polar::PolarForm, X::Union{State, Control}, ::typeof(power_balance), V)
     nbus = get(polar, PS.NumberOfBuses())
     pf = polar.network
-    ref = pf.ref ; nref = length(ref)
-    pv = pf.pv ; npv = length(pv)
-    pq = pf.pq ; npq = length(pq)
+    ref, pv, pq = index_buses_host(polar)
+    nref = length(ref)
+    npv = length(pv)
+    npq = length(pq)
     Ybus = pf.Ybus
 
     dSbus_dVm, dSbus_dVa = PS.matpower_residual_jacobian(V, Ybus)
@@ -121,11 +118,9 @@ function matpower_hessian(
     buffer::PolarNetworkState,
     λ::AbstractVector,
 )
-    ref = polar.network.ref
-    pv = polar.network.pv
-    pq = polar.network.pq
+    ref, pv, pq = index_buses_host(polar)
     λ_host = λ |> Array
-    V = buffer.vmag .* exp.(im .* buffer.vang) |> Array
+    V = voltage_host(buffer)
     hxx, hxu, huu = PS.residual_hessian(V, polar.network.Ybus, λ_host, pv, pq, ref)
     return FullSpaceHessian(hxx, hxu, huu)
 end

--- a/src/Polar/Constraints/power_balance.jl
+++ b/src/Polar/Constraints/power_balance.jl
@@ -121,9 +121,9 @@ function matpower_hessian(
     buffer::PolarNetworkState,
     λ::AbstractVector,
 )
-    ref = polar.indexing.index_ref
-    pv = polar.indexing.index_pv
-    pq = polar.indexing.index_pq
+    ref = polar.network.ref
+    pv = polar.network.pv
+    pq = polar.network.pq
     λ_host = λ |> Array
     V = buffer.vmag .* exp.(im .* buffer.vang) |> Array
     hxx, hxu, huu = PS.residual_hessian(V, polar.network.Ybus, λ_host, pv, pq, ref)

--- a/src/Polar/Constraints/reactive_power.jl
+++ b/src/Polar/Constraints/reactive_power.jl
@@ -26,7 +26,7 @@ function reactive_power_constraints(polar::PolarForm, cons, buffer)
     # Refresh reactive power generation in buffer
     update!(polar, PS.Generators(), PS.ReactivePower(), buffer)
     # Constraint on Q_ref (generator) (Q_inj = Q_g - Q_load)
-    copy!(cons, buffer.qgen)
+    copyto!(cons, buffer.qgen)
     return
 end
 
@@ -99,7 +99,7 @@ function matpower_jacobian(polar::PolarForm, X::Union{State,Control}, ::typeof(r
     ref = pf.ref
     pv = pf.pv
     pq = pf.pq
-    gen2bus = polar.indexing.index_generators
+    gen2bus = polar.indexing.index_generators |> Array
     Ybus = pf.Ybus
 
     dSbus_dVm, dSbus_dVa = PS.matpower_residual_jacobian(V, Ybus)
@@ -117,10 +117,10 @@ end
 
 function matpower_hessian(polar::PolarForm, ::typeof(reactive_power_constraints), buffer, λ)
     nbus = get(polar, PS.NumberOfBuses())
-    ref = polar.indexing.index_ref
-    pv = polar.indexing.index_pv
-    pq = polar.indexing.index_pq
-    gen2bus = polar.indexing.index_generators
+    ref = polar.network.ref
+    pv = polar.network.pv
+    pq = polar.network.pq
+    gen2bus = polar.indexing.index_generators |> Array
     # Check consistency
     @assert length(λ) == length(gen2bus)
 

--- a/src/Polar/Constraints/voltage_magnitude.jl
+++ b/src/Polar/Constraints/voltage_magnitude.jl
@@ -4,13 +4,13 @@ is_linear(polar::PolarForm, ::typeof(voltage_magnitude_constraints)) = true
 
 # We add constraint only on vmag_pq
 function voltage_magnitude_constraints(polar::PolarForm, cons, vmag, vang, pnet, qnet, pload, qload)
-    index_pq = polar.indexing.index_pq
-    cons .= @view vmag[index_pq]
+    _, _, pq = index_buses_device(polar)
+    cons .= @view vmag[pq]
     return
 end
 function voltage_magnitude_constraints(polar::PolarForm, cons, buffer)
-    index_pq = polar.indexing.index_pq
-    cons .= @view buffer.vmag[index_pq]
+    _, _, pq = index_buses_device(polar)
+    cons .= @view buffer.vmag[pq]
     return
 end
 
@@ -35,8 +35,8 @@ function adjoint!(
     pnet, ∂pnet,
     pload, qload,
 ) where {F<:typeof(voltage_magnitude_constraints), S, I}
-    index_pq = polar.indexing.index_pq
-    ∂vmag[index_pq] .= ∂cons
+    _, _, pq = index_buses_device(polar)
+    ∂vmag[pq] .= ∂cons
 end
 
 function matpower_jacobian(

--- a/src/Polar/batch.jl
+++ b/src/Polar/batch.jl
@@ -77,8 +77,7 @@ function batch_buffer(polar::PolarForm{T, VI, VT, MT}, nbatch::Int) where {T, VI
     nbus = PS.get(polar.network, PS.NumberOfBuses())
     ngen = PS.get(polar.network, PS.NumberOfGenerators())
     nstates = get(polar, NumberOfState())
-    gen2bus = polar.indexing.index_generators
-    h_gen2bus = polar.indexing.index_generators |> Array
+    gen2bus, _, _ = index_generators_device(polar)
     buffer =  PolarNetworkState{VI,MT}(
         MT(undef, nbus, nbatch),
         MT(undef, nbus, nbatch),
@@ -102,6 +101,7 @@ function batch_buffer(polar::PolarForm{T, VI, VT, MT}, nbatch::Int) where {T, VI
     qd = get(polar.network, PS.ReactiveLoad())
     pg = get(polar.network, PS.ActivePower())
     qg = get(polar.network, PS.ReactivePower())
+    h_gen2bus, _, _ = index_generators_host(polar)
     pbus[h_gen2bus] .= pg
     qbus[h_gen2bus] .= qg
 

--- a/src/Polar/batch.jl
+++ b/src/Polar/batch.jl
@@ -78,6 +78,7 @@ function batch_buffer(polar::PolarForm{T, VI, VT, MT}, nbatch::Int) where {T, VI
     ngen = PS.get(polar.network, PS.NumberOfGenerators())
     nstates = get(polar, NumberOfState())
     gen2bus = polar.indexing.index_generators
+    h_gen2bus = polar.indexing.index_generators |> Array
     buffer =  PolarNetworkState{VI,MT}(
         MT(undef, nbus, nbatch),
         MT(undef, nbus, nbatch),
@@ -101,8 +102,8 @@ function batch_buffer(polar::PolarForm{T, VI, VT, MT}, nbatch::Int) where {T, VI
     qd = get(polar.network, PS.ReactiveLoad())
     pg = get(polar.network, PS.ActivePower())
     qg = get(polar.network, PS.ReactivePower())
-    pbus[gen2bus] .= pg
-    qbus[gen2bus] .= qg
+    pbus[h_gen2bus] .= pg
+    qbus[h_gen2bus] .= qg
 
     for i in 1:nbatch
         copyto!(buffer.vmag, nbus * (i-1) + 1, vmag, 1, nbus)

--- a/src/Polar/caches.jl
+++ b/src/Polar/caches.jl
@@ -10,6 +10,8 @@ struct IndexingCache{IVT} <: AbstractBuffer
     index_pv_to_gen::IVT
     index_ref_to_gen::IVT
 end
+index_buses(idx::IndexingCache) = (idx.index_ref, idx.index_pv, idx.index_pq)
+index_generators(idx::IndexingCache) = (idx.index_generators, idx.index_ref_to_gen, idx.index_pv_to_gen)
 
 """
     PolarNetworkState{VI, VT} <: AbstractNetworkBuffer
@@ -92,6 +94,9 @@ function Base.iszero(buf::PolarNetworkState)
         iszero(buf.balance) &&
         iszero(buf.dx)
 end
+
+voltage(buf::PolarNetworkState) = buf.vmag .* exp.(im .* buf.vang)
+voltage_host(buf::PolarNetworkState) = voltage(buf) |> Array
 
 "Store topology of the network on target device."
 struct NetworkTopology{VTI, VTD}

--- a/src/Polar/polar.jl
+++ b/src/Polar/polar.jl
@@ -72,22 +72,8 @@ function PolarForm(pf::PS.PowerNetwork, device::KA.Device)
     idx_pv = PS.get(pf, PS.PVIndexes())
     idx_pq = PS.get(pf, PS.PQIndexes())
     # Build-up reverse index for performance
-    pv_to_gen = similar(idx_pv)
-    ref_to_gen = similar(idx_ref)
-    ## We assume here that the indexing of generators is the same
-    ## as in MATPOWER
-    for i in 1:ngens
-        bus = idx_gen[i]
-        i_pv = findfirst(isequal(bus), idx_pv)
-        if !isnothing(i_pv)
-            pv_to_gen[i_pv] = i
-        else
-            i_ref = findfirst(isequal(bus), idx_ref)
-            if !isnothing(i_ref)
-                ref_to_gen[i_ref] = i
-            end
-        end
-    end
+    pv_to_gen = PS.get(pf, PS.PVToGeneratorsIndex())
+    ref_to_gen = PS.get(pf, PS.SlackToGeneratorsIndex())
 
     gidx_gen = convert(IT, idx_gen)
     gidx_ref = convert(IT, idx_ref)
@@ -161,9 +147,13 @@ function get(polar::PolarForm, ::NumberOfControl)
     return nref + 2*npv
 end
 
-function get(polar::PolarForm, attr::PS.AbstractNetworkAttribute)
-    return get(polar.network, attr)
-end
+get(polar::PolarForm, attr::PS.AbstractNetworkAttribute) = get(polar.network, attr)
+
+index_buses_host(polar) = PS.get(polar.network, PS.AllBusesIndex())
+index_buses_device(polar) = index_buses(polar.indexing)
+
+index_generators_host(polar) = PS.get(polar.network, PS.AllGeneratorsIndex())
+index_generators_device(polar) = index_generators(polar.indexing)
 
 ## Bounds
 function bounds(polar::PolarForm{T, IT, VT, MT}, ::State) where {T, IT, VT, MT}
@@ -176,17 +166,18 @@ end
 
 # Initial position
 function initial(polar::PolarForm{T, IT, VT, MT}, X::Union{State,Control}) where {T, IT, VT, MT}
+    ref, pv, pq = index_buses_host(polar)
+    _, _, pv2gen = index_generators_host(polar)
     # Load data from PowerNetwork
     vmag = abs.(polar.network.vbus)
     vang = angle.(polar.network.vbus)
     pg = get(polar.network, PS.ActivePower())
-    pv2gen = polar.indexing.index_pv_to_gen |> Array
 
     if isa(X, State)
         # build vector x
-        return [vang[polar.network.pv] ; vang[polar.network.pq] ; vmag[polar.network.pq]] |> VT
+        return [vang[pv] ; vang[pq] ; vmag[pq]] |> VT
     elseif isa(X, Control)
-        return [vmag[polar.network.ref] ; vmag[polar.network.pv] ; pg[pv2gen]] |> VT
+        return [vmag[ref] ; vmag[pv] ; pg[pv2gen]] |> VT
     end
 end
 
@@ -207,14 +198,15 @@ function get!(
     npv = get(polar, PS.NumberOfPVBuses())
     npq = get(polar, PS.NumberOfPQBuses())
     nref = get(polar, PS.NumberOfSlackBuses())
+    ref, pv, pq = index_buses_host(polar)
     # Copy values of vang and vmag into x
     # NB: this leads to 3 memory allocation on the GPU
     #     we use indexing on the CPU, as for some reason
     #     we get better performance than with the indexing on the GPU
     #     stored in the buffer polar.indexing.
-    x[1:npv] .= @view buffer.vang[polar.network.pv]
-    x[npv+1:npv+npq] .= @view buffer.vang[polar.network.pq]
-    x[npv+npq+1:npv+2*npq] .= @view buffer.vmag[polar.network.pq]
+    x[1:npv] .= @view buffer.vang[pv]
+    x[npv+1:npv+npq] .= @view buffer.vang[pq]
+    x[npv+npq+1:npv+2*npq] .= @view buffer.vmag[pq]
 end
 
 function get!(
@@ -226,11 +218,13 @@ function get!(
     npv = get(polar, PS.NumberOfPVBuses())
     npq = get(polar, PS.NumberOfPQBuses())
     nref = get(polar, PS.NumberOfSlackBuses())
+    ref, pv, pq = index_buses_host(polar)
+    _, _, pv2gen = index_generators_host(polar)
     # build vector u
     nᵤ = get(polar, NumberOfControl())
-    u[1:nref] .= @view buffer.vmag[polar.network.ref]
-    u[nref + 1:nref + npv] .= @view buffer.vmag[polar.network.pv]
-    u[nref + npv + 1:nref + 2*npv] .= @view buffer.pgen[polar.indexing.index_pv_to_gen]
+    u[1:nref] .= @view buffer.vmag[ref]
+    u[nref + 1:nref + npv] .= @view buffer.vmag[pv]
+    u[nref + npv + 1:nref + 2*npv] .= @view buffer.pgen[pv2gen]
     return u
 end
 

--- a/src/Polar/polar.jl
+++ b/src/Polar/polar.jl
@@ -177,29 +177,16 @@ end
 # Initial position
 function initial(polar::PolarForm{T, IT, VT, MT}, X::Union{State,Control}) where {T, IT, VT, MT}
     # Load data from PowerNetwork
-    vmag = abs.(polar.network.vbus) |> VT
-    vang = angle.(polar.network.vbus) |> VT
+    vmag = abs.(polar.network.vbus)
+    vang = angle.(polar.network.vbus)
     pg = get(polar.network, PS.ActivePower())
-
-    npv = get(polar, PS.NumberOfPVBuses())
-    npq = get(polar, PS.NumberOfPQBuses())
-    nref = get(polar, PS.NumberOfSlackBuses())
+    pv2gen = polar.indexing.index_pv_to_gen |> Array
 
     if isa(X, State)
         # build vector x
-        dimension = get(polar, NumberOfState())
-        x = xzeros(VT, dimension)
-        x[1:npv] = vang[polar.network.pv]
-        x[npv+1:npv+npq] = vang[polar.network.pq]
-        x[npv+npq+1:end] = vmag[polar.network.pq]
-        return x
+        return [vang[polar.network.pv] ; vang[polar.network.pq] ; vmag[polar.network.pq]] |> VT
     elseif isa(X, Control)
-        dimension = get(polar, NumberOfControl())
-        u = xzeros(VT, dimension)
-        u[1:nref] = vmag[polar.network.ref]
-        u[nref + 1:nref + npv] = vmag[polar.network.pv]
-        u[nref + npv + 1:nref + 2*npv] = pg[polar.indexing.index_pv_to_gen]
-        return u
+        return [vmag[polar.network.ref] ; vmag[polar.network.pv] ; pg[pv2gen]] |> VT
     end
 end
 

--- a/src/Polar/powerflow.jl
+++ b/src/Polar/powerflow.jl
@@ -28,9 +28,7 @@ function powerflow(
     nvbus = length(polar.network.vbus)
     ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
 
-    ref = polar.indexing.index_ref
-    pv = polar.indexing.index_pv
-    pq = polar.indexing.index_pq
+    ref, pv, pq = index_buses_device(polar)
 
     # iteration variables
     iter = 0
@@ -150,9 +148,7 @@ function batch_powerflow(
     nvbus = length(polar.network.vbus)
     ybus_re, ybus_im = get(polar.topology, PS.BusAdmittanceMatrix())
 
-    ref = polar.indexing.index_ref
-    pv = polar.indexing.index_pv
-    pq = polar.indexing.index_pq
+    ref, pv, pq = index_buses_device(polar)
 
     # iteration variables
     iter = 0

--- a/src/PowerSystem/PowerSystem.jl
+++ b/src/PowerSystem/PowerSystem.jl
@@ -125,6 +125,13 @@ struct BusAdmittanceMatrix <: AbstractNetworkAttribute end
 abstract type AbstractIndexing <: AbstractNetworkAttribute end
 
 """
+    AllBusesIndex <: AbstractIndexing
+
+Indexes of all the buses in a `AbstractPowerSystem`.
+"""
+struct AllBusesIndex <: AbstractIndexing end
+
+"""
     PVIndexes <: AbstractIndexing
 
 Indexes of the PV buses in a `AbstractPowerSystem`.
@@ -151,6 +158,10 @@ struct SlackIndexes <: AbstractIndexing end
 Indexes of the generators in a `AbstractPowerSystem`.
 """
 struct GeneratorIndexes <: AbstractIndexing end
+
+struct PVToGeneratorsIndex <: AbstractIndexing end
+struct SlackToGeneratorsIndex <: AbstractIndexing end
+struct AllGeneratorsIndex <: AbstractIndexing end
 
 """
     AbstractNetworkValues

--- a/src/PowerSystem/topology.jl
+++ b/src/PowerSystem/topology.jl
@@ -132,6 +132,36 @@ function bustypeindex(bus, gen, bus_to_indexes)
     return ref, pv, pq, bustype, inactive_generators
 end
 
+function generators_to_buses(gens, bus_to_indexes)
+    GEN_BUS = IndexSet.idx_gen()[1]
+    ngens = size(gens, 1)
+    # Create array on host memory
+    indexing = zeros(Int, ngens)
+    # Here, we keep the same ordering as specified in Matpower.
+    for i in 1:ngens
+        indexing[i] = bus_to_indexes[gens[i, GEN_BUS]]
+    end
+    return indexing
+end
+
+function buses_to_generators(gen2bus, pv, ref)
+    pv2gen = zeros(Int, length(pv))
+    ref2gen = zeros(Int, length(ref))
+    for i in eachindex(gen2bus)
+        bus = gen2bus[i]
+        i_pv = findfirst(isequal(bus), pv)
+        if !isnothing(i_pv)
+            pv2gen[i_pv] = i
+        else
+            i_ref = findfirst(isequal(bus), ref)
+            if !isnothing(i_ref)
+                ref2gen[i_ref] = i
+            end
+        end
+    end
+    return (pv2gen, ref2gen)
+end
+
 """
     assembleSbus(gen, load, SBASE, nbus)
 

--- a/src/architectures.jl
+++ b/src/architectures.jl
@@ -12,3 +12,4 @@ xnorm(x::CUDA.CuVector) = CUBLAS.nrm2(x)
 xzeros(S, n) = fill!(S(undef, n), zero(eltype(S)))
 xones(S, n) = fill!(S(undef, n), one(eltype(S)))
 
+xnorm_inf(a) = maximum(abs.(a))

--- a/test/Evaluators/auglag.jl
+++ b/test/Evaluators/auglag.jl
@@ -60,7 +60,7 @@ function test_auglag_evaluator(nlp, device, MT)
             hess_fd = FiniteDiff.finite_difference_hessian(reduced_cost, u)
 
             h_H = H |> Array
-            h_H_fd = hess_fd.data
+            h_H_fd = hess_fd.data |> Array
 
             @test isapprox(h_H, h_H_fd, rtol=1e-5)
         end

--- a/test/Evaluators/auglag.jl
+++ b/test/Evaluators/auglag.jl
@@ -34,7 +34,7 @@ function test_auglag_evaluator(nlp, device, MT)
             ExaPF.update!(pen, u_)
             return ExaPF.objective(pen, u_)
         end
-        grad_fd = FiniteDiff.finite_difference_jacobian(reduced_cost, u)
+        grad_fd = FiniteDiff.finite_difference_gradient(reduced_cost, u)
         h_grad_fd = grad_fd[:] |> Array
         h_g = g |> Array
         @test isapprox(h_grad_fd, h_g, rtol=1e-5)

--- a/test/Polar/TestPolarForm.jl
+++ b/test/Polar/TestPolarForm.jl
@@ -31,7 +31,7 @@ end
 function myisapprox(a, b; options...)
     h_a = a |> Array
     h_b = b |> Array
-    return isapprox(a, b; options...)
+    return isapprox(h_a, h_b; options...)
 end
 
 function runtests(datafile, device, AT)

--- a/test/Polar/TestPolarForm.jl
+++ b/test/Polar/TestPolarForm.jl
@@ -22,6 +22,18 @@ include("gradient.jl")
 include("hessian.jl")
 include("batch.jl")
 
+function myisless(a, b)
+    h_a = a |> Array
+    h_b = b |> Array
+    return h_a <= h_b
+end
+
+function myisapprox(a, b; options...)
+    h_a = a |> Array
+    h_b = b |> Array
+    return isapprox(a, b; options...)
+end
+
 function runtests(datafile, device, AT)
     pf = PS.PowerNetwork(datafile)
     polar = PolarForm(pf, device)

--- a/test/Polar/api.jl
+++ b/test/Polar/api.jl
@@ -66,15 +66,18 @@ function test_polar_api(polar, device, M)
     u_min, u_max = ExaPF.bounds(polar, Control())
     x_min, x_max = ExaPF.bounds(polar, State())
 
-    @test isless(u_min, u_max)
-    @test isless(x_min, x_max)
+    h_u_min, h_u_max = u_min |> Array, u_max |> Array
+    h_x_min, h_x_max = x_min |> Array, x_max |> Array
+    @test isless(h_u_min, h_u_max)
+    @test isless(h_x_min, h_x_max)
 
     # Test callbacks
     ## Power Balance
     cons = cache.balance
     ExaPF.power_balance(polar, cons, cache)
     # As we run powerflow before, the balance should be below tolerance
-    @test norm(cons, Inf) < tolerance
+    h_cons = cons |> Array
+    @test norm(h_cons, Inf) < tolerance
 
     ## Cost Production
     c2 = ExaPF.cost_production(polar, cache)
@@ -104,7 +107,7 @@ function test_polar_constraints(polar, device, M)
         @test length(g_max) == m
         @test isa(g_min, M)
         @test isa(g_max, M)
-        @test g_min <= g_max
+        @test Array(g_min) <= Array(g_max)
     end
     return nothing
 end

--- a/test/Polar/api.jl
+++ b/test/Polar/api.jl
@@ -76,8 +76,7 @@ function test_polar_api(polar, device, M)
     cons = cache.balance
     ExaPF.power_balance(polar, cons, cache)
     # As we run powerflow before, the balance should be below tolerance
-    h_cons = cons |> Array
-    @test norm(h_cons, Inf) < tolerance
+    @test ExaPF.xnorm_inf(cons) < tolerance
 
     ## Cost Production
     c2 = ExaPF.cost_production(polar, cache)
@@ -107,7 +106,7 @@ function test_polar_constraints(polar, device, M)
         @test length(g_max) == m
         @test isa(g_min, M)
         @test isa(g_max, M)
-        @test Array(g_min) <= Array(g_max)
+        @test myisless(g_min, g_max)
     end
     return nothing
 end

--- a/test/Polar/autodiff.jl
+++ b/test/Polar/autodiff.jl
@@ -15,7 +15,7 @@ function test_constraints_jacobian(polar, device, MT)
     # Solve power flow
     conv = powerflow(polar, jx, cache, NewtonRaphson(tol=1e-12))
     # Get solution in complex form.
-    V = cache.vmag .* exp.(im .* cache.vang) |> Array
+    V = ExaPF.voltage_host(cache)
 
     # Test Jacobian w.r.t. State
     @testset "Constraint $(cons)" for cons in [
@@ -128,12 +128,10 @@ function test_constraints_adjoint(polar, device, MT)
         end
         vv = [cache.vmag; cache.vang]
         vv_fd = FiniteDiff.finite_difference_jacobian(test_fd, vv)
-        # Transfer data back to the CPU
-        h_vm = pbm.stack.∂vm |> Array
-        h_va = pbm.stack.∂va |> Array
-        h_vv_fd = vv_fd |> Array
-        @test isapprox(h_vv_fd[1:nbus], h_vm, rtol=1e-6)
-        @test isapprox(h_vv_fd[1+nbus:2*nbus], h_va, rtol=1e-6)
+        # Loosen the tolerance to 1e-5 there (finite_difference_jacobian
+        # is less accurate than finite_difference_gradient)
+        @test myisapprox(vv_fd[1:nbus], pbm.stack.∂vm, rtol=1e-5)
+        @test myisapprox(vv_fd[1+nbus:2*nbus], pbm.stack.∂va, rtol=1e-5)
     end
 end
 

--- a/test/Polar/gradient.jl
+++ b/test/Polar/gradient.jl
@@ -18,7 +18,7 @@ function test_reduced_gradient(polar, device, MT)
     @test isequal(∇gₓ, ∇gᵥ)
 
     # Test with Matpower's Jacobian
-    V = cache.vmag .* exp.(im * cache.vang) |> Array
+    V = ExaPF.voltage_host(cache)
     Jx = ExaPF.matpower_jacobian(polar, State(), ExaPF.power_balance, V)
     Ju = ExaPF.matpower_jacobian(polar, Control(), ExaPF.power_balance, V)
     h∇gₓ = ∇gₓ |> SparseMatrixCSC |> Array
@@ -52,8 +52,7 @@ function test_reduced_gradient(polar, device, MT)
     end
 
     grad_fd = FiniteDiff.finite_difference_jacobian(reduced_cost, u)
-    grad_fd = grad_fd[:] |> Array # Transfer gradient to host
-    @test isapprox(grad_fd, grad_adjoint, rtol=1e-4)
+    @test isapprox(grad_fd[:], grad_adjoint, rtol=1e-4)
 end
 
 function test_line_flow_gradient(polar, device, MT)
@@ -97,8 +96,6 @@ function test_line_flow_gradient(polar, device, MT)
     ExaPF.flow_constraints_grad!(polar, gradg, cache, weights)
     # @test isapprox(adgradg, fdgradg)
     # TODO: The gradient is slightly off with the handwritten adjoint
-    h_gradg = gradg |> Array
-    h_fdgradg = fdgradg[:] |> Array
-    @test_broken isapprox(gradg, fdgradg)
+    @test_broken isapprox(gradg, fdgradg[:])
 end
 

--- a/test/Polar/hessian.jl
+++ b/test/Polar/hessian.jl
@@ -25,9 +25,10 @@ function test_hessian_with_matpower(polar, device, AT; atol=1e-6, rtol=1e-6)
         ExaPF.reactive_power_constraints,
     ]
         ncons = ExaPF.size_constraint(polar, constraints)
-        λ = rand(ncons) |> AT
+        hλ = rand(ncons)
+        λ = hλ |> AT
         # Evaluate Hessian-vector product (full ∇²g is a 3rd dimension tensor)
-        ∇²gλ = ExaPF.matpower_hessian(polar, constraints, cache, λ)
+        ∇²gλ = ExaPF.matpower_hessian(polar, constraints, cache, hλ)
         nx = size(∇²gλ.xx, 1)
         nu = size(∇²gλ.uu, 1)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,6 @@ using SparseArrays
 
 using CUDA
 using CUDA.CUSPARSE
-using CUDAKernels
 using KernelAbstractions
 
 using FiniteDiff
@@ -26,7 +25,6 @@ has_cuda_gpu() && push!(ARCHS, (CUDADevice(), CuArray, CuSparseMatrixCSR))
 @isdefined(TestPolarFormulation) || include("Polar/TestPolarForm.jl")
 @isdefined(TestEvaluators)       || include("Evaluators/TestEvaluators.jl")
 
-error()
 init_time = time()
 @testset "Test ExaPF" begin
     @testset "ExaPF.PowerSystem" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using SparseArrays
 using CUDA
 using CUDA.CUSPARSE
 using KernelAbstractions
+using CUDAKernels
 
 using FiniteDiff
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ has_cuda_gpu() && push!(ARCHS, (CUDADevice(), CuArray, CuSparseMatrixCSR))
 @isdefined(TestPolarFormulation) || include("Polar/TestPolarForm.jl")
 @isdefined(TestEvaluators)       || include("Evaluators/TestEvaluators.jl")
 
+error()
 init_time = time()
 @testset "Test ExaPF" begin
     @testset "ExaPF.PowerSystem" begin


### PR DESCRIPTION
With this PR, all the operations in `src/Polar/` do not use scalar indexing anymore. Now, the following code works: 
```julia
julia> CUDA.allowscalar(false)

julia> TestPolarFormulation.runtests("data/case9.m", CUDADevice(), CuArray)
Test Summary: | Pass  Total
PolarForm API |   50     50
Test Summary:      | Pass  Total
PolarForm AutoDiff |   46     46
Test Summary:      | Pass  Broken  Total
PolarForm Gradient |    5       1      6
Test Summary:      | Pass  Total
PolarForm Hessians |   13     13
Test Summary:    |
Batch algorithms | No tests
Test.DefaultTestSet("Batch algorithms", Any[], 0, false, false)
```

Before fixing the `Evaluators` code, I prefer to wait till #179 is merged, as this is a thorough refactoring of the Hessian code.


Ref #80 