### PR TITLE
Removing CUSOLVERRF and adding CUDSS to docs

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -74,4 +74,5 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@latest
       - run: julia --project=docs/ docs/make.jl

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -65,6 +65,7 @@ jobs:
       JULIA_DEPOT_PATH: /scratch/github-actions/julia_depot_exapf
       DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JULIA_DEBUG: Documenter
     runs-on: self-hosted
 
     steps:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          os: [ubuntu-22.04]
+          os: [ubuntu-latest]
           julia-version: ['lts', '1']
           julia-arch: [x64]
 
@@ -27,6 +27,7 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
 
@@ -39,7 +40,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         julia-version: ['lts', '1']
         julia-arch: [x64]
 
@@ -49,10 +50,27 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
-      - run: julia --project=docs/ docs/make.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
         with:
           file: lcov.info
+
+  docs:
+    name: Build documentation
+    env:
+      CUDA_VISIBLE_DEVICES: 1
+      JULIA_DEPOT_PATH: /scratch/github-actions/julia_depot_exapf
+      DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+      - run: julia --project=docs/ docs/make.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ExaPF"
 uuid = "0cf0e50c-a82e-488f-ac7e-41ffdff1b8aa"
-authors = ["Adrian Maldonado <maldonadod@anl.gov>", "Michel Schanen <mschanen@anl.gov>", "François Pacaud <fpacaud@anl.gov>"]
+authors = ["Adrian Maldonado <maldonadod@anl.gov>", "Michel Schanen <mschanen@anl.gov>", "François Pacaud <fpacaud@anl.gov>", "Alexis Montoison <amontoison@anl.gov>"]
 version = "0.12.0"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExaPF"
 uuid = "0cf0e50c-a82e-488f-ac7e-41ffdff1b8aa"
 authors = ["Adrian Maldonado <maldonadod@anl.gov>", "Michel Schanen <mschanen@anl.gov>", "François Pacaud <fpacaud@anl.gov>"]
-version = "0.11.0"
+version = "0.12.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/LocalPreferences.toml
+++ b/docs/LocalPreferences.toml
@@ -1,2 +1,0 @@
-[CUDA_Runtime_jll]
-version = "11.8"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,6 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUSOLVERRF = "a8cc9031-bad2-4722-94f5-40deabb4245c"
+CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ExaPF = "0cf0e50c-a82e-488f-ac7e-41ffdff1b8aa"
 KLU = "ef3ab10e-7fda-4108-b977-705223b18434"
@@ -8,9 +8,6 @@ KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-
-[extras]
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 
 [compat]
 OpenSSL_jll = "~3.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,7 +6,11 @@ ExaPF = "0cf0e50c-a82e-488f-ac7e-41ffdff1b8aa"
 KLU = "ef3ab10e-7fda-4108-b977-705223b18434"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [extras]
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
+
+[compat]
+OpenSSL_jll = "~3.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ makedocs(
         mathengine = Documenter.KaTeX(),
     ),
     modules = [ExaPF],
-    repo = "https://github.com/exanauts/ExaPF.jl",
+    repo = "https://github.com/exanauts/ExaPF.jl//blob/{commit}{path}#L{line}",
     checkdocs = :exports,
     pages = [
         "Home" => "index.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ makedocs(
         mathengine = Documenter.KaTeX(),
     ),
     modules = [ExaPF],
-    repo = Remotes.GitHub("exanauts", "ExaPF.jl"),
+    repo = "github.com/exanauts/ExaPF.jl/blob/{commit}{path}#{line}",
     checkdocs = :exports,
     pages = [
         "Home" => "index.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ makedocs(
         mathengine = Documenter.KaTeX(),
     ),
     modules = [ExaPF],
