### PR TITLE
Build binary using juliac

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -79,3 +79,51 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - run: julia --project=docs/ docs/make.jl
+
+  build-binary:
+    name: Build binary
+    needs: [test-github-cpuonly]
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1'
+
+      - uses: julia-actions/cache@v2
+
+      - name: Install JuliaC
+        run: |
+          julia -e 'using Pkg; Pkg.Registry.update(); Pkg.add("JuliaC")'
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(julia -e 'using TOML; print(TOML.parsefile("Project.toml")["version"])')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build ExaPFApp binary
+        run: |
+          julia -e '
+            using JuliaC
+            JuliaC.main([
+              "--output-exe", "ExaPFBin",
+              "--bundle", "build",
+              "--experimental",
+              "app/ExaPFApp"
+            ])
+          '
+
+      - name: Create tarball
+        run: |
+          tar -czvf ExaPF-${{ steps.version.outputs.version }}-linux-x86_64.tar.gz -C build .
+
+      - name: Upload binary to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ExaPF-${{ steps.version.outputs.version }}-linux-x86_64.tar.gz

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ExaPF"
 uuid = "0cf0e50c-a82e-488f-ac7e-41ffdff1b8aa"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Adrian Maldonado <maldonadod@anl.gov>", "Michel Schanen <mschanen@anl.gov>", "François Pacaud <fpacaud@anl.gov>", "Alexis Montoison <amontoison@anl.gov>"]
 
 [deps]

--- a/app/ExaPFApp/Project.toml
+++ b/app/ExaPFApp/Project.toml
@@ -3,11 +3,5 @@ uuid = "aa457b0c-507e-42d5-98f7-a9bb415058c8"
 version = "0.1.0"
 
 [deps]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
 ExaPF = "0cf0e50c-a82e-488f-ac7e-41ffdff1b8aa"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-
-[compat]
-CUDA = "5.9.5"
-CUDSS = "0.6.4"

