### PR TITLE
Update to KA 0.7 and CUDA.jl 3.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,11 +20,11 @@ SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
-CUDA = "~2.6, ~3.2"
+CUDA = "~2.6, ~3.2, ~3.3"
 ExprTools = "= 0.1.3"
 FiniteDiff = "2.7"
 ForwardDiff = "0.10"
-KernelAbstractions = "0.6"
+KernelAbstractions = "0.6, 0.7"
 Krylov = "~0.7.3"
 LightGraphs = "1.3"
 MathOptInterface = "0.9"

--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -240,7 +240,9 @@ function ldiv!(solver::DQGMRES,
     y::AbstractVector, J::AbstractMatrix, x::AbstractVector,
 )
     P = solver.precond.P
-    (y[:], status) = Krylov.dqgmres!(solver.inner, J, x; N=P)
+    CUDA.allowscalar() do
+        global (y[:], status) = Krylov.dqgmres!(solver.inner, J, x; N=P)
+    end
     return length(status.residuals)
 end
 
@@ -270,11 +272,13 @@ end
 function ldiv!(solver::KrylovBICGSTAB,
     y::AbstractVector, J::AbstractMatrix, x::AbstractVector,
 )
-    (y[:], status) = Krylov.bicgstab!(solver.inner, J, x;
-                                      N=solver.precond.P,
-                                      atol=solver.atol,
-                                      rtol=solver.rtol,
-                                      verbose=solver.verbose)
+    CUDA.allowscalar() do
+        global (y[:], status) = Krylov.bicgstab!(solver.inner, J, x;
+                                        N=solver.precond.P,
+                                        atol=solver.atol,
+                                        rtol=solver.rtol,
+                                        verbose=solver.verbose)
+    end
     return length(status.residuals)
 end
 

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -291,7 +291,7 @@ end
 
 function batch_init_seed_hessian!(dest, tmp, v::CUDA.CuMatrix, nmap, device)
     ndrange = (nmap, size(dest, 2))
-    ev = _gpu_init_seed_hessian!(device)(dest, v, ndrange=ndrange, workgroupsize=256)
+    ev = _gpu_init_seed_hessian!(device)(dest, v, ndrange=ndrange, dependencies=Event(device), workgroupsize=256)
     wait(ev)
 end
 


### PR DESCRIPTION
Two things:

* `] test` passes all tests, but `julia --project test/runtests.jl` fails on moonshot due to a kernel crashing. @frapac can you confirm this on your side? If so, we might have to investigate that.
* We used the trick `x[i:i]` to avoid scalar access warnings. Shouldn't we use `allowscalar` to explicitly allow it for a statement? That might be easier to track in the future.
* This also adds the `BlockPowerFlow` package. That was actually by accident, but now I'm wondering whether it should not be in `Project.toml`? Let me know your opinion and I'll rebase.