### PR TITLE
Disallow scalar indexing on GPU - part II

### DIFF
--- a/src/Evaluators/auglag.jl
+++ b/src/Evaluators/auglag.jl
@@ -96,6 +96,7 @@ function AugLagEvaluator(
 end
 
 has_hessian(nlp::AugLagEvaluator) = has_hessian(nlp.inner)
+backend(nlp::AugLagEvaluator) = backend(nlp.inner)
 
 # Default fallback
 function _update_internal!(ag::AugLagEvaluator, ::CONSTRAINTS_TYPE)

--- a/src/Evaluators/bridge_evaluator.jl
+++ b/src/Evaluators/bridge_evaluator.jl
@@ -33,11 +33,15 @@ struct BridgeDeviceEvaluator{Evaluator, VT, MT, DVT, DMT} <: AbstractNLPEvaluato
     bridge::BridgeDeviceArrays{DVT, DMT}
 end
 function BridgeDeviceEvaluator(nlp::AbstractNLPEvaluator, device)
+    if isa(nlp, BridgeDeviceEvaluator)
+        error("BridgeDeviceEvaluator cannot wrap another BridgeDeviceEvaluator.")
+    end
     n, m = n_variables(nlp), n_constraints(nlp)
     # Deporting device
     VT = Array{Float64, 1}
     MT = Array{Float64, 2}
-    if isa(nlp.model.device, CPU)
+    model = backend(nlp)
+    if isa(model.device, CPU)
         VTD = Array{Float64, 1}
         MTD = Array{Float64, 2}
     else

--- a/src/Evaluators/common.jl
+++ b/src/Evaluators/common.jl
@@ -59,7 +59,7 @@ macro define_hessian(function_name, target_function, args...)
             @inbounds for i in 1:n
                 hv = @view hess[:, i]
                 fill!(v, 0)
-                v[i] = 1.0
+                v[i:i] .= 1.0
                 $target_function(nlp, hv, $(map(esc, argstup)...), v)
             end
         end

--- a/src/Evaluators/feasibility_evaluator.jl
+++ b/src/Evaluators/feasibility_evaluator.jl
@@ -31,6 +31,7 @@ constraints_type(::FeasibilityEvaluator) = :bound
 
 has_hessian(nlp::FeasibilityEvaluator) = has_hessian(nlp.inner)
 has_hessian_lagrangian(nlp::FeasibilityEvaluator) = has_hessian(nlp)
+backend(nlp::FeasibilityEvaluator) = backend(nlp.inner)
 
 # Getters
 get(nlp::FeasibilityEvaluator, attr::AbstractNLPAttribute) = get(nlp.inner, attr)

--- a/src/Evaluators/proxal_evaluators.jl
+++ b/src/Evaluators/proxal_evaluators.jl
@@ -109,6 +109,7 @@ n_constraints(nlp::ProxALEvaluator) = n_constraints(nlp.inner)
 
 constraints_type(::ProxALEvaluator) = :inequality
 has_hessian(::ProxALEvaluator) = true
+backend(nlp::ProxALEvaluator) = backend(nlp.inner)
 
 # Getters
 get(nlp::ProxALEvaluator, attr::AbstractNLPAttribute) = get(nlp.inner, attr)

--- a/src/Polar/derivatives.jl
+++ b/src/Polar/derivatives.jl
@@ -411,9 +411,9 @@ function update_full_jacobian!(
         Jx = AutoDiff.jacobian!(polar, ad.x, buffer)::SpMT
         Ju = AutoDiff.jacobian!(polar, ad.u, buffer)::Union{Nothing, SpMT}
         # Copy back results
-        _transfer_sparse!(cons_jac.Jx, Jx, shift)
+        _transfer_sparse!(cons_jac.Jx, Jx, shift, polar.device)
         if !isnothing(Ju)
-            _transfer_sparse!(cons_jac.Ju, Ju, shift)
+            _transfer_sparse!(cons_jac.Ju, Ju, shift, polar.device)
         end
 
         shift += size(Jx, 1)

--- a/test/Evaluators/TestEvaluators.jl
+++ b/test/Evaluators/TestEvaluators.jl
@@ -16,6 +16,18 @@ import ExaPF: PowerSystem, LinearSolvers
 const PS = PowerSystem
 const LS = LinearSolvers
 
+function myisless(a, b)
+    h_a = a |> Array
+    h_b = b |> Array
+    return h_a <= h_b
+end
+
+function myisapprox(a, b; options...)
+    h_a = a |> Array
+    h_b = b |> Array
+    return isapprox(h_a, h_b; options...)
+end
+
 include("powerflow.jl")
 include("api.jl")
 include("proxal_evaluator.jl")
@@ -50,7 +62,6 @@ function runtests(datafile, device, AT)
         ExaPF.ProxALEvaluator,
         ExaPF.SlackEvaluator,
         ExaPF.FeasibilityEvaluator,
-        ExaPF.BridgeDeviceEvaluator,
     ]
         nlp = Evaluator(datafile; device=device)
         test_evaluator_api(nlp, device, AT)


### PR DESCRIPTION
Now, all the code in ExaPF supports `CUDA.allowscalar(false)`. 

Two tricks to disallow scalar indexing: 
1. Replace scalar indexing 
```julia
x[i] = 0.0
```
by a broadcast operator to launch a kernel:
```julia
x[i:i] .= 0.0
```
2. In tests, `FiniteDiff.finite_difference_gradient` does not support `allowscalar(false)`, and `finite_difference_jacobian` is less accurate. To overcome this, we wrap the evaluators tested on the GPU by a `BridgeDeviceEvaluator` to deport the finite difference computation on the CPU