### PR TITLE
[exaopt] Integrate properly line flow constraints in optimization routine

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ LightGraphs = "1.3"
 Metis = "1"
 SparseDiffTools = "1"
 TimerOutputs = "0.5"
-julia = "1.7"
+julia = "1.6"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/LinearSolvers/LinearSolvers.jl
+++ b/src/LinearSolvers/LinearSolvers.jl
@@ -95,26 +95,26 @@ struct DirectSolver{Fac} <: AbstractLinearSolver
     factorization::Fac
 end
 
-DirectSolver(J::SparseMatrixCSC{T, Int}) where T = DirectSolver(lu(J))
+DirectSolver(J::SparseMatrixCSC{T, Int}; options...) where T = DirectSolver(lu(J))
 
 # Reuse factorization in update
 function ldiv!(s::DirectSolver, y::AbstractVector, J::AbstractMatrix, x::AbstractVector)
     lu!(s.factorization, J) # Update factorization inplace
-    LinearAlgebra.ldiv!(y, s.factorization, x) # Forward-backward solve
+    LinearAlgebra.ldiv!(y, s.factorization, x)
     return 0
 end
 function rdiv!(s::DirectSolver, y::AbstractVector, J::AbstractMatrix, x::AbstractVector)
     lu!(s.factorization, J) # Update factorization inplace
