### PR TITLE
allow to load MATPOWER instances directly from PGLIB/MATPOWER

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -4,3 +4,10 @@ lazy = true
     [[ExaData.download]]
     url = "https://web.cels.anl.gov/~mschanen/ExaData-e1b6123.tar.gz"
     sha256 = "f6e22f26fbf273e97625a25b1b55f07d0eb0e15283483c545dda6eda84c48fdd"
+
+[PGLib_opf]
+git-tree-sha1 = "91f3110e356432d4e093502e8fa60d6dc97104d2"
+lazy=true
+    [[PGLib_opf.download]]
+    sha256 = "9c53214a8b74d921a662235faeea234e3e2bfa7cf62619410e9ec52f4277c797"
+    url = "https://github.com/power-grid-lib/pglib-opf/archive/refs/tags/v21.07.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ CUDAKernels = "72cfdca4-0801-4ab0-bf6a-d52aa10adc57"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
@@ -30,7 +31,6 @@ julia = "1.7"
 
 [extras]
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
-LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/Project.toml
+++ b/Project.toml
@@ -35,4 +35,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "LazyArtifacts", "FiniteDiff"]
+test = ["Test", "Random", "FiniteDiff"]

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -9,12 +9,11 @@ using CUDAKernels
 # Algorithms
 using Krylov
 using ExaPF
-using LazyArtifacts
 
 const LS = ExaPF.LinearSolvers
+const PS = ExaPF.PowerSystem
 
 const CONFIG_FILE = joinpath(dirname(@__FILE__), "config.json")
-const BENCHMARK_DIR = joinpath(artifact"ExaData", "ExaData")
 const OUTPUT_DIR = joinpath(dirname(@__FILE__), "results")
 
 DEFAULT_CONFIG = Dict{Symbol, Any}(
@@ -347,8 +346,7 @@ function benchmark(
         mkdir(outputdir)
     end
     println("BENCHMARK $casename on $(device)")
-    casefile = joinpath(BENCHMARK_DIR, casename)
-    polar = PolarForm(casefile, device)
+    polar = PolarForm(PS.load_case(casename), device)
     if isa(device, CPU)
         ext = ".cpu.csv"
     elseif isa(device, CUDADevice)

--- a/docs/src/lib/formulations.md
+++ b/docs/src/lib/formulations.md
@@ -1,6 +1,9 @@
 ```@meta
 CurrentModule = ExaPF
 const PS = ExaPF.PowerSystem
+DocTestSetup = quote
+    using ExaPF
+end
 ```
 
 
@@ -19,6 +22,7 @@ Control
 ## Structure and variables
 ```@docs
 PolarForm
+load_polar
 NetworkStack
 BlockNetworkStack
 init!

--- a/docs/src/lib/powersystem.md
+++ b/docs/src/lib/powersystem.md
@@ -9,6 +9,7 @@ CurrentModule = ExaPF.PowerSystem
 ```@docs
 AbstractPowerSystem
 PowerNetwork
+load_case
 ```
 
 ## API Reference

--- a/src/Polar/polar.jl
+++ b/src/Polar/polar.jl
@@ -19,11 +19,38 @@ end
 PolarForm(datafile::String, device=CPU()) = PolarForm(PS.PowerNetwork(datafile), device)
 PolarForm(polar::PolarForm, device=CPU()) = PolarForm(polar.network, device)
 
+"""
+    load_polar(case, device=CPU(); dir=PS.EXADATA)
+
+Load a [`PolarForm`](@ref) instance from the specified
+benchmark library `dir` on the target `device` (default is `CPU`).
+ExaPF uses two different benchmark libraries: MATPOWER (`dir=EXADATA`)
+and PGLIB-OPF (`dir=PGLIB`).
+
+## Examples
+```jldoctest; setup=:(using ExaPF)
+julia> polar = ExaPF.load_polar("case9")
+Polar formulation model (instantiated on device CPU())
+Network characteristics:
+    #buses:      9  (#slack: 1  #PV: 2  #PQ: 6)
+    #generators: 3
+    #lines:      9
+giving a mathematical formulation with:
+    #controls:   5
+    #states  :   14
+
+```
+
+"""
+function load_polar(case, device=CPU(); dir=PS.EXADATA)
+    return PolarForm(PS.load_case(case, dir), device)
+end
 
 # Getters (bridge to PowerNetwork)
 get(polar::PolarForm, attr::PS.AbstractNetworkAttribute) = get(polar.network, attr)
 
 number(polar::PolarForm, v::AbstractVariable) = length(mapping(polar, v))
+
 
 # Default ordering in NetworkStack: [vmag, vang, pgen]
 

--- a/src/PowerSystem/PowerSystem.jl
+++ b/src/PowerSystem/PowerSystem.jl
@@ -1,6 +1,7 @@
 module PowerSystem
 
 using Printf
+using LazyArtifacts
 using LinearAlgebra
 using SparseArrays
 

--- a/test/Polar/TestPolarForm.jl
+++ b/test/Polar/TestPolarForm.jl
@@ -38,9 +38,8 @@ function myisapprox(a, b; options...)
     end
 end
 
-function runtests(datafile, device, AT)
-    pf = PS.PowerNetwork(datafile)
-    polar = PolarForm(pf, device)
+function runtests(case, device, AT)
+    polar = ExaPF.load_polar(case, device)
     # Test printing
     println(devnull, polar)
 

--- a/test/powersystem.jl
+++ b/test/powersystem.jl
@@ -5,6 +5,7 @@ using Test
 using ExaPF
 import ExaPF: PowerSystem
 import ExaPF.PowerSystem: ParsePSSE
+using LazyArtifacts
 
 const PS = PowerSystem
 const INSTANCES_DIR = joinpath(artifact"ExaData", "ExaData")

--- a/test/quickstart.jl
+++ b/test/quickstart.jl
@@ -7,17 +7,14 @@ using ExaPF
 import ExaPF: AutoDiff
 const PS = ExaPF.PowerSystem
 const LS = ExaPF.LinearSolvers
-const INSTANCES_DIR = joinpath(artifact"ExaData", "ExaData")
 
 # Test quickstart guide in docs/src/quickstart.md
 # If one test is broken, please update the documentation.
 
 @testset "Documentation: quickstart" begin
-    pglib_instance = "case1354.m"
-    datafile = joinpath(INSTANCES_DIR, pglib_instance)
-
+    case = "case1354.m"
     # Short version
-    polar = ExaPF.PolarForm(datafile, CPU())
+    polar = ExaPF.load_polar(case, CPU())
     # Initial values
     stack = ExaPF.NetworkStack(polar)
     convergence = run_pf(polar, stack; rtol=1e-10)
@@ -26,7 +23,7 @@ const INSTANCES_DIR = joinpath(artifact"ExaData", "ExaData")
     @test convergence.norm_residuals <= 1e-10
 
     # Long version
-    pf = PS.PowerNetwork(datafile)
+    pf = PS.load_case(case)
     nbus = PS.get(pf, PS.NumberOfBuses())
     @test nbus == 1354
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,11 +8,9 @@ using CUDA
 using KernelAbstractions
 
 using ExaPF
-using LazyArtifacts
 
 Random.seed!(2713)
 
-const INSTANCES_DIR = joinpath(artifact"ExaData", "ExaData")
 const BENCHMARK_DIR = joinpath(dirname(@__FILE__), "..", "benchmark")
 const CASES = ["case9.m", "case30.m"]
 
@@ -64,8 +62,7 @@ init_time = time()
         println("Test PolarForm ...")
         tic = time()
         @testset "ExaPF.PolarForm ($case)" for case in CASES
-            datafile = joinpath(INSTANCES_DIR, case)
-            TestPolarFormulation.runtests(datafile, device, AT)
+            TestPolarFormulation.runtests(case, device, AT)
         end
         println("Took $(round(time() - tic; digits=1)) seconds.")
     end


### PR DESCRIPTION
- add PGLIB benchmark in Artifacts.toml
- add function `PS.load_case` to load `PowerNetwork` from case's name
- add function `load_polar` to load `PolarForm` from case's name