--- a/app/ExaPFApp/Project.toml
+++ b/app/ExaPFApp/Project.toml
@@ -1,0 +1,13 @@
+name = "ExaPFApp"
+uuid = "aa457b0c-507e-42d5-98f7-a9bb415058c8"
+version = "0.1.0"
+
+[deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
+ExaPF = "0cf0e50c-a82e-488f-ac7e-41ffdff1b8aa"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+
+[compat]
+CUDA = "5.9.5"
+CUDSS = "0.6.4"

--- a/app/ExaPFApp/Project.toml
+++ b/app/ExaPFApp/Project.toml
@@ -3,5 +3,15 @@ uuid = "aa457b0c-507e-42d5-98f7-a9bb415058c8"
 version = "0.1.0"
 
 [deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
 ExaPF = "0cf0e50c-a82e-488f-ac7e-41ffdff1b8aa"
+GPUCompiler = "61eb1bfa-7361-4325-ad38-22787b887f55"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[compat]
+CUDA = "5.9.5"
+CUDSS = "0.6.4"
+PrecompileTools = "1.3.3"

--- a/app/ExaPFApp/src/ExaPFApp.jl
+++ b/app/ExaPFApp/src/ExaPFApp.jl
@@ -1,0 +1,28 @@
+module ExaPFApp
+
+using ExaPF
+using KernelAbstractions
+using CUDA, CUDSS
+
+function run_pf_gpu(case::String)
+    println("Using GPU Backend (CUDA + CUDSS)")
+    run_pf(case, CUDABackend(), :polar; verbose=2)
+end
+
+function run_pf_cpu(case::String)
+    run_pf(case, CPU(), :polar; verbose=2)
+end
+
+function @main(args::Vector{String})::Int
+    if args[2] == "cpu"
+        run_pf_cpu(args[1])
+    elseif args[2] == "gpu"
+        run_pf_gpu(args[1])
+    else
+        @error "Unknown backend: $(args[2]). Use 'cpu' or 'gpu'."
+        return 1
+    end
+    return 0
+end
+
+end # module

--- a/app/ExaPFApp/src/ExaPFApp.jl
+++ b/app/ExaPFApp/src/ExaPFApp.jl
@@ -2,12 +2,13 @@ module ExaPFApp
 
 using ExaPF
 using KernelAbstractions
-using CUDA, CUDSS
+# TODO: uncomment this when https://github.com/JuliaGPU/GPUCompiler.jl/issues/611 is fixed
+# using CUDA, CUDSS
 
-function run_pf_gpu(case::String)
-    println("Using GPU Backend (CUDA + CUDSS)")
-    run_pf(case, CUDABackend(), :polar; verbose=2)
-end
+# function run_pf_gpu(case::String)
+#     println("Using GPU Backend (CUDA + CUDSS)")
+#     run_pf(case, CUDABackend(), :polar; verbose=2)
+# end
 
 function run_pf_cpu(case::String)
     run_pf(case, CPU(), :polar; verbose=2)
@@ -17,7 +18,9 @@ function @main(args::Vector{String})::Int
     if args[2] == "cpu"
         run_pf_cpu(args[1])
     elseif args[2] == "gpu"
-        run_pf_gpu(args[1])
+        @error "GPU backend is not supported yet"
+        return 1
+        # run_pf_gpu(args[1])
     else
         @error "Unknown backend: $(args[2]). Use 'cpu' or 'gpu'."
         return 1

--- a/app/ExaPFApp/src/ExaPFApp.jl
+++ b/app/ExaPFApp/src/ExaPFApp.jl
@@ -3,12 +3,24 @@ module ExaPFApp
 using ExaPF
 using KernelAbstractions
 # TODO: uncomment this when https://github.com/JuliaGPU/GPUCompiler.jl/issues/611 is fixed
-# using CUDA, CUDSS
+using CUDA, CUDSS
+using SparseArrays: sprand
 
-# function run_pf_gpu(case::String)
-#     println("Using GPU Backend (CUDA + CUDSS)")
-#     run_pf(case, CUDABackend(), :polar; verbose=2)
+using PrecompileTools
+
+# Note: CUDA precompilation workloads are disabled for juliac native compilation
+# as NVVM intrinsics cannot be compiled to native CPU code.
+# @compile_workload begin
+#     # Force compilation of CUDA sparse matrix methods
+#     if CUDA.functional()
+#         dummy = CUDA.CUSPARSE.CuSparseMatrixCSR(sprand(Float64, 4, 4, 0.5))
+#     end
 # end
+
+function run_pf_gpu(case::String)
+    println("Using GPU Backend (CUDA + CUDSS)")
+    run_pf(case, CUDABackend(), :polar; verbose=2)
+end
 
 function run_pf_cpu(case::String)
     run_pf(case, CPU(), :polar; verbose=2)
@@ -18,9 +30,7 @@ function @main(args::Vector{String})::Int
     if args[2] == "cpu"
         run_pf_cpu(args[1])
     elseif args[2] == "gpu"
-        @error "GPU backend is not supported yet"
-        return 1
-        # run_pf_gpu(args[1])
+        run_pf_gpu(args[1])
     else
         @error "Unknown backend: $(args[2]). Use 'cpu' or 'gpu'."
         return 1

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,15 @@
+# Build ExaPF Binary using JuliaC
+
+- Install `juliac` with
+
+```julia
+] app add juliac
+```
+
+- Instantiate the `app/ExaPFApp` environment
+
+- From the `app` folder, run
+
+```bash
+juliac ExaPFApp --output-exe ExaPFBin --bundle exapfdir --experimental
+```

--- a/app/README.md
+++ b/app/README.md
@@ -3,7 +3,7 @@
 - Install `juliac` with
 
 ```julia
-] app add juliac
+] app add JuliaC
 ```
 
 - Instantiate the `app/ExaPFApp` environment

--- a/ext/cuda_wrapper.jl
+++ b/ext/cuda_wrapper.jl
@@ -25,7 +25,7 @@ function Base.unsafe_wrap(Atype::Type{CUDA.CuArray{T, 1, CUDA.DeviceMemory}},
     unsafe_wrap(CUDA.CuVector{T}, p, (dim,); own, ctx)
 end
 
-CUSPARSE.CuSparseMatrixCSR{Tv, Int32}(A::SparseMatrixCSC{Tv, Ti}) where {Tv, Ti} = CuSparseMatrixCSR(A)
+CUSPARSE.CuSparseMatrixCSR{Tv, Int32}(A::SparseMatrixCSC{Tv, Ti}) where {Tv, Ti <: Integer} = CuSparseMatrixCSR(A)
 
 
 # AbstractStack


### PR DESCRIPTION
@amontoison @frapac I've played a bit around with juliac for🎄 from [this talk](https://www.youtube.com/watch?v=WNSG2J-kSLg).

I've managed to build a binary of ExaPF with only CPU support. It seems to me that `CUDA/GPUCompiler.jl` generated code cannot yet be digested through juliac, even if you don't trim. I've tried multiple things. Maybe there is a way.
```
$ juliac ExaPFApp --output-exe ExaPFBin --bundle exapfdir --experimental
◑ Compiling...LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.membar.cta

[107726] signal 6 (-6): Aborted
in expression starting at none:0
Allocations: 797069608 (Pool: 797066510; Big: 3098); GC: 383
✓ Compiling...
ERROR: Failed to compile ExaPFApp
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:44
 [2] compile_products(recipe::JuliaC.ImageRecipe)
   @ JuliaC ~/.julia/packages/JuliaC/0OTq8/src/compiling.jl:123
 [3] _main_cli(args::Vector{String}; io::Base.TTY)
   @ JuliaC ~/.julia/packages/JuliaC/0OTq8/src/JuliaC.jl:191
 [4] _main_cli(args::Vector{String})
   @ JuliaC ~/.julia/packages/JuliaC/0OTq8/src/JuliaC.jl:182
 [5] main(ARGS::Vector{String})
   @ JuliaC ~/.julia/packages/JuliaC/0OTq8/src/JuliaC.jl:197
 [6] _start()
   @ Base ./client.jl:556
```
This hit a CUDA intrinsic that gets sent to the Julia (CPU) LLVM backend.
I've added a [README.md](https://github.com/exanauts/ExaPF.jl/blob/ms/app/app/README.md) if you want to start playing too.