-    LinearAlgebra.ldiv!(y, s.factorization', x) # Forward-backward solve
+    LinearAlgebra.ldiv!(y, s.factorization', x)
     return 0
 end
 # Solve system Ax = y
 function ldiv!(s::DirectSolver, y::AbstractArray, x::AbstractArray)
-    LinearAlgebra.ldiv!(y, s.factorization, x) # Forward-backward solve
+    LinearAlgebra.ldiv!(y, s.factorization, x)
     return 0
 end
 function ldiv!(s::DirectSolver, y::AbstractArray)
-    LinearAlgebra.ldiv!(s.factorization, y) # Forward-backward solve
+    LinearAlgebra.ldiv!(s.factorization, y)
     return 0
 end
 

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -725,31 +725,3 @@ KA.@kernel function adj_branch_flow_node_kernel!(
     end
 end
 
-function adj_branch_flow!(
-        adj_slines, vmag, adj_vm, vang, adj_va,
-        adj_vm_from_lines, adj_va_from_lines, adj_vm_to_lines, adj_va_to_lines,
-        yff_re, yft_re, ytf_re, ytt_re,
-        yff_im, yft_im, ytf_im, ytt_im,
-        f, t, nlines, device
-    )
-    nvbus = length(vang)
-    kernel_edge! = adj_branch_flow_edge_kernel!(device)
-    kernel_node! = adj_branch_flow_node_kernel!(device)
-
-    ev = kernel_edge!(
-            adj_slines, vmag, adj_vm, vang, adj_va,
-            adj_va_to_lines, adj_va_from_lines, adj_vm_to_lines, adj_vm_from_lines,
-            yff_re, yft_re, ytf_re, ytt_re,
-            yff_im, yft_im, ytf_im, ytt_im,
-            f, t, nlines, ndrange = (nlines, size(adj_slines, 2)),
-            dependencies=Event(device)
-    )
-    wait(ev)
-    ev = kernel_node!(
-            vmag, adj_vm, vang, adj_va,
-            adj_va_to_lines, adj_va_from_lines, adj_vm_to_lines, adj_vm_from_lines,
-            f, t, nlines, ndrange = (nvbus, size(adj_slines, 2)),
-            dependencies=Event(device)
-    )
-    wait(ev)
-end

--- a/src/Polar/kernels.jl
+++ b/src/Polar/kernels.jl
@@ -678,7 +678,7 @@ KA.@kernel function adj_branch_flow_edge_kernel!(
     # )
     # slines[ℓ + nlines] = to_flow
 
-    adj_to_flow = adj_slines[ℓ + nlines, j]
+    adj_to_flow = adj_slines[ℓ + nlines]
     adj_vm_to_lines[ℓ, j] += (2.0 * vmag[to_bus, j] * ytf_abs * vmag[fr_bus, j]^2
                       + 4.0 * vmag[to_bus, j]^3 * ytt_abs
                       + 6.0 * vmag[fr_bus, j] * vmag[to_bus, j]^2 * (yre_to * cosθ - yim_to * sinθ)
@@ -689,7 +689,7 @@ KA.@kernel function adj_branch_flow_edge_kernel!(
     adj_cosθ = 2.0 * vmag[to_bus, j]^3 * vmag[fr_bus, j] *   yre_to  * adj_to_flow
     adj_sinθ = 2.0 * vmag[to_bus, j]^3 * vmag[fr_bus, j] * (-yim_to) * adj_to_flow
 
-    adj_from_flow = adj_slines[ℓ, j]
+    adj_from_flow = adj_slines[ℓ]
     adj_vm_from_lines[ℓ, j] += (4.0 * yff_abs * vmag[fr_bus, j]^3
                       + 2.0 * vmag[to_bus, j]^2 * vmag[fr_bus, j] * yft_abs
                       + 6.0 * vmag[fr_bus, j]^2 * vmag[to_bus, j] * (yre_fr * cosθ - yim_fr * sinθ)

--- a/src/Polar/polar.jl
+++ b/src/Polar/polar.jl
@@ -276,6 +276,7 @@ function powerflow_jacobian_device(polar)
     J = powerflow_jacobian(polar)
     return J |> SpMT
 end
+default_jacobian(polar::PolarForm) = powerflow_jacobian_device(polar)
 
 function Base.show(io::IO, polar::PolarForm)
     # Network characteristics

--- a/src/Polar/powerflow.jl
+++ b/src/Polar/powerflow.jl
@@ -2,7 +2,7 @@
 function powerflow(
     polar::PolarForm,
     algo::AbstractNonLinearSolver;
-    linear_solver=DirectSolver(),
+    linear_solver=DirectSolver(default_jacobian(polar)),
 )
     buffer = get(polar, PhysicalState())
     init_buffer!(polar, buffer)
@@ -15,7 +15,7 @@ function powerflow(
     jacobian::AutoDiff.Jacobian,
     buffer::PolarNetworkState{IT,VT},
     algo::NewtonRaphson;
-    linear_solver=DirectSolver(),
+    linear_solver=DirectSolver(jacobian.J),
 ) where {T, IT, VT, MT}
     # Retrieve parameter and initial voltage guess
     Vm, Va = buffer.vmag, buffer.vang

--- a/src/models.jl
+++ b/src/models.jl
@@ -171,7 +171,7 @@ from the object `form`.
 
 ## Optional arguments
 
-* `linear_solver::AbstractLinearSolver` (default `DirectSolver()`): solver to solve the linear systems ``J x = y`` arising at each iteration of the Newton-Raphson algorithm.
+* `linear_solver::AbstractLinearSolver` (default `DirectSolver`): solver to solve the linear systems ``J x = y`` arising at each iteration of the Newton-Raphson algorithm.
 
 """
 function powerflow end

--- a/src/models.jl
+++ b/src/models.jl
@@ -194,6 +194,8 @@ function cost_penalty_ramping_constraints end
 
 function network_operations end
 
+function network_line_operations end
+
 # Generic constraints
 
 """

--- a/test/quickstart.jl
+++ b/test/quickstart.jl
@@ -37,7 +37,7 @@ const LS = ExaPF.LinearSolvers
     ExaPF.init_buffer!(polar, physical_state)
     jx = AutoDiff.Jacobian(polar, ExaPF.power_balance, State())
 
-    linear_solver = LS.DirectSolver()
+    linear_solver = LS.DirectSolver(jx.J)
     convergence = ExaPF.powerflow(
         polar, jx, physical_state, pf_algo;
         linear_solver=linear_solver
@@ -73,7 +73,7 @@ const LS = ExaPF.LinearSolvers
         jx_gpu = AutoDiff.Jacobian(polar_gpu, ExaPF.power_balance, State())
         physical_state_gpu = get(polar_gpu, ExaPF.PhysicalState())
         ExaPF.init_buffer!(polar_gpu, physical_state_gpu)
-        linear_solver = LS.DirectSolver()
+        linear_solver = LS.DirectSolver(jx_gpu.J)
         convergence = ExaPF.powerflow(
             polar_gpu, jx_gpu, physical_state_gpu, pf_algo;
             linear_solver=linear_solver


### PR DESCRIPTION
- [breaking] Update interface for `DirectSolver`. Now the constructor requires a sparse matrix `J` to be instantiated: `linsol = DirectSolver(J)` (explicit is better than implicit). 
- Add efficient evaluation of line flow's Hessian (cf new function `network_line_operations`). 
- fix line flow's adjoint in batch mode (adjoint is 1D, not 2D)
