### PR TITLE
Fix ProxALEvaluator

### DIFF
--- a/src/Evaluators/MOI_wrapper.jl
+++ b/src/Evaluators/MOI_wrapper.jl
@@ -67,9 +67,9 @@ function MOI.eval_constraint(ev::MOIEvaluator, cons, x)
 end
 
 function MOI.eval_constraint_jacobian(ev::MOIEvaluator, jac, x)
+    _update!(ev, x)
     n = length(x)
     m = n_constraints(ev.nlp)
-    _update!(ev, x)
     fill!(jac, 0)
     J = reshape(jac, m, n)
     jacobian!(ev.nlp, J, x)

--- a/src/Evaluators/proxal_evaluators.jl
+++ b/src/Evaluators/proxal_evaluators.jl
@@ -46,7 +46,6 @@ function ProxALEvaluator(
     nu = n_variables(nlp)
     ng = get(nlp, PS.NumberOfGenerators())
 
-
     s_min = xzeros(VT, ng)
     s_max = xones(VT, ng)
     λf = xzeros(VT, ng)
@@ -56,21 +55,7 @@ function ProxALEvaluator(
     pgc = xzeros(VT, ng)
     pgt = xzeros(VT, ng)
 
-    intermediate = (
-        s = similar(s_min),
-        t = Int(time),
-        σ = scale_obj,
-        τ = τ,
-        λf = λf,
-        λt = λt,
-        ρf = ρf,
-        ρt = ρt,
-        p1 = pgf,
-        p2 = pgc,
-        p3 = pgt,
-    )
-
-    pbm = pullback_ramping(nlp.model, intermediate)
+    pbm = pullback_ramping(nlp.model, nothing)
 
     hess = nothing
     if want_hessian
@@ -144,7 +129,6 @@ function update!(nlp::ProxALEvaluator, w)
     s = @view w[nlp.nu+1:end]
     conv = update!(nlp.inner, u)
     pg = get(nlp.inner, PS.ActivePower())
-    copyto!(nlp.obj_stack.intermediate.s, s)
     return conv
 end
 
@@ -179,43 +163,37 @@ function objective(nlp::ProxALEvaluator, w)
 end
 
 ## Gradient
-function full_gradient!(nlp::ProxALEvaluator, jx, ju, w)
+function _gradient_control!(nlp::ProxALEvaluator, grad, w)
+    # Gradient wrt u
+    gu = @view grad[1:nlp.nu]
+    u = @view w[1:nlp.nu]
+    s = @view w[nlp.nu+1:end]
     buffer = get(nlp.inner, PhysicalState())
     ∂obj = nlp.obj_stack
+    ju = ∂obj.stack.∇fᵤ ; jx = ∂obj.stack.∇fₓ
     # Evaluate adjoint of cost function and update inplace AdjointStackObjective
-    gradient_objective!(nlp.inner.model, ∂obj, buffer)
-    copyto!(jx, ∂obj.stack.∇fₓ)
-    copyto!(ju, ∂obj.stack.∇fᵤ)
+    adjoint_penalty_ramping_constraints!(
+        nlp.inner.model, ∂obj, buffer, s, Int(nlp.time),
+        nlp.scale_objective, nlp.τ, nlp.λf, nlp.λt, nlp.ρf, nlp.ρt, nlp.pg_f, nlp.pg_ref, nlp.pg_t
+    )
+    reduced_gradient!(nlp.inner, gu, jx, ju, w)
 end
 
-function gradient_slack!(nlp::ProxALEvaluator, grad, w)
+function _gradient_slack!(nlp::ProxALEvaluator, grad, w)
     s = @view w[nlp.nu+1:end]
     pg = get(nlp.inner, PS.ActivePower())
     # Gradient wrt s
-    g_s = @view grad[nlp.nu+1:end]
+    gs = @view grad[nlp.nu+1:end]
     if nlp.time != Origin
-        g_s .= nlp.λf .+ nlp.ρf .* (nlp.pg_f .- pg .+ s)
+        gs .= nlp.λf .+ nlp.ρf .* (nlp.pg_f .- pg .+ s)
     else
-        g_s .= 0.0
+        gs .= 0.0
     end
 end
 
-function reduced_gradient!(nlp::ProxALEvaluator, grad, jvx, jvu, w)
-    g = @view grad[1:nlp.nu]
-    reduced_gradient!(nlp.inner, g, jvx, jvu, w)
-    gradient_slack!(nlp, grad, w)
-end
-
-## Gradient
 function gradient!(nlp::ProxALEvaluator, g, w)
-    # Import AutoDiff objects
-    ∂obj = nlp.obj_stack
-    jvu = ∂obj.stack.∇fᵤ ; jvx = ∂obj.stack.∇fₓ
-    fill!(jvx, 0)  ; fill!(jvu, 0)
-    full_gradient!(nlp, jvx, jvu, w)
-
-    ## Evaluation of reduced gradient
-    reduced_gradient!(nlp, g, jvx, jvu, w)
+    _gradient_control!(nlp, g, w)
+    _gradient_slack!(nlp, g, w)
     return nothing
 end
 
@@ -225,25 +203,30 @@ function constraint!(nlp::ProxALEvaluator, cons, w)
 end
 
 function jacobian_structure(nlp::ProxALEvaluator)
-    m, nu = n_constraints(nlp), nlp.nu
-    nnzj = m * nu
+    m, n = n_constraints(nlp), n_variables(nlp)
+    nnzj = m * n
     rows = zeros(Int, nnzj)
     cols = zeros(Int, nnzj)
-    jacobian_structure!(nlp.inner, rows, cols)
+    jacobian_structure!(nlp, rows, cols)
     return rows, cols
 end
 
 ## Jacobian
 function jacobian_structure!(nlp::ProxALEvaluator, rows, cols)
-    jacobian_structure!(nlp.inner, rows, cols)
+    m, n = n_constraints(nlp), n_variables(nlp)
+    idx = 1
+    for i in 1:n # number of variables
+        for c in 1:m #number of constraints
+            rows[idx] = c ; cols[idx] = i
+            idx += 1
+        end
+    end
 end
 
 function jacobian!(nlp::ProxALEvaluator, jac, w)
     m = n_constraints(nlp)
-    nnj = length(jac)
     u = @view w[1:nlp.nu]
-    J = reshape(jac, m, div(nnj, m))
-    Jᵤ = @view J[:, 1:nlp.nu]
+    Jᵤ = @view jac[:, 1:nlp.nu]
     jacobian!(nlp.inner, Jᵤ, u)
 end
 
@@ -260,23 +243,35 @@ function jtprod!(nlp::ProxALEvaluator, jv, w, v)
     jvu = @view jv[1:nlp.nu]
     jtprod!(nlp.inner, jvu, u, v)
 end
-function full_jtprod!(nlp::ProxALEvaluator, jvx, jvu, w, v)
-    u = @view w[1:nlp.nu]
-    full_jtprod!(nlp.inner, jvx, jvu, u, v)
-end
 
-function ojtprod!(nlp::ProxALEvaluator, jv, u, σ, v)
+function ojtprod!(nlp::ProxALEvaluator, jv, w, σ, v)
+    gu = @view jv[1:nlp.nu]
+    s = @view w[nlp.nu+1:end]
+    u = @view w[1:nlp.nu]
+
+    # w.r.t. u
+    buffer = get(nlp.inner, PhysicalState())
     ∂obj = nlp.obj_stack
     jvx = ∂obj.stack.jvₓ ; fill!(jvx, 0)
     jvu = ∂obj.stack.jvᵤ ; fill!(jvu, 0)
+
+    # Evaluate adjoint of cost function and update inplace AdjointStackObjective
+    adjoint_penalty_ramping_constraints!(
+        nlp.inner.model, ∂obj, buffer, s, Int(nlp.time),
+        nlp.scale_objective, nlp.τ, nlp.λf, nlp.λt, nlp.ρf, nlp.ρt, nlp.pg_f, nlp.pg_ref, nlp.pg_t
+    )
+    copyto!(jvx, ∂obj.stack.∇fₓ)
+    copyto!(jvu, ∂obj.stack.∇fᵤ)
     # compute gradient of objective
-    full_gradient!(nlp, jvx, jvu, u)
     jvx .*= σ
     jvu .*= σ
     # compute transpose Jacobian vector product of constraints
-    full_jtprod!(nlp, jvx, jvu, u, v)
+    full_jtprod!(nlp.inner, jvx, jvu, u, v)
     # Evaluate gradient in reduced space
-    reduced_gradient!(nlp, jv, jvx, jvu, u)
+    reduced_gradient!(nlp.inner, gu, jvx, jvu, w)
+
+    # w.r.t. s
+    _gradient_slack!(nlp, jv, w)
 end
 
 #=


### PR DESCRIPTION
Solve https://github.com/exanauts/ProxAL.jl/issues/31

- now reduced Jacobian is dense, to follow the convention used by other evaluators 
- fix the reduced gradient by removing unneeded intermediate states (which were not updated)