### PR TITLE
Another look at the line flow gradient

### DIFF
--- a/src/Polar/Constraints/line_flow.jl
+++ b/src/Polar/Constraints/line_flow.jl
@@ -35,6 +35,10 @@ function flow_constraints_grad!(polar::PolarForm, cons_grad, buffer, weights)
     ∂edge_vm_to = similar(cons_grad, nlines)
     ∂edge_va_fr = similar(cons_grad, nlines)
     ∂edge_va_to = similar(cons_grad, nlines)
+    fill!(∂edge_vm_fr, 0)
+    fill!(∂edge_vm_to, 0)
+    fill!(∂edge_va_fr, 0)
+    fill!(∂edge_va_to, 0)
     adj_branch_flow!(weights, buffer.vmag, adj_vmag,
             buffer.vang, adj_vang,
             ∂edge_vm_fr, ∂edge_vm_to,

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -649,6 +649,8 @@ KA.@kernel function adj_branch_flow_edge_kernel!(
     Δθ = vang[fr_bus, j] - vang[to_bus, j]
     cosθ = cos(Δθ)
     sinθ = sin(Δθ)
+    dcosθ = -sinθ
+    dsinθ = cosθ
 
     # branch apparent power limits - from bus
     yff_abs = yff_re[ℓ]^2 + yff_im[ℓ]^2
@@ -698,8 +700,8 @@ KA.@kernel function adj_branch_flow_edge_kernel!(
     adj_cosθ += 2.0 * vmag[to_bus, j] * vmag[fr_bus, j]^3 *   yre_fr  * adj_from_flow
     adj_sinθ += 2.0 * vmag[to_bus, j] * vmag[fr_bus, j]^3 * (-yim_fr) * adj_from_flow
 
-    adj_Δθ =   cosθ * adj_sinθ
-    adj_Δθ -=  sinθ * adj_cosθ
+    adj_Δθ =   dsinθ * adj_sinθ
+    adj_Δθ +=  dcosθ * adj_cosθ
     adj_va_from_lines[ℓ, j] += adj_Δθ
     adj_va_to_lines[ℓ, j] -= adj_Δθ
 end

--- a/test/Polar/TestPolarForm.jl
+++ b/test/Polar/TestPolarForm.jl
@@ -4,6 +4,7 @@ module TestPolarFormulation
 
 using Test
 
+using CUDA
 using FiniteDiff
 using ForwardDiff
 using KernelAbstractions


### PR DESCRIPTION
* The tests of line flow gradient fail with the default tolerance of `rtol=1e-8`. I made both tolerances as tight as possible.
* Fixed a minor bug where arrays were uninitialized. This triggered the test too.
* I also adapted the kernel to just change the function `cos` to some other function both for AD and handwritten. The gradient test then passes.