-    repo = "https://github.com/exanauts/ExaPF.jl/blob/{commit}{path}#{line}",
+    repo = "https://github.com/exanauts/ExaPF.jl",
     checkdocs = :exports,
     pages = [
         "Home" => "index.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,10 +12,11 @@ makedocs(
     sitename = "ExaPF.jl",
     format = Documenter.HTML(
         prettyurls = Base.get(ENV, "CI", nothing) == "true",
+        canonical = "https://exanauts.github.io/ExaPF.jl/stable/",
         mathengine = Documenter.KaTeX(),
     ),
     modules = [ExaPF],
-    repo = "https://github.com/exanauts/ExaPF.jl//blob/{commit}{path}#L{line}",
+    repo = "https://github.com/exanauts/ExaPF.jl/blob/{commit}{path}#L{line}",
     checkdocs = :exports,
     pages = [
         "Home" => "index.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ makedocs(
         mathengine = Documenter.KaTeX(),
     ),
     modules = [ExaPF],
-    repo = "github.com/exanauts/ExaPF.jl/blob/{commit}{path}#{line}",
+    repo = "https://github.com/exanauts/ExaPF.jl/blob/{commit}{path}#{line}",
     checkdocs = :exports,
     pages = [
         "Home" => "index.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,15 +6,16 @@ Pkg.instantiate()
 
 using Documenter
 using ExaPF
+using Documenter.Remotes
 
 makedocs(
     sitename = "ExaPF.jl",
     format = Documenter.HTML(
         prettyurls = Base.get(ENV, "CI", nothing) == "true",
-        mathengine = Documenter.KaTeX()
+        mathengine = Documenter.KaTeX(),
     ),
     modules = [ExaPF],
-    repo = "https://github.com/exanauts/ExaPF.jl/blob/{commit}{path}#{line}",
+    repo = Remotes.GitHub("exanauts", "ExaPF.jl"),
     checkdocs = :exports,
     pages = [
         "Home" => "index.md",

--- a/docs/src/tutorials/batch_evaluation.md
+++ b/docs/src/tutorials/batch_evaluation.md
@@ -145,9 +145,10 @@ reshape(blk_stack.vmag, nbus, nscen)
 When the [`BlockPolarForm`](@ref) model is instantiated on the GPU,
 the expressions are evaluated in batch.
 The syntax to solve the power flow equations is exactly the same as on the
-CPU, using `cusolverRF` to solve the different linear systems:
+CPU, using `cuDSS` to solve the different linear systems:
 ```@example batch_pf
-using CUDA, CUSOLVERRF
+using CUDA
+using CUDSS
 polar_gpu = ExaPF.load_polar("case9.m", CUDABackend());
 blk_polar_gpu = ExaPF.BlockPolarForm(polar_gpu, nscen); # load model on GPU
 blk_stack_gpu = ExaPF.NetworkStack(blk_polar_gpu);
@@ -156,7 +157,7 @@ powerflow_gpu = ExaPF.PowerFlowBalance(blk_polar_gpu) ∘ ExaPF.PolarBasis(blk_p
 blk_jx_gpu = ExaPF.ArrowheadJacobian(blk_polar_gpu, powerflow_gpu, State());
 ExaPF.set_params!(blk_jx_gpu, blk_stack_gpu);
 ExaPF.jacobian!(blk_jx_gpu, blk_stack_gpu);
-rf_fac = CUSOLVERRF.RFLU(blk_jx_gpu.J)
+rf_fac = CUDSS.lu(blk_jx_gpu.J)
 rf_solver = LS.DirectSolver(rf_fac)
 conv = ExaPF.nlsolve!(
     NewtonRaphson(verbose=2),

--- a/docs/src/tutorials/direct_solver.md
+++ b/docs/src/tutorials/direct_solver.md
@@ -128,13 +128,12 @@ ExaPF.nlsolve!(pf_solver, jx, stack; linear_solver=klu_solver)
 We observe KLU reduces considerably the time spent in the linear solver.
 
 
-## cusolverRF (CUDA)
+## cuDSS (CUDA)
 
-[cusolverRF](https://docs.nvidia.com/cuda/cusolver/index.html#cuSolverRF-reference)
+[cuDSS](https://developer.nvidia.com/cudss)
 is an efficient LU refactorization routine implemented in CUDA.
-It is wrapped in Julia inside the package [CUSOLVERRF.jl](https://github.com/exanauts/CUSOLVERRF.jl):
 ```@example direct_solver
-using CUSOLVERRF
+using CUDSS
 ```
 
 The principle is the following: the initial symbolic factorization
@@ -149,19 +148,18 @@ flow Jacobian doesn't change along the Newton iterations and
 (ii) the Jacobian is super-sparse. In ExaPF, it is the linear solver
 of choice when it comes to solve the power flow entirely on the GPU.
 
-CUSOLVERRF.jl follows the LinearAlgebra's interface, so we can use
-it directly in ExaPF.
 We first have to instantiate everything on the GPU:
 ```@example direct_solver
 using CUDA
+using CUDSS
 polar_gpu = ExaPF.load_polar("case9241pegase.m", CUDABackend())
 stack_gpu = ExaPF.NetworkStack(polar_gpu)
 func_gpu = ExaPF.PowerFlowBalance(polar_gpu) ∘ ExaPF.PolarBasis(polar_gpu)
 jx_gpu = ExaPF.Jacobian(polar_gpu, func_gpu, State()) # init AD
 ```
-We can instantiate a new cusolverRF's instance as
+We can instantiate a new cuDSS's instance as
 ```@example direct_solver
-rf_fac = CUSOLVERRF.RFLU(jx_gpu.J)
+rf_fac = CUDSS.lu(jx_gpu.J)
 rf_solver = LS.DirectSolver(rf_fac)
 
 ```
@@ -170,4 +168,3 @@ Then, we are able to solve the power flow *entirely on the GPU*, simply as
 ExaPF.nlsolve!(pf_solver, jx_gpu, stack_gpu; linear_solver=rf_solver)
 
 ```
-

--- a/test/LocalPreferences.toml
+++ b/test/LocalPreferences.toml
@@ -1,2 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.8"


### PR DESCRIPTION
The CI errored because the documentation was not building. While I was at it, I wanted to remove CUSOLVERRF and replace it with CUDSS.

@amontoison It might be nice to add `<: LinearAlgebra.Factorization` to CUDSS. It would make the integration even easier.

@frapac I am not sure I call CUDSS right for the refactorization. But as far as I can see, there is also no refactorization done in the documentation.