### PR TITLE
[hotfix] run finite difference tests on CPU

### DIFF
--- a/src/Polar/polar.jl
+++ b/src/Polar/polar.jl
@@ -17,6 +17,8 @@ function PolarForm(pf::PS.PowerNetwork, device::KA.CPU)
 end
 # Convenient constructor
 PolarForm(datafile::String, device=CPU()) = PolarForm(PS.PowerNetwork(datafile), device)
+PolarForm(polar::PolarForm, device=CPU()) = PolarForm(polar.network, device)
+
 
 # Getters (bridge to PowerNetwork)
 get(polar::PolarForm, attr::PS.AbstractNetworkAttribute) = get(polar.network, attr)

--- a/test/Polar/TestPolarForm.jl
+++ b/test/Polar/TestPolarForm.jl
@@ -28,7 +28,14 @@ end
 function myisapprox(a, b; options...)
     h_a = a |> Array
     h_b = b |> Array
-    return isapprox(h_a, h_b; options...)
+    istrue = isapprox(h_a, h_b; options...)
+    if istrue
+        return istrue
+    else
+        println(h_a)
+        println(h_b)
+        return istrue
+    end
 end
 
 function runtests(datafile, device, AT)


### PR DESCRIPTION
Tests were broken with FiniteDiff.jl 2.12, with `FiniteDiff.finite_difference_jacobian` function not supporting `CUDA.allowscalar(false)` anymore.

Run FiniteDiff entirely on the CPU instead.

Fix #250 