### PR TITLE
Get rid of uninitialized Arrays

### DIFF
--- a/src/Polar/functions.jl
+++ b/src/Polar/functions.jl
@@ -364,7 +364,7 @@ end
 
 function bounds(polar::PolarForm{T,VI,VT,MT}, func::PowerFlowBalance) where {T,VI,VT,MT}
     m = length(func)
-    return (fill!(VT(undef, m), zero(T)) , fill!(VT(undef, m), zero(T)))
+    return (VT(zeros(T, m)) , VT(zeros(T, m)))
 end
 
 function Base.show(io::IO, func::PowerFlowBalance)
@@ -661,8 +661,8 @@ end
 
 function bounds(polar::PolarForm{T, VI, VT, MT}, func::MultiExpressions) where {T, VI, VT, MT}
     m = length(func)
-    g_min = VT(undef, m)
-    g_max = VT(undef, m)
+    g_min = VT(zeros(T, m))
+    g_max = VT(zeros(T, m))
     k = 0
     for expr in func.exprs
         m = length(expr)

--- a/src/Polar/newton.jl
+++ b/src/Polar/newton.jl
@@ -54,7 +54,7 @@ struct NLBuffer{VT}
     x::VT
     y::VT
 end
-NLBuffer{VT}(n::Int) where VT = NLBuffer(VT(undef, n), VT(undef, n))
+NLBuffer{VT}(n::Int) where VT = NLBuffer(VT(zeros(eltype(VT), n)), VT(zeros(eltype(VT), n)))
 
 @doc raw"""
     nlsolve!(

--- a/src/Polar/stacks.jl
+++ b/src/Polar/stacks.jl
@@ -51,7 +51,7 @@ struct NetworkStack{VT,VD,NT} <: AbstractNetworkStack{VT}
 end
 
 function NetworkStack(nbus, ngen, nlines, VT, VD)
-    input = VD(undef, 2*nbus + ngen) ; fill!(input, 0.0)
+    input = VD(zeros(eltype(VD), 2*nbus + ngen))
     # Wrap directly array x to avoid dealing with views
     p0 = pointer(input)
     vmag = unsafe_wrap(VD, p0, nbus)
@@ -61,25 +61,22 @@ function NetworkStack(nbus, ngen, nlines, VT, VD)
     pgen = unsafe_wrap(VD, p2, ngen)
 
     # Basis function
-    ψ = VD(undef, 2*nlines + nbus) ; fill!(ψ, 0.0)
+    ψ = VD(zeros(eltype(VD), 2*nlines + nbus))
     # Intermediate expressions to avoid unecessary allocations
     intermediate = (
-        c = VD(undef, ngen),     # buffer for costs
-        sfp = VD(undef, nlines), # buffer for line-flow
-        sfq = VD(undef, nlines), # buffer for line-flow
-        stp = VD(undef, nlines), # buffer for line-flow
-        stq = VD(undef, nlines), # buffer for line-flow
-        ∂edge_vm_fr = VD(undef, nlines), # buffer for basis
-        ∂edge_vm_to = VD(undef, nlines), # buffer for basis
-        ∂edge_va_fr = VD(undef, nlines), # buffer for basis
-        ∂edge_va_to = VD(undef, nlines), # buffer for basis
+        c = VD(zeros(eltype(VD), ngen)),     # buffer for costs
+        sfp = VD(zeros(eltype(VD), nlines)), # buffer for line-flow
+        sfq = VD(zeros(eltype(VD), nlines)), # buffer for line-flow
+        stp = VD(zeros(eltype(VD), nlines)), # buffer for line-flow
+        stq = VD(zeros(eltype(VD), nlines)), # buffer for line-flow
+        ∂edge_vm_fr = VD(zeros(eltype(VD), nlines)), # buffer for basis
+        ∂edge_vm_to = VD(zeros(eltype(VD), nlines)), # buffer for basis
+        ∂edge_va_fr = VD(zeros(eltype(VD), nlines)), # buffer for basis
+        ∂edge_va_to = VD(zeros(eltype(VD), nlines)), # buffer for basis
     )
-    for f in fieldnames(typeof(intermediate))
-        fill!(getfield(intermediate, f), 0.0)
-    end
 
     # Parameters: loads
-    params = VT(undef, 2*nbus) ; fill!(params, 0.0)
+    params = VT(zeros(eltype(VT), 2*nbus))
     p0 = pointer(params)
     pload = unsafe_wrap(VT, p0, nbus)
     p1 = pointer(params, nbus+1)
@@ -188,7 +185,7 @@ end
 
 function BlockNetworkStack(k, nbus, ngen, nlines, VT, VD)
     m = (2*nbus + ngen) * k
-    input = VD(undef, m) ; fill!(input, 0.0)
+    input = VD(zeros(eltype(VD), m))
     # Wrap directly array x to avoid dealing with views
     p0 = pointer(input)
     vmag = unsafe_wrap(VD, p0, k*nbus)
@@ -198,25 +195,22 @@ function BlockNetworkStack(k, nbus, ngen, nlines, VT, VD)
     pgen = unsafe_wrap(VD, p2, k*ngen)
 
     # Basis function
-    ψ = VD(undef, k * (2*nlines+nbus)) ; fill!(ψ, 0.0)
+    ψ = VD(zeros(eltype(VD), k * (2*nlines+nbus)))
     # Intermediate expressions to avoid unecessary allocations
     intermediate = (
-        c = VD(undef, k*ngen),     # buffer for costs
-        sfp = VD(undef, k*nlines), # buffer for line-flow
-        sfq = VD(undef, k*nlines), # buffer for line-flow
-        stp = VD(undef, k*nlines), # buffer for line-flow
-        stq = VD(undef, k*nlines), # buffer for line-flow
-        ∂edge_vm_fr = VD(undef, k*nlines), # buffer for basis
-        ∂edge_vm_to = VD(undef, k*nlines), # buffer for basis
-        ∂edge_va_fr = VD(undef, k*nlines), # buffer for basis
-        ∂edge_va_to = VD(undef, k*nlines), # buffer for basis
+        c = VD(zeros(eltype(VD), k*ngen)),     # buffer for costs
+        sfp = VD(zeros(eltype(VD), k*nlines)), # buffer for line-flow
+        sfq = VD(zeros(eltype(VD), k*nlines)), # buffer for line-flow
+        stp = VD(zeros(eltype(VD), k*nlines)), # buffer for line-flow
+        stq = VD(zeros(eltype(VD), k*nlines)), # buffer for line-flow
+        ∂edge_vm_fr = VD(zeros(eltype(VD), k*nlines)), # buffer for basis
+        ∂edge_vm_to = VD(zeros(eltype(VD), k*nlines)), # buffer for basis
+        ∂edge_va_fr = VD(zeros(eltype(VD), k*nlines)), # buffer for basis
+        ∂edge_va_to = VD(zeros(eltype(VD), k*nlines)), # buffer for basis
     )
-    for f in fieldnames(typeof(intermediate))
-        fill!(getfield(intermediate, f), 0.0)
-    end
 
     # Parameters: loads
-    params = VT(undef, 2*k*nbus) ; fill!(params, 0.0)
+    params = VT(zeros(eltype(VT), 2*k*nbus))
     p0 = pointer(params)
     pload = unsafe_wrap(VT, p0, k*nbus)
     p1 = pointer(params, k*nbus+1)

--- a/src/PowerSystem/parsers/parse_con.jl
+++ b/src/PowerSystem/parsers/parse_con.jl
@@ -25,7 +25,7 @@ function parse_con(filename::AbstractString; delim=" \t")
         pos += 1
     end
 
-    data = Array{Any}(undef, ndata, 5)
+    data = Array{Any}(zeros(Float64, ndata, 5))
 
     label = ""
     ndata = 0

--- a/src/PowerSystem/parsers/parse_psse.jl
+++ b/src/PowerSystem/parsers/parse_psse.jl
@@ -19,7 +19,7 @@ function parse_data(lines::Array{String}, pos::Int, info::Array;
     start = last = pos
     last = parse_skipsection(lines, start)
     ndata = last - start
-    data = Array{Any}(undef, ndata, length(info))
+    data = Array{Any}(zeros(Float64, ndata, length(info)))
 
     for i=1:ndata
         # Get rid of the single quotes.

--- a/src/PowerSystem/parsers/parse_raw.jl
+++ b/src/PowerSystem/parsers/parse_raw.jl
@@ -162,7 +162,7 @@ function raw_xfmr(lines::Array{String}, pos::Int, info::Array;
     end
 
     ndata = Int((last - start)/4)
-    data = Array{Any}(undef, ndata, length(info))
+    data = Array{Any}(zeros(Float64, ndata, length(info)+1))
 
     for i=1:ndata
         # Each transformer record consists of 4 lines.

--- a/src/PowerSystem/parsers/parse_rop.jl
+++ b/src/PowerSystem/parsers/parse_rop.jl
@@ -51,7 +51,7 @@ function rop_join_tables(ropdata::Dict{String,Array})
     pwlcost = ropdata["PIECEWISE LINEAR COST"]
 
     ndata = size(gendspt, 1)
-    data = Array{Any}(undef, ndata, 4)
+    data = Array{Any}(zeros(Float64, ndata, 4))
 
     for i=1:ndata
         dsptbl = gendspt[i, 3]
@@ -93,8 +93,8 @@ function rop_pwl(lines::Array{String}, pos::Int, info::Array;
         line = strip(lines[last])
     end
 
-    data = Array{Any}(undef, ndata, length(info)+1)
-    pairs = Array{Float64}(undef, tot_npairs, 2)
+    data = Array{Any}(zeros(Float64, ndata, length(info)+1))
+    pairs = Array{Float64}(zeros(Float64, tot_npairs, 2))
 
     offset = start
     npairs = tot_npairs = 0

--- a/test/Polar/api.jl
+++ b/test/Polar/api.jl
@@ -164,7 +164,7 @@ function test_polar_constraints(polar, device, M)
         constraints = expr ∘ basis
         m = length(constraints)
         @test isa(m, Int)
-        g = M{Float64, 1}(undef, m) # TODO: this signature is not great
+        g = M{Float64, 1}(zeros(Float64, m)) # TODO: this signature is not great
         fill!(g, 0)
         constraints(g, stack)
 

--- a/test/Polar/first_order.jl
+++ b/test/Polar/first_order.jl
@@ -224,6 +224,12 @@ function test_block_jacobian(polar, device, MT)
 
         blk_J_cpu = blk_jac.J |> SparseMatrixCSC
         J_cpu = jac.J |> SparseMatrixCSC
+        blk_diag_J = blockdiag([J_cpu for i in 1:nblocks]...)
+        @test blk_J_cpu.m == blk_diag_J.m
+        @test blk_J_cpu.n == blk_diag_J.n
+        @test all(blk_J_cpu.colptr .== blk_diag_J.colptr)
+        @test all(blk_J_cpu.rowval .== blk_diag_J.rowval)
+        @test all(blk_J_cpu.nzval .≈ blk_diag_J.nzval)
         @test blk_J_cpu ≈ blockdiag([J_cpu for i in 1:nblocks]...)
     end
 

--- a/test/powersystem.jl
+++ b/test/powersystem.jl
@@ -29,7 +29,7 @@ const INSTANCES_DIR = joinpath(artifact"ExaData", "ExaData")
     nbus = size(bus, 1)
 
     # obtain V0 from raw data
-    V = Array{Complex{Float64}}(undef, nbus)
+    V = zeros(Complex{Float64}, nbus)
     T = Vector
     for i in 1:nbus
         V[i] = bus[i, VM]*exp(1im * pi/180 * bus[i, VA])


### PR DESCRIPTION
Removed `undef` everywhere. Uninitialized variables can lead to bugs in the derivatives that are very hard to debug. I would be in favor or not using `undef` as a matter of style.