### PR TITLE
Add load values as parameters in NetworkStack

### DIFF
--- a/src/Polar/first_order.jl
+++ b/src/Polar/first_order.jl
@@ -1,9 +1,9 @@
 
-struct Jacobian{Model, Func, VD, SMT, VI} <: AutoDiff.AbstractJacobian
+struct Jacobian{Model, Func, VT, VD, SMT, VI} <: AutoDiff.AbstractJacobian
     model::Model
     func::Func
     map::VI
-    stack::NetworkStack{VD}
+    stack::NetworkStack{VT, VD}
     coloring::VI
     ncolors::Int
     t1sF::VD
@@ -54,7 +54,8 @@ function Jacobian(polar::PolarForm{T, VI, VT, MT}, func::AutoDiff.AbstractExpres
     J = J_host |> SMT
 
     # Structures
-    stack = NetworkStack(nbus, ngen, nlines, VD)
+    stack = NetworkStack(nbus, ngen, nlines, VT, VD)
+    init!(polar, stack)
     t1sF = zeros(Float64, n_cons) |> VD
 
     coloring = coloring |> VI

--- a/src/Polar/second_order.jl
+++ b/src/Polar/second_order.jl
@@ -1,10 +1,10 @@
 
-struct HessianProd{Model, Func, VD, VI, Buff} <: AutoDiff.AbstractHessianProd
+struct HessianProd{Model, Func, VT, VD, VI, Buff} <: AutoDiff.AbstractHessianProd
     model::Model
     func::Func
     map::VI
-    stack::NetworkStack{VD}
-    ∂stack::NetworkStack{VD}
+    stack::NetworkStack{VT, VD}
+    ∂stack::NetworkStack{VT, VD}
     t1sF::VD
     ∂t1sF::VD
     buffer::Buff
@@ -26,8 +26,10 @@ function HessianProd(polar::PolarForm{T, VI, VT, MT}, func::AutoDiff.AbstractExp
     t1s{N} = ForwardDiff.Dual{Nothing,Float64, N} where N
     VD = A{t1s{1}}
 
-    stack = NetworkStack(nbus, ngen, nlines, VD)
-    ∂stack = NetworkStack(nbus, ngen, nlines, VD)
+    stack = NetworkStack(nbus, ngen, nlines, VT, VD)
+    init!(polar, stack)
+
+    ∂stack = NetworkStack(nbus, ngen, nlines, VT, VD)
 
     t1sF = zeros(Float64, n_cons) |> VD
     adj_t1sF = similar(t1sF)
@@ -70,12 +72,12 @@ function _hessian_sparsity(polar::PolarForm, func)
     return matpower_hessian(polar, func, V, y)
 end
 
-struct FullHessian{Model, Func, VD, SMT, VI, Buff} <: AutoDiff.AbstractFullHessian
+struct FullHessian{Model, Func, VT, VD, SMT, VI, Buff} <: AutoDiff.AbstractFullHessian
     model::Model
     func::Func
     map::VI
-    stack::NetworkStack{VD}
-    ∂stack::NetworkStack{VD}
+    stack::NetworkStack{VT, VD}
+    ∂stack::NetworkStack{VT, VD}
     coloring::VI
     ncolors::Int
     t1sF::VD
@@ -111,8 +113,10 @@ function FullHessian(polar::PolarForm{T, VI, VT, MT}, func::AutoDiff.AbstractExp
     H = H_host |> SMT
 
     # Structures
-    stack = NetworkStack(nbus, ngen, nlines, VD)
-    ∂stack = NetworkStack(nbus, ngen, nlines, VD)
+    stack = NetworkStack(nbus, ngen, nlines, VT, VD)
+    init!(polar, stack)
+
+    ∂stack = NetworkStack(nbus, ngen, nlines, VT, VD)
     t1sF = zeros(Float64, n_cons) |> VD
     adj_t1sF = similar(t1sF)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,6 +36,15 @@ end
     end
 end
 
+@kernel function _spmv_csr_kernel_double!(Y, X, colVal, rowPtr, nzVal, alpha, beta, n, m)
+    i = @index(Global, Linear)
+    Y[1, i] *= beta
+    @inbounds for c in rowPtr[i]:rowPtr[i+1]-1
+        j = colVal[c]
+        Y[1, i] += alpha * nzVal[c] * X[j]
+    end
+end
+
 #=
     CSC2CSR
 =#


### PR DESCRIPTION
Before, the load values where stored inside the power system object, and loaded on the fly when needed. 
This PR moves the loads as parameters inside the `NetworkStack` object. This way, it's easier to modify them, and to streamline the evaluation across different set of loads (as it is the case in SC-OPF). This also makes sure that the loads are defined once